### PR TITLE
Create namespace if it doesn't exist in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,16 @@ Create an instance of the Istio resource to install the Istio Control Plane.
 Use the `istio-sample-kubernetes.yaml` file on vanilla Kubernetes:
 
 ```sh
+# Namespace must exist prior to creating istio resource
+kubectl get ns istio-system || kubectl create ns istio-system
 kubectl apply -f chart/samples/istio-sample-kubernetes.yaml
 ```
 
 Use the `istio-sample-openshift.yaml` file on OpenShift:
 
 ```sh
+# Namespace must exist prior to creating istio resource
+kubectl get ns istio-system || kubectl create ns istio-system
 kubectl apply -f chart/samples/istio-sample-openshift.yaml
 ```
 


### PR DESCRIPTION
Updates the README example to create the namespace if it doesn't exist. Otherwise when you just run the example without creating the namespace first the reconciliation will fail.