### PR TITLE
Update the README with more user focused info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Sail-operator
 
-This project is an operator that can be used to manage the installation of an [Istio](https://istio.io) control plane.
+The Sail-operator manages the lifecycle of your [Istio](https://istio.io) control plane. It provides custom resources for you to deploy and manage your control plane components.
 
 ## Table of Contents
+
+- [How it works](#how-it-works)
 - [Getting Started](#getting-started)
     - [Deploying the operator](#deploying-the-operator)
     - [Deploying the Istio Control Plane](#deploying-the-istio-control-plane)
-    - [Deploying the Istio CNI plugin](#deploying-the-istio-cni-plugin)
     - [Undeploying the operator](#undeploying-the-operator)
-    - [How it works](#how-it-works)
+- [Development](#undeploying-the-operator)
     - [Repository Setup](#repository-setup)
     - [Test It Out](#test-it-out)
     - [Modifying the API definitions](#modifying-the-api-definitions)
@@ -18,12 +19,66 @@ This project is an operator that can be used to manage the installation of an [I
 - [Community Support and Contributing](#community-support-and-contributing)
 - [Issue management](#issue-management)
 
+## How it works
+
+You manage your controlplane through an `Istio` resource.
+
+```yaml
+apiVersion: operator.istio.io/v1alpha1
+kind: Istio
+metadata:
+  name: example
+spec:
+  namespace: istio-system
+  version: v1.22.0
+```
+
+When you create an `Istio` resource, the sail operator then creates an `IstioRevision` that represents a control plane deployment.
+
+```yaml
+apiVersion: operator.istio.io/v1alpha1
+kind: IstioRevision
+metadata:
+  name: example
+  ...
+spec:
+  namespace: istio-system
+  version: v1.22.0
+status:
+  ...
+  state: Healthy
+```
+
+You can customize your controlplane installation through the `Istio` resource using Istio's `Helm` configuration values:
+
+```yaml
+apiVersion: operator.istio.io/v1alpha1
+kind: Istio
+metadata:
+  name: example
+spec:
+  version: v1.20.0
+  values:
+    global:
+      mtls:
+        enabled: true
+      trustDomainAliases:
+      - example.net
+    meshConfig:
+      trustDomain: example.com
+      trustDomainAliases:
+      - example.net
+```
+
 ## Getting Started
+
 You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
 **Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
 ### Deploying the operator
+
 Deploy the operator to the cluster:
+
 ```sh
 make deploy
 ```
@@ -37,7 +92,8 @@ make deploy-olm
 Make sure that the `HUB` and `TAG` environment variables point to your container image repository and that the repository is publicly accessible.
 
 ### Deploying the Istio Control Plane
-Create an instance of the Istio resource to install the Istio Control Plane. 
+
+Create an instance of the `Istio` resource to install the Istio Control Plane.
 
 Use the `istio-sample-kubernetes.yaml` file on vanilla Kubernetes:
 
@@ -55,11 +111,16 @@ kubectl get ns istio-system || kubectl create ns istio-system
 kubectl apply -f chart/samples/istio-sample-openshift.yaml
 ```
 
-### Deploying the Istio CNI plugin
-On OpenShift, you must also deploy the Istio CNI plugin by creating an instance of the IstioCNI resource:
+On OpenShift, you must also deploy the Istio CNI plugin by creating an instance of the `IstioCNI` resource:
 
 ```sh
 kubectl apply -f chart/samples/istiocni-sample.yaml
+```
+
+View your controlplane:
+
+```sh
+kubectl get istio default
 ```
 
 ### Undeploying the operator
@@ -69,13 +130,15 @@ Undeploy the operator from the cluster:
 make undeploy
 ```
 
-### How it works
+## Development
+
 This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
 
 It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
 which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster.
 
 ### Repository Setup
+
 We're using [gitleaks](https://github.com/gitleaks/gitleaks) to scan the repository for secrets. After cloning, please enable the pre-commit hook by running `make git-hook`. This will make sure that `gitleaks` scans your contributions before you push them to GitHub, avoiding any potential secret leaks.
 
 ```sh
@@ -85,6 +148,7 @@ make git-hook
 You will also need to sign off your commits to this repository. This can be done by adding the `-s` flag to your `git commit` command. If you want to automate that for this repository, take a look at `.git/hooks/prepare-commit-msg.sample`, it contains an example to do just that.
 
 ### Test It Out
+
 1. Install the CRDs into the cluster:
 
 ```sh
@@ -100,6 +164,7 @@ make run
 **NOTE:** You can also run this in one step by running: `make install run`
 
 ### Modifying the API definitions
+
 If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
 
 ```sh
@@ -111,11 +176,13 @@ make manifests
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 
 ### Writing Tests
+
 Please try to keep business logic in separate packages that can be independently tested wherever possible, especially if you can avoid the usage of Kubernetes clients. It greatly simplifies testing if we don't need to use envtest everywhere.
 
 E2E and integration tests should use the ginkgo-style BDD testing method, an example can be found in [`tests/integration/api/istio_test.go`](https://github.com/istio-ecosystem/sail-operator/blob/main/tests/integration/api/istio_test.go) for the test code and suite setup in [`tests/integration/api/suite_test.go`](https://github.com/istio-ecosystem/sail-operator/blob/main/tests/integration/api/suite_test.go). Unit tests should use standard golang xUnit-style tests (see [`pkg/kube/finalizers_test.go`](https://github.com/istio-ecosystem/sail-operator/blob/main/pkg/kube/finalizers_test.go) for an example).
 
 ### Integration Tests
+
 Please check the specific instructions for the integration tests in the [integration](https://github.com/istio-ecosystem/sail-operator/blob/main/tests/integration/README.md) directory.
 
 To run the integration tests, you can use the following command:
@@ -125,6 +192,7 @@ make test.integration
 ```
 
 ### End-to-End Tests
+
 Please check the specific instructions for the end-to-end tests in the [e2e](https://github.com/istio-ecosystem/sail-operator/blob/main/tests/e2e/README.md) directory.
 
 To run the end-to-end tests, you can use the following command:


### PR DESCRIPTION
Provides some more details on how to use the sail operator in the main `README` and moves the developer focused information into a separate `Development` section.