### PR TITLE
Introduce validation errors

### DIFF
--- a/controllers/istio/istio_controller.go
+++ b/controllers/istio/istio_controller.go
@@ -86,10 +86,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, istio *v1alpha1.Istio) (ctrl
 // function should get reported in the status of the Istio object by the caller.
 func (r *Reconciler) doReconcile(ctx context.Context, istio *v1alpha1.Istio) (result ctrl.Result, err error) {
 	if istio.Spec.Version == "" {
-		return ctrl.Result{}, fmt.Errorf("no spec.version set")
+		return ctrl.Result{}, reconciler.NewValidationError("no spec.version set")
 	}
 	if istio.Spec.Namespace == "" {
-		return ctrl.Result{}, fmt.Errorf("no spec.namespace set")
+		return ctrl.Result{}, reconciler.NewValidationError("no spec.namespace set")
 	}
 
 	var values *v1alpha1.Values

--- a/controllers/istiocni/istiocni_controller.go
+++ b/controllers/istiocni/istiocni_controller.go
@@ -111,10 +111,10 @@ func (r *Reconciler) Finalize(ctx context.Context, cni *v1alpha1.IstioCNI) error
 
 func validateIstioCNI(cni *v1alpha1.IstioCNI) error {
 	if cni.Spec.Version == "" {
-		return fmt.Errorf("spec.version not set")
+		return reconciler.NewValidationError("spec.version not set")
 	}
 	if cni.Spec.Namespace == "" {
-		return fmt.Errorf("spec.namespace not set")
+		return reconciler.NewValidationError("spec.namespace not set")
 	}
 	return nil
 }

--- a/controllers/istiorevision/istiorevision_controller.go
+++ b/controllers/istiorevision/istiorevision_controller.go
@@ -119,23 +119,23 @@ func (r *Reconciler) Finalize(ctx context.Context, rev *v1alpha1.IstioRevision) 
 
 func validateIstioRevision(rev *v1alpha1.IstioRevision) error {
 	if rev.Spec.Version == "" {
-		return fmt.Errorf("spec.version not set")
+		return reconciler.NewValidationError("spec.version not set")
 	}
 	if rev.Spec.Namespace == "" {
-		return fmt.Errorf("spec.namespace not set")
+		return reconciler.NewValidationError("spec.namespace not set")
 	}
 	if rev.Spec.Values == nil {
-		return fmt.Errorf("spec.values not set")
+		return reconciler.NewValidationError("spec.values not set")
 	}
 
 	if rev.Name == v1alpha1.DefaultRevision && rev.Spec.Values.Revision != "" {
-		return fmt.Errorf("spec.values.revision must be \"\" when IstioRevision name is %s", v1alpha1.DefaultRevision)
+		return reconciler.NewValidationError(fmt.Sprintf("spec.values.revision must be \"\" when IstioRevision name is %s", v1alpha1.DefaultRevision))
 	} else if rev.Name != v1alpha1.DefaultRevision && rev.Spec.Values.Revision != rev.Name {
-		return fmt.Errorf("spec.values.revision does not match IstioRevision name")
+		return reconciler.NewValidationError("spec.values.revision does not match IstioRevision name")
 	}
 
 	if rev.Spec.Values.Global == nil || rev.Spec.Values.Global.IstioNamespace != rev.Spec.Namespace {
-		return fmt.Errorf("spec.values.global.istioNamespace does not match spec.namespace")
+		return reconciler.NewValidationError("spec.values.global.istioNamespace does not match spec.namespace")
 	}
 	return nil
 }

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -20,6 +20,7 @@ import (
 	"path"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/helm"
+	"github.com/istio-ecosystem/sail-operator/pkg/reconciler"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -53,7 +54,7 @@ func getValuesFromProfiles(profilesDir string, profiles []string) (helm.Values, 
 	alreadyApplied := sets.New[string]()
 	for _, profile := range profiles {
 		if profile == "" {
-			return nil, fmt.Errorf("profile name cannot be empty")
+			return nil, reconciler.NewValidationError("profile name cannot be empty")
 		}
 		if alreadyApplied.Contains(profile) {
 			continue
@@ -63,7 +64,7 @@ func getValuesFromProfiles(profilesDir string, profiles []string) (helm.Values, 
 		file := path.Join(profilesDir, profile+".yaml")
 		// prevent path traversal attacks
 		if path.Dir(file) != profilesDir {
-			return nil, fmt.Errorf("invalid profile name %s", profile)
+			return nil, reconciler.NewValidationError(fmt.Sprintf("invalid profile name %s", profile))
 		}
 
 		profileValues, err := getProfileValues(file)

--- a/pkg/reconciler/errors.go
+++ b/pkg/reconciler/errors.go
@@ -1,0 +1,34 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import "errors"
+
+type ValidationError struct {
+	message string
+}
+
+func (v ValidationError) Error() string {
+	return v.message
+}
+
+func NewValidationError(message string) error {
+	return &ValidationError{message: message}
+}
+
+func IsValidationError(err error) bool {
+	e := &ValidationError{}
+	return errors.As(err, &e)
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -104,6 +104,9 @@ func (r *StandardReconciler[T]) Reconcile(ctx context.Context, req ctrl.Request)
 	} else if errors.IsConflict(err) {
 		log.Info("Conflict detected. Retrying...")
 		return ctrl.Result{Requeue: true}, nil
+	} else if IsValidationError(err) {
+		log.Info("Validation failed", "error", err)
+		return ctrl.Result{}, nil
 	}
 	return result, err
 }

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -235,6 +235,26 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "handles ValidationErrors",
+			objects: []client.Object{
+				&v1alpha1.Istio{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       key.Name,
+						Finalizers: []string{testFinalizer},
+					},
+				},
+			},
+			setup: func(g *WithT, mock *mockReconciler) {
+				mock.reconcileError = NewValidationError("simulated validation error")
+			},
+			assert: func(g *WithT, cl client.Client, result ctrl.Result, err error, mock *mockReconciler) {
+				g.Expect(result).To(Equal(reconcile.Result{}))
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(mock.reconcileInvoked).To(BeTrue())
+				g.Expect(mock.finalizeInvoked).To(BeFalse())
+			},
+		},
+		{
 			name: "requeues when gc admission plugin does not yet know about our resources",
 			objects: []client.Object{
 				&v1alpha1.Istio{


### PR DESCRIPTION
When a validation error occurs, it should not be logged as an error and should *not* requeue the object, since the same error will happen on the next reconciliation attempt.