### PR TITLE
Create make target for helm package

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -260,6 +260,10 @@ install: gen-manifests ## Install CRDs into an existing cluster.
 uninstall: ## Uninstall CRDs from an existing cluster.
 	kubectl delete --ignore-not-found -f chart/crds
 
+.PHONY: helm-package
+helm-package: helm ## Package the helm chart.
+	$(HELM) package chart
+
 .PHONY: deploy
 deploy: helm ## Deploy controller to an existing cluster.
 	$(info NAMESPACE: $(NAMESPACE))


### PR DESCRIPTION
This is part of this task: https://github.com/istio-ecosystem/sail-operator/issues/110

The idea is to have a make target to be able to create the package with all the charts of the operator and create later a job/automation to be able to automatically create the release is the release section of github