### PR TITLE
Fix profiles

### DIFF
--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/sail-operator:3.0-latest
-    createdAt: "2024-04-15T23:01:41Z"
+    createdAt: "2024-04-16T12:16:12Z"
     description: Experimental operator for installing Istio service mesh
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -535,7 +535,7 @@ spec:
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
-                - --default-profiles=default,openshift
+                - --default-profile=openshift
                 command:
                 - /manager
                 image: quay.io/maistra-dev/sail-operator:3.0-latest

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
 {{- if eq .Values.platform "openshift" }}
-        - --default-profiles=default,openshift
+        - --default-profile=openshift
 {{- end }}
         command:
         - /manager

--- a/controllers/istio/istio_controller_test.go
+++ b/controllers/istio/istio_controller_test.go
@@ -64,7 +64,7 @@ func TestReconcile(t *testing.T) {
 		cl := newFakeClientBuilder().
 			WithObjects(istio).
 			Build()
-		reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, nil)
+		reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, "")
 
 		_, err := reconciler.Reconcile(ctx, istio)
 		if err == nil {
@@ -100,7 +100,7 @@ func TestReconcile(t *testing.T) {
 			WithStatusSubresource(&v1alpha1.Istio{}).
 			WithObjects(istio).
 			Build()
-		reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, []string{"invalid-profile"})
+		reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, "invalid-profile")
 
 		_, err := reconciler.Reconcile(ctx, istio)
 		if err == nil {
@@ -140,7 +140,7 @@ func TestReconcile(t *testing.T) {
 				},
 			}).
 			Build()
-		reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, nil)
+		reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, "")
 
 		_, err := reconciler.Reconcile(ctx, istio)
 		if err == nil {
@@ -472,7 +472,7 @@ func TestDetermineStatus(t *testing.T) {
 				WithObjects(initObjs...).
 				WithInterceptorFuncs(interceptorFuncs).
 				Build()
-			reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, nil)
+			reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, "")
 
 			status, err := reconciler.determineStatus(ctx, istio, tc.reconciliationErr)
 			if (err != nil) != tc.wantErr {
@@ -670,7 +670,7 @@ func TestUpdateStatus(t *testing.T) {
 				WithObjects(initObjs...).
 				WithInterceptorFuncs(interceptorFuncs).
 				Build()
-			reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, nil)
+			reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, "")
 
 			err := reconciler.updateStatus(ctx, istio, tc.reconciliationErr)
 			if (err != nil) != tc.wantErr {
@@ -797,7 +797,7 @@ func TestReconcileActiveRevision(t *testing.T) {
 					}
 
 					cl := newFakeClientBuilder().WithObjects(initObjs...).Build()
-					reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, nil)
+					reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, "")
 
 					err := reconciler.reconcileActiveRevision(ctx, istio, &tc.istioValues)
 					if err != nil {
@@ -1009,7 +1009,7 @@ func TestPruneInactiveRevisions(t *testing.T) {
 			}
 
 			cl := newFakeClientBuilder().WithObjects(initObjs...).Build()
-			reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, nil)
+			reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, "")
 
 			result, err := reconciler.pruneInactiveRevisions(ctx, istio)
 			if err != nil {
@@ -1202,7 +1202,7 @@ spec:
 		},
 	}
 
-	result, err := computeIstioRevisionValues(istio, []string{"default"}, resourceDir)
+	result, err := computeIstioRevisionValues(istio, "default", resourceDir)
 	if err != nil {
 		t.Errorf("Expected no error, but got an error: %v", err)
 	}

--- a/controllers/istiocni/istiocni_controller.go
+++ b/controllers/istiocni/istiocni_controller.go
@@ -51,18 +51,18 @@ const cniReleaseName = "istio-cni"
 // Reconciler reconciles an IstioCNI object
 type Reconciler struct {
 	ResourceDirectory string
-	DefaultProfiles   []string
+	DefaultProfile    string
 	client.Client
 	Scheme       *runtime.Scheme
 	ChartManager *helm.ChartManager
 }
 
 func NewReconciler(
-	client client.Client, scheme *runtime.Scheme, resourceDir string, chartManager *helm.ChartManager, defaultProfiles []string,
+	client client.Client, scheme *runtime.Scheme, resourceDir string, chartManager *helm.ChartManager, defaultProfile string,
 ) *Reconciler {
 	return &Reconciler{
 		ResourceDirectory: resourceDir,
-		DefaultProfiles:   defaultProfiles,
+		DefaultProfile:    defaultProfile,
 		Client:            client,
 		Scheme:            scheme,
 		ChartManager:      chartManager,
@@ -136,7 +136,7 @@ func (r *Reconciler) installHelmChart(ctx context.Context, cni *v1alpha1.IstioCN
 	userValues = applyImageDigests(cni, userValues, config.Config)
 
 	// apply userValues on top of defaultValues from profiles
-	mergedHelmValues, err := profiles.Apply(getProfilesDir(r.ResourceDirectory, cni), getProfiles(cni, r.DefaultProfiles), helm.FromValues(userValues))
+	mergedHelmValues, err := profiles.Apply(getProfilesDir(r.ResourceDirectory, cni), r.DefaultProfile, cni.Spec.Profile, helm.FromValues(userValues))
 	if err != nil {
 		return err
 	}
@@ -147,13 +147,6 @@ func (r *Reconciler) installHelmChart(ctx context.Context, cni *v1alpha1.IstioCN
 
 func (r *Reconciler) getChartDir(cni *v1alpha1.IstioCNI) string {
 	return path.Join(r.ResourceDirectory, cni.Spec.Version, "charts", "cni")
-}
-
-func getProfiles(cni *v1alpha1.IstioCNI, defaultProfiles []string) []string {
-	if cni.Spec.Profile == "" {
-		return defaultProfiles
-	}
-	return append(defaultProfiles, cni.Spec.Profile)
 }
 
 func getProfilesDir(resourceDir string, cni *v1alpha1.IstioCNI) string {

--- a/controllers/istiocni/istiocni_controller_test.go
+++ b/controllers/istiocni/istiocni_controller_test.go
@@ -196,7 +196,7 @@ func TestDetermineReadyCondition(t *testing.T) {
 
 			cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tt.clientObjects...).WithInterceptorFuncs(tt.interceptors).Build()
 
-			r := NewReconciler(cl, scheme.Scheme, resourceDir, nil, nil)
+			r := NewReconciler(cl, scheme.Scheme, resourceDir, nil, "")
 
 			cni := &v1alpha1.IstioCNI{
 				ObjectMeta: metav1.ObjectMeta{
@@ -378,7 +378,7 @@ func TestDetermineStatus(t *testing.T) {
 	ctx := context.TODO()
 	resourceDir := t.TempDir()
 	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
-	r := NewReconciler(cl, scheme.Scheme, resourceDir, nil, nil)
+	r := NewReconciler(cl, scheme.Scheme, resourceDir, nil, "")
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -26,12 +26,23 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
-func Apply(profilesDir string, profiles []string, userValues helm.Values) (helm.Values, error) {
-	defaultValues, err := getValuesFromProfiles(profilesDir, profiles)
+func Apply(profilesDir string, defaultProfile, userProfile string, userValues helm.Values) (helm.Values, error) {
+	defaultValues, err := getValuesFromProfiles(profilesDir, resolve(defaultProfile, userProfile))
 	if err != nil {
 		return nil, err
 	}
 	return mergeOverwrite(defaultValues, userValues), nil
+}
+
+func resolve(defaultProfile, userProfile string) []string {
+	switch {
+	case userProfile != "" && userProfile != "default":
+		return []string{"default", userProfile}
+	case defaultProfile != "" && defaultProfile != "default":
+		return []string{"default", defaultProfile}
+	default:
+		return []string{"default"}
+	}
 }
 
 func getValuesFromProfiles(profilesDir string, profiles []string) (helm.Values, error) {

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/istio-ecosystem/sail-operator/pkg/helm"
+	. "github.com/onsi/gomega"
 )
 
 func TestGetValuesFromProfiles(t *testing.T) {
@@ -223,6 +224,33 @@ func TestMergeOverwrite(t *testing.T) {
 			if diff := cmp.Diff(tc.expect, result); diff != "" {
 				t.Errorf("unexpected merge result; diff (-expected, +actual):\n%v", diff)
 			}
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	testCases := []struct {
+		dflt     string
+		user     string
+		expected []string
+	}{
+		{dflt: "", user: "", expected: []string{"default"}},
+		{dflt: "", user: "default", expected: []string{"default"}},
+		{dflt: "", user: "demo", expected: []string{"default", "demo"}},
+
+		{dflt: "default", user: "", expected: []string{"default"}},
+		{dflt: "default", user: "default", expected: []string{"default"}},
+		{dflt: "default", user: "demo", expected: []string{"default", "demo"}},
+
+		{dflt: "openshift", user: "", expected: []string{"default", "openshift"}},
+		{dflt: "openshift", user: "default", expected: []string{"default", "openshift"}},
+		{dflt: "openshift", user: "openshift", expected: []string{"default", "openshift"}},
+		{dflt: "openshift", user: "openshift-ambient", expected: []string{"default", "openshift-ambient"}},
+	}
+	for _, tc := range testCases {
+		t.Run("default:"+tc.dflt+",user:"+tc.user, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(resolve(tc.dflt, tc.user)).To(Equal(tc.expected))
 		})
 	}
 }

--- a/tests/integration/api/suite_test.go
+++ b/tests/integration/api/suite_test.go
@@ -70,15 +70,14 @@ var _ = BeforeSuite(func() {
 
 	chartManager := helm.NewChartManager(mgr.GetConfig(), "")
 	resourceDir := path.Join(config.RepositoryRoot, "resources")
-	defaultProfiles := []string{"default"}
 
-	Expect(istio.NewReconciler(mgr.GetClient(), mgr.GetScheme(), resourceDir, defaultProfiles).
+	Expect(istio.NewReconciler(mgr.GetClient(), mgr.GetScheme(), resourceDir, "").
 		SetupWithManager(mgr)).To(Succeed())
 
 	Expect(istiorevision.NewReconciler(mgr.GetClient(), mgr.GetScheme(), resourceDir, chartManager).
 		SetupWithManager(mgr)).To(Succeed())
 
-	Expect(istiocni.NewReconciler(mgr.GetClient(), mgr.GetScheme(), resourceDir, chartManager, defaultProfiles).
+	Expect(istiocni.NewReconciler(mgr.GetClient(), mgr.GetScheme(), resourceDir, chartManager, "").
 		SetupWithManager(mgr)).To(Succeed())
 
 	// create new cancellable context


### PR DESCRIPTION
Only a single profile can be set as default. It gets applied only when you don't specify the profile in Istio.spec.profile. However, the profile (either the one selected in Istio.spec.profile or the default profile) is always applied on top of the profile called "default", but this profile is always applied on top of the profile called "default", just as when using istioctl install.