### PR TITLE
Remove outdated comments from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest 
-# gcr.io/distroless/static:nonroot
 
 ARG TARGETOS TARGETARCH
 


### PR DESCRIPTION
We're not planning on using distroless