### PR TITLE
Update Sail Operator cli instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,16 @@ Create an instance of the `Istio` resource to install the Istio Control Plane.
 Use the `istio-sample-kubernetes.yaml` file on vanilla Kubernetes:
 
 ```sh
-# Namespace must exist prior to creating istio resource
-kubectl get ns istio-system || kubectl create ns istio-system
+# Create the istio-system namespace if it does not exist
+kubectl create ns istio-system
 kubectl apply -f chart/samples/istio-sample-kubernetes.yaml
 ```
 
 Use the `istio-sample-openshift.yaml` file on OpenShift:
 
 ```sh
-# Namespace must exist prior to creating istio resource
-kubectl get ns istio-system || kubectl create ns istio-system
+# Create the istio-system namespace if it does not exist
+kubectl create ns istio-system
 kubectl apply -f chart/samples/istio-sample-openshift.yaml
 ```
 
@@ -119,7 +119,7 @@ On OpenShift, you must also deploy the Istio CNI plugin by creating an instance 
 
 ```sh
 # Create the istio-cni namespace if it does not exist
-kubectl get ns istio-cni || kubectl create ns istio-cni
+kubectl create ns istio-cni
 kubectl apply -f chart/samples/istiocni-sample.yaml
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,31 +69,33 @@ is installed. `Succeeded` should appear in the **Status** column.
 1. Create the `openshift-operators` namespace (if it does not already exist).
 
     ```bash
-    $ kubectl create namespace openshift-operators
+    $ kubectl get ns openshift-operators || kubectl create ns openshift-operators
     ```
 
 1. Create the `Subscription` object with the desired `spec.channel`.
 
-    ```yaml
-    apiVersion: operators.coreos.com/v1alpha1
-    kind: Subscription
-    metadata:
-      name: sailoperator
-      namespace: openshift-operators
-    spec:
-      channel: "0.1-nightly"
-      installPlanApproval: Automatic
-      name: sailoperator
-      source: community-operators
-      sourceNamespace: openshift-marketplace
-    ```
+   ```bash
+   kubectl apply -f - <<EOF
+       apiVersion: operators.coreos.com/v1alpha1
+       kind: Subscription
+       metadata:
+         name: sailoperator
+         namespace: openshift-operators
+       spec:
+         channel: "3.0-nightly"
+         installPlanApproval: Automatic
+         name: sailoperator
+         source: community-operators
+         sourceNamespace: openshift-marketplace
+   EOF
+   ```
 
 1. Verify that the installation succeeded by inspecting the CSV status.
 
     ```bash
     $ kubectl get csv -n openshift-operators
     NAME                                     DISPLAY         VERSION                    REPLACES                                 PHASE
-    sailoperator.v0.1.0-nightly-2024-06-25   Sail Operator   0.1.0-nightly-2024-06-25   sailoperator.v0.1.0-nightly-2024-06-21   Succeeded
+    sailoperator.v3.0.0-nightly-2024-05-13   Sail Operator   3.0.0-nightly-2024-05-13   sailoperator.v3.0.0-nightly-2024-05-11   Succeeded
     ```
 
     `Succeeded` should appear in the sailoperator CSV `PHASE` column.

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ is installed. `Succeeded` should appear in the **Status** column.
 1. Create the `openshift-operators` namespace (if it does not already exist).
 
     ```bash
-    $ kubectl get ns openshift-operators || kubectl create ns openshift-operators
+    $ kubectl create namespace openshift-operators
     ```
 
 1. Create the `Subscription` object with the desired `spec.channel`.
@@ -82,7 +82,7 @@ is installed. `Succeeded` should appear in the **Status** column.
          name: sailoperator
          namespace: openshift-operators
        spec:
-         channel: "3.0-nightly"
+         channel: "0.1-nightly"
          installPlanApproval: Automatic
          name: sailoperator
          source: community-operators
@@ -95,7 +95,7 @@ is installed. `Succeeded` should appear in the **Status** column.
     ```bash
     $ kubectl get csv -n openshift-operators
     NAME                                     DISPLAY         VERSION                    REPLACES                                 PHASE
-    sailoperator.v3.0.0-nightly-2024-05-13   Sail Operator   3.0.0-nightly-2024-05-13   sailoperator.v3.0.0-nightly-2024-05-11   Succeeded
+    sailoperator.v0.1.0-nightly-2024-06-25   Sail Operator   0.1.0-nightly-2024-06-25   sailoperator.v0.1.0-nightly-2024-06-21   Succeeded
     ```
 
     `Succeeded` should appear in the sailoperator CSV `PHASE` column.
@@ -398,10 +398,10 @@ EOF
 
 ### Deploy Gateway and Bookinfo
 
-Create the bookinfo namespace and enable injection.
+Create the bookinfo namespace (if it doesn't already exist) and enable injection.
 
 ```sh
-kubectl get namespace bookinfo || kubectl create namespace bookinfo
+kubectl create namespace bookinfo
 kubectl label namespace bookinfo istio.io/rev=test
 ```
 


### PR DESCRIPTION
Some minor updates to the doc:

1. openshift-operators is usually present in any OCP deployment, so the instructions should create it only if its missing.
2. The instructions were only suggesting the yaml for `Subscription` but there were no instructions to apply it.