### PR TITLE
e2e tests: skip deletion of operator namespace on OCP

### DIFF
--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -274,6 +274,10 @@ spec:
 			To(Succeed(), "Operator failed to be deleted")
 		GinkgoWriter.Println("Operator uninstalled")
 
+		if ocp {
+			Success("Skipping deletion of operator namespace to avoid removal of operator container image from internal registry")
+			return
+		}
 		Expect(kubectl.DeleteNamespace(namespace)).To(Succeed(), "Namespace failed to be deleted")
 		Success("Namespace deleted")
 	})


### PR DESCRIPTION
When removing the namespace, all related container image repositories are deleted from the internal registry, causing following tests to fail.