### PR TITLE
Don't log error when namespace is being deleted

### DIFF
--- a/controllers/istio/istio_controller.go
+++ b/controllers/istio/istio_controller.go
@@ -85,7 +85,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, istio *v1alpha1.Istio) (ctrl
 // doReconcile is the function that actually reconciles the Istio object. Any error reported by this
 // function should get reported in the status of the Istio object by the caller.
 func (r *Reconciler) doReconcile(ctx context.Context, istio *v1alpha1.Istio) (result ctrl.Result, err error) {
-	if err := validateIstio(istio); err != nil {
+	if err := validate(istio); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -101,12 +101,12 @@ func (r *Reconciler) doReconcile(ctx context.Context, istio *v1alpha1.Istio) (re
 	return r.pruneInactiveRevisions(ctx, istio)
 }
 
-func validateIstio(istio *v1alpha1.Istio) error {
+func validate(istio *v1alpha1.Istio) error {
 	if istio.Spec.Version == "" {
-		return reconciler.NewValidationError("no spec.version set")
+		return reconciler.NewValidationError("spec.version not set")
 	}
 	if istio.Spec.Namespace == "" {
-		return reconciler.NewValidationError("no spec.namespace set")
+		return reconciler.NewValidationError("spec.namespace not set")
 	}
 	return nil
 }

--- a/pkg/validation/namespace.go
+++ b/pkg/validation/namespace.go
@@ -1,0 +1,41 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/istio-ecosystem/sail-operator/pkg/reconciler"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ValidateTargetNamespace checks if the target namespace exists and is not being deleted.
+func ValidateTargetNamespace(ctx context.Context, cl client.Client, namespace string) error {
+	ns := &corev1.Namespace{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconciler.NewValidationError(fmt.Sprintf("namespace %q doesn't exist", namespace))
+		}
+		return fmt.Errorf("get failed: %w", err)
+	}
+	if ns.DeletionTimestamp != nil {
+		return reconciler.NewValidationError(fmt.Sprintf("namespace %q is being deleted", namespace))
+	}
+	return nil
+}

--- a/pkg/validation/namespace_test.go
+++ b/pkg/validation/namespace_test.go
@@ -1,0 +1,96 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/istio-ecosystem/sail-operator/pkg/scheme"
+	"github.com/istio-ecosystem/sail-operator/pkg/test/testtime"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestValidateTargetNamespace(t *testing.T) {
+	testCases := []struct {
+		name         string
+		objects      []client.Object
+		interceptors interceptor.Funcs
+		expectErr    string
+	}{
+		{
+			name: "success",
+			objects: []client.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-namespace",
+					},
+				},
+			},
+			expectErr: "",
+		},
+		{
+			name:      "namespace not found",
+			objects:   []client.Object{},
+			expectErr: `namespace "my-namespace" doesn't exist`,
+		},
+		{
+			name: "namespace deleted",
+			objects: []client.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "my-namespace",
+						DeletionTimestamp: testtime.OneMinuteAgo(),
+						Finalizers:        []string{"dummy"}, // required for fake client builder to accept a deleted object
+					},
+				},
+			},
+			expectErr: `namespace "my-namespace" is being deleted`,
+		},
+		{
+			name: "get error",
+			interceptors: interceptor.Funcs{
+				Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					return fmt.Errorf("simulated error")
+				},
+			},
+			expectErr: "simulated error",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(tc.objects...).
+				WithInterceptorFuncs(tc.interceptors).
+				Build()
+
+			err := ValidateTargetNamespace(context.TODO(), cl, "my-namespace")
+			if tc.expectErr == "" {
+				g.Expect(err).ToNot(HaveOccurred())
+			} else {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectErr))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, when the namespace referenced in IstioCni or IstioRevision.spec.namespace was being deleted, the operator log would show this as an error (with a stacktrace). Because of the requeues, the error was also logged many times.

Now, if the namespace is being deleted, the operator logs this at INFO level. It also doesn't requeue the object in this case.