### PR TITLE
Use the `quote` function to properly escape CSV annotations

### DIFF
--- a/chart/templates/olm/clusterserviceversion.yaml
+++ b/chart/templates/olm/clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
     support: {{ .Values.csv.support }}
 {{- if .Values.csv.annotations }}
 {{- range $key, $val := .Values.csv.annotations }}
-    {{ $key }}: "{{ $val }}" 
+    {{ $key | quote }}: {{ $val | quote }}
 {{- end}}
 {{- end}}
   name: {{ .Values.name }}.v{{ .Values.csv.version }}


### PR DESCRIPTION
I need this to port one of the annotations we have in the midstream repo - there we're using sed to insert it directly into the CSV.
