### PR TITLE
Add minor information to bundle readme

### DIFF
--- a/bundle/README.md
+++ b/bundle/README.md
@@ -198,6 +198,8 @@ at the terminal:
     ```
 
 
+*Note*: `istioctl install` is not supported. The Sail Operator installs Istio.
+
 ## Installing the Bookinfo Application
 
 You can use the `bookinfo` example application to explore service mesh features. 


### PR DESCRIPTION
Adding to the documentation to the section `istioctl` a note to remark that `istioctl install`. is not a supported operation 