### PR TITLE
Add option to log events that cause resources to be enqueued

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/controllers/istiocni"
 	"github.com/istio-ecosystem/sail-operator/controllers/istiorevision"
 	"github.com/istio-ecosystem/sail-operator/pkg/config"
+	"github.com/istio-ecosystem/sail-operator/pkg/enqueuelogger"
 	"github.com/istio-ecosystem/sail-operator/pkg/helm"
 	"github.com/istio-ecosystem/sail-operator/pkg/scheme"
 	"github.com/istio-ecosystem/sail-operator/pkg/version"
@@ -55,6 +56,8 @@ func main() {
 	flag.BoolVar(&printVersion, "version", printVersion, "Prints version information and exits")
 	flag.BoolVar(&leaderElectionEnabled, "leader-elect", true,
 		"Enable leader election for this operator. Enabling this will ensure there is only one active controller manager.")
+
+	flag.BoolVar(&enqueuelogger.LogEnqueueEvents, "log-enqueue-events", false, "Whether to log events that cause an object to be enqueued for reconciliation")
 
 	opts := zap.Options{
 		Development: true,

--- a/pkg/enqueuelogger/queue.go
+++ b/pkg/enqueuelogger/queue.go
@@ -1,0 +1,81 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enqueuelogger
+
+import (
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+// AdditionNotifierQueue is a queue that calls an onAdd function whenever an item is added to the queue.
+// It is meant to be used in conjunction with EnqueueEventLogger to log items enqueued by a handler.
+type AdditionNotifierQueue struct {
+	delegate workqueue.RateLimitingInterface
+	onAdd    func(item any)
+}
+
+var _ workqueue.RateLimitingInterface = &AdditionNotifierQueue{}
+
+func NewAdditionNotifierQueue(delegate workqueue.RateLimitingInterface, onAddFunc func(item any)) *AdditionNotifierQueue {
+	return &AdditionNotifierQueue{delegate: delegate}
+}
+
+func (q *AdditionNotifierQueue) Add(item interface{}) {
+	q.delegate.Add(item)
+	q.onAdd(item)
+}
+
+func (q *AdditionNotifierQueue) Len() int {
+	return q.delegate.Len()
+}
+
+func (q *AdditionNotifierQueue) Get() (item interface{}, shutdown bool) {
+	return q.delegate.Get()
+}
+
+func (q *AdditionNotifierQueue) Done(item interface{}) {
+	q.delegate.Done(item)
+}
+
+func (q *AdditionNotifierQueue) ShutDown() {
+	q.delegate.ShutDown()
+}
+
+func (q *AdditionNotifierQueue) ShutDownWithDrain() {
+	q.delegate.ShutDownWithDrain()
+}
+
+func (q *AdditionNotifierQueue) ShuttingDown() bool {
+	return q.delegate.ShuttingDown()
+}
+
+func (q *AdditionNotifierQueue) AddAfter(item interface{}, duration time.Duration) {
+	q.delegate.AddAfter(item, duration)
+	q.onAdd(item)
+}
+
+func (q *AdditionNotifierQueue) AddRateLimited(item interface{}) {
+	q.delegate.AddRateLimited(item)
+	q.onAdd(item)
+}
+
+func (q *AdditionNotifierQueue) Forget(item interface{}) {
+	q.delegate.Forget(item)
+}
+
+func (q *AdditionNotifierQueue) NumRequeues(item interface{}) int {
+	return q.delegate.NumRequeues(item)
+}

--- a/pkg/enqueuelogger/wrapper.go
+++ b/pkg/enqueuelogger/wrapper.go
@@ -1,0 +1,115 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enqueuelogger
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var LogEnqueueEvents = false
+
+// EnqueueEventLogger is a handler.EventHandler that wraps another handler.EventHandler and logs enqueued items (i.e.
+// if the wrapped handler enqueues items from the event that is being handled, the EnqueueEventLogger logs them).
+// The main purpose of this wrapper is to help with debugging which watch events are causing an object to be enqueued
+// for reconciliation.
+type EnqueueEventLogger struct {
+	kind     string
+	logger   logr.Logger
+	delegate handler.EventHandler
+}
+
+var _ handler.EventHandler = &EnqueueEventLogger{}
+
+func (h *EnqueueEventLogger) Create(ctx context.Context, e event.TypedCreateEvent[client.Object], q workqueue.RateLimitingInterface) {
+	h.delegate.Create(ctx, e, h.wrapQueue(q, "Create", e.Object))
+}
+
+func (h *EnqueueEventLogger) Update(ctx context.Context, e event.TypedUpdateEvent[client.Object], q workqueue.RateLimitingInterface) {
+	h.delegate.Update(ctx, e, h.wrapQueue(q, "Update", e.ObjectNew))
+}
+
+func (h *EnqueueEventLogger) Delete(ctx context.Context, e event.TypedDeleteEvent[client.Object], q workqueue.RateLimitingInterface) {
+	h.delegate.Delete(ctx, e, h.wrapQueue(q, "Delete", e.Object))
+}
+
+func (h *EnqueueEventLogger) Generic(ctx context.Context, e event.TypedGenericEvent[client.Object], q workqueue.RateLimitingInterface) {
+	h.delegate.Generic(ctx, e, h.wrapQueue(q, "Generic", e.Object))
+}
+
+func (h *EnqueueEventLogger) wrapQueue(q workqueue.RateLimitingInterface, eventType string, obj client.Object) workqueue.RateLimitingInterface {
+	return &AdditionNotifierQueue{
+		delegate: q,
+		onAdd: func(item any) {
+			request := item.(reconcile.Request)
+			requestSummary := ObjectSummary{
+				Kind:      h.kind,
+				Namespace: request.Namespace,
+				Name:      request.Name,
+			}
+
+			eventSummary := EventSummary{
+				Type: eventType,
+				Object: ObjectSummary{
+					Kind:      determineKind(obj),
+					Name:      obj.GetName(),
+					Namespace: obj.GetNamespace(),
+				},
+			}
+
+			h.logger.Info("Object queued for reconciliation due to event", "object", requestSummary, "event", eventSummary)
+		},
+	}
+}
+
+func determineKind(obj client.Object) string {
+	if obj == nil {
+		return ""
+	}
+	kind := obj.GetObjectKind().GroupVersionKind().Kind
+	if kind == "" {
+		kind = reflect.TypeOf(obj).Elem().Name()
+	}
+	return kind
+}
+
+func WrapIfNecessary(kind string, logger logr.Logger, handler handler.EventHandler) handler.EventHandler {
+	if LogEnqueueEvents {
+		return &EnqueueEventLogger{
+			kind:     kind,
+			logger:   logger,
+			delegate: handler,
+		}
+	}
+	return handler
+}
+
+type EventSummary struct {
+	Type   string        `json:"type"`
+	Object ObjectSummary `json:"object"`
+}
+
+type ObjectSummary struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+}


### PR DESCRIPTION
When you run the operator with the `--log-enqueue-events` option, the operator will log every watch event that causes a resource (e.g. IstioRevision) to be queued for reconciliation. This will allow us to easily see why a resource is being reconciled continuously.