### PR TITLE
Include steps to create istio-cni ns when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ kubectl apply -f chart/samples/istio-sample-openshift.yaml
 On OpenShift, you must also deploy the Istio CNI plugin by creating an instance of the `IstioCNI` resource:
 
 ```sh
+# Create the istio-cni namespace if it does not exist
+kubectl get ns istio-cni || kubectl create ns istio-cni
 kubectl apply -f chart/samples/istiocni-sample.yaml
 ```
 


### PR DESCRIPTION
If we try to create `IstioCNI` resource while the `istio-cni` namespace is missing, it results in failures, and the following logs appear in the sail-operator.

```
2024-06-22T08:21:42Z    INFO    ctrlr.istiocni  Reconciliation done. Updating status.   {"IstioCNI": "default", "reconcileID": "5adcbf42-0e4f-4b89-9dee-a552b8b7c960"}                        
2024-06-22T08:21:42Z    INFO    ctrlr.istiocni  Validation failed   {"IstioCNI": "default", "reconcileID": "5adcbf42-0e4f-4b89-9dee-a552b8b7c960", "error": "validation error: namespace \"istio-cni\" doesn't exist"}  
``` 