### PR TITLE
Ensure only one IstioCNI can exist at a time

### DIFF
--- a/api/v1alpha1/istiocni_types.go
+++ b/api/v1alpha1/istiocni_types.go
@@ -170,6 +170,7 @@ const (
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="The current state of this object."
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.version",description="The version of the Istio CNI installation."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the object"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default'",message="metadata.name must be 'default'"
 
 // IstioCNI represents a deployment of the Istio CNI component.
 type IstioCNI struct {

--- a/bundle/README.md
+++ b/bundle/README.md
@@ -72,10 +72,10 @@ Repeat the process to create a project named `istio-cni`.
 ### Creating the IstioCNI resource
 
 1. In the OpenShift Container Platform web console, click **Operators** -> **Installed Operators**. 
-1. Select `istio-cni` in the **Project** drop-down menu.
 1. Click the Sail Operator.
 1. Click **IstioCNI**.
 1. Click **Create IstioCNI**.
+1. Ensure that the name is `default`.
 1. Select the `istio-cni` project from the **Namespace** drop-down menu.
 1. Click **Create**. This action deploys the Istio CNI plugin.
 1. When `State: Healthy` appears in the `Status` column, the Istio CNI plugin is successfully deployed.

--- a/bundle/manifests/operator.istio.io_istiocnis.yaml
+++ b/bundle/manifests/operator.istio.io_istiocnis.yaml
@@ -1428,6 +1428,9 @@ spec:
                 type: string
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: metadata.name must be 'default'
+          rule: self.metadata.name == 'default'
     served: true
     storage: true
     subresources:

--- a/chart/crds/operator.istio.io_istiocnis.yaml
+++ b/chart/crds/operator.istio.io_istiocnis.yaml
@@ -1428,6 +1428,9 @@ spec:
                 type: string
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: metadata.name must be 'default'
+          rule: self.metadata.name == 'default'
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
Currently, we don't support creating more than one IstioCNI object, because Helm fails when installing the second instance. This happens because the ClusterRole name is hardcoded to "istio-cni".