### PR TITLE
Remove the patch that deleted fixed UIDs from istiod charts

### DIFF
--- a/hack/download-charts.sh
+++ b/hack/download-charts.sh
@@ -89,13 +89,6 @@ function patchIstioCharts() {
   resources: ["securitycontextconstraints"] \
   resourceNames: ["privileged"] \
   verbs: ["use"]/' "${CHARTS_DIR}/cni/templates/clusterrole.yaml"
-  
-  echo "patching istio charts ${CHARTS_DIR}/istiod/templates/deployment.yaml "
-  # Remove fsGroup, runAsUser, runAsGroup from istiod deployment so that it can run on OpenShift
-  sed -i "${CHARTS_DIR}/istiod/templates/deployment.yaml" \
-    -e '/fsGroup: 1337/d' \
-    -e '/runAsUser: 1337/d' \
-    -e '/runAsGroup: 1337/d'
 }
 
 function convertIstioProfiles() {


### PR DESCRIPTION
This patch is not needed anymore as we removed support for v1.20 - the lines it attempts to remove have been removed upstream as part of istio/istio#45394.