### PR TITLE
Add relatedImages to ClusterServiceVersion

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -483,6 +483,8 @@ $(GITLEAKS): $(LOCALBIN)
 bundle: gen helm operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(HELM) template chart chart $(HELM_TEMPL_DEF_FLAGS) --set image='$(IMAGE)' --set platform=openshift --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 
+	@hack/patch-csv.sh bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+
 	# update CSV's spec.customresourcedefinitions.owned field. ideally we could do this straight in ./bundle, but
 	# sadly this is only possible if the file lives in a `bases` directory
 	mkdir -p _tmp/bases
@@ -500,7 +502,6 @@ bundle: gen helm operator-sdk ## Generate bundle manifests and metadata, then va
 			fi \
 		fi
 
-	@hack/patch-csv.sh bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -499,6 +499,8 @@ bundle: gen helm operator-sdk ## Generate bundle manifests and metadata, then va
 				git checkout "$$csvPath" || echo "failed to revert timestamp change. assuming we're in the middle of a merge"; \
 			fi \
 		fi
+
+	@hack/patch-csv.sh bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -442,6 +442,10 @@ CONTROLLER_TOOLS_VERSION ?= v0.15.0
 OPM_VERSION ?= v1.45.0
 GITLEAKS_VERSION ?= v8.18.4
 
+# GENERATE_RELATED_IMAGES defines whether `spec.relatedImages` is going to be generated or not
+# To disable set flag to false
+GENERATE_RELATED_IMAGES ?= true
+
 .PHONY: helm $(HELM)
 helm: $(HELM) ## Download helm to bin directory. If wrong version is installed, it will be overwritten.
 $(HELM): $(LOCALBIN)
@@ -483,7 +487,9 @@ $(GITLEAKS): $(LOCALBIN)
 bundle: gen helm operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(HELM) template chart chart $(HELM_TEMPL_DEF_FLAGS) --set image='$(IMAGE)' --set platform=openshift --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 
+ifeq ($(GENERATE_RELATED_IMAGES), true)
 	@hack/patch-csv.sh bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+endif
 
 	# update CSV's spec.customresourcedefinitions.owned field. ideally we could do this straight in ./bundle, but
 	# sadly this is only possible if the file lives in a `bases` directory

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/sail-operator:0.1-latest
-    createdAt: "2024-08-01T14:16:13Z"
+    createdAt: "2024-08-05T12:57:49Z"
     description: Experimental operator for installing Istio service mesh
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -57,218 +57,260 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - kind: WasmPlugin
-        name: wasmplugins.extensions.istio.io
-        version: v1alpha1
-      - kind: DestinationRule
-        name: destinationrules.networking.istio.io
-        version: v1
-      - kind: DestinationRule
-        name: destinationrules.networking.istio.io
-        version: v1alpha3
-      - kind: DestinationRule
-        name: destinationrules.networking.istio.io
-        version: v1beta1
-      - kind: EnvoyFilter
-        name: envoyfilters.networking.istio.io
-        version: v1alpha3
-      - kind: Gateway
-        name: gateways.networking.istio.io
-        version: v1
-      - kind: Gateway
-        name: gateways.networking.istio.io
-        version: v1alpha3
-      - kind: Gateway
-        name: gateways.networking.istio.io
-        version: v1beta1
-      - kind: ProxyConfig
-        name: proxyconfigs.networking.istio.io
-        version: v1beta1
-      - kind: ServiceEntry
-        name: serviceentries.networking.istio.io
-        version: v1
-      - kind: ServiceEntry
-        name: serviceentries.networking.istio.io
-        version: v1alpha3
-      - kind: ServiceEntry
-        name: serviceentries.networking.istio.io
-        version: v1beta1
-      - kind: Sidecar
-        name: sidecars.networking.istio.io
-        version: v1
-      - kind: Sidecar
-        name: sidecars.networking.istio.io
-        version: v1alpha3
-      - kind: Sidecar
-        name: sidecars.networking.istio.io
-        version: v1beta1
-      - kind: VirtualService
-        name: virtualservices.networking.istio.io
-        version: v1
-      - kind: VirtualService
-        name: virtualservices.networking.istio.io
-        version: v1alpha3
-      - kind: VirtualService
-        name: virtualservices.networking.istio.io
-        version: v1beta1
-      - kind: WorkloadEntry
-        name: workloadentries.networking.istio.io
-        version: v1
-      - kind: WorkloadEntry
-        name: workloadentries.networking.istio.io
-        version: v1alpha3
-      - kind: WorkloadEntry
-        name: workloadentries.networking.istio.io
-        version: v1beta1
-      - kind: WorkloadGroup
-        name: workloadgroups.networking.istio.io
-        version: v1
-      - kind: WorkloadGroup
-        name: workloadgroups.networking.istio.io
-        version: v1alpha3
-      - kind: WorkloadGroup
-        name: workloadgroups.networking.istio.io
-        version: v1beta1
-      - kind: AuthorizationPolicy
-        name: authorizationpolicies.security.istio.io
-        version: v1
-      - kind: AuthorizationPolicy
-        name: authorizationpolicies.security.istio.io
-        version: v1beta1
-      - kind: PeerAuthentication
-        name: peerauthentications.security.istio.io
-        version: v1
-      - kind: PeerAuthentication
-        name: peerauthentications.security.istio.io
-        version: v1beta1
-      - kind: RequestAuthentication
-        name: requestauthentications.security.istio.io
-        version: v1
-      - kind: RequestAuthentication
-        name: requestauthentications.security.istio.io
-        version: v1beta1
-      - kind: Telemetry
-        name: telemetries.telemetry.istio.io
-        version: v1
-      - kind: Telemetry
-        name: telemetries.telemetry.istio.io
-        version: v1alpha1
-      - description: IstioCNI represents a deployment of the Istio CNI component.
-        displayName: Istio CNI
-        kind: IstioCNI
-        name: istiocnis.operator.istio.io
-        specDescriptors:
-          - description: 'Defines the version of Istio to install. Must be one of: v1.22.3, v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0, latest.'
-            displayName: Istio Version
-            path: version
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
-              - urn:alm:descriptor:com.tectonic.ui:select:latest
-          - description: Namespace to which the Istio CNI component should be installed.
-            displayName: Namespace
-            path: namespace
-            x-descriptors:
-              - urn:alm:descriptor:io.kubernetes:Namespace
-          - description: 'The built-in installation configuration profile to use. The ''default'' profile is always applied. On OpenShift, the ''openshift'' profile is also applied on top of ''default''. Must be one of: ambient, default, demo, empty, external, minimal, openshift-ambient, openshift, preview, remote, stable.'
-            displayName: Profile
-            path: profile
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:hidden
-          - description: Defines the values to be passed to the Helm charts when installing Istio CNI.
-            displayName: Helm Values
-            path: values
-        version: v1alpha1
-      - description: IstioRevision represents a single revision of an Istio Service Mesh deployment. Users shouldn't create IstioRevision objects directly. Instead, they should create an Istio object and allow the operator to create the underlying IstioRevision object(s).
-        displayName: Istio Revision
-        kind: IstioRevision
-        name: istiorevisions.operator.istio.io
-        specDescriptors:
-          - description: 'Defines the version of Istio to install. Must be one of: v1.22.3, v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0, latest.'
-            displayName: Istio Version
-            path: version
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
-              - urn:alm:descriptor:com.tectonic.ui:select:latest
-          - description: Namespace to which the Istio components should be installed.
-            displayName: Namespace
-            path: namespace
-            x-descriptors:
-              - urn:alm:descriptor:io.kubernetes:Namespace
-          - description: Defines the values to be passed to the Helm charts when installing Istio.
-            displayName: Helm Values
-            path: values
-        version: v1alpha1
-      - description: Istio represents an Istio Service Mesh deployment consisting of one or more control plane instances (represented by one or more IstioRevision objects). To deploy an Istio Service Mesh, a user creates an Istio object with the desired Istio version and configuration. The operator then creates an IstioRevision object, which in turn creates the underlying Deployment objects for istiod and other control plane components, similar to how a Deployment object in Kubernetes creates ReplicaSets that create the Pods.
-        displayName: Istio
-        kind: Istio
-        name: istios.operator.istio.io
-        specDescriptors:
-          - description: "Type of strategy to use. Can be \"InPlace\" or \"RevisionBased\". When the \"InPlace\" strategy is used, the existing Istio control plane is updated in-place. The workloads therefore don't need to be moved from one control plane instance to another. When the \"RevisionBased\" strategy is used, a new Istio control plane instance is created for every change to the Istio.spec.version field. The old control plane remains in place until all workloads have been moved to the new control plane instance. \n The \"InPlace\" strategy is the default.\tTODO: change default to \"RevisionBased\""
-            displayName: Type
-            path: updateStrategy.type
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:select:InPlace
-              - urn:alm:descriptor:com.tectonic.ui:select:RevisionBased
-          - description: 'Defines the version of Istio to install. Must be one of: v1.22.3, v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0, latest.'
-            displayName: Istio Version
-            path: version
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
-              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
-              - urn:alm:descriptor:com.tectonic.ui:select:latest
-          - description: Defines how many seconds the operator should wait before removing a non-active revision after all the workloads have stopped using it. You may want to set this value on the order of minutes. The minimum and the default value is 30.
-            displayName: Inactive Revision Deletion Grace Period (seconds)
-            path: updateStrategy.inactiveRevisionDeletionGracePeriodSeconds
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:number
-          - description: Defines whether the workloads should be moved from one control plane instance to another automatically. If updateWorkloads is true, the operator moves the workloads from the old control plane instance to the new one after the new control plane is ready. If updateWorkloads is false, the user must move the workloads manually by updating the istio.io/rev labels on the namespace and/or the pods. Defaults to false.
-            displayName: Update Workloads Automatically
-            path: updateStrategy.updateWorkloads
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-          - description: Namespace to which the Istio components should be installed.
-            displayName: Namespace
-            path: namespace
-            x-descriptors:
-              - urn:alm:descriptor:io.kubernetes:Namespace
-          - description: 'The built-in installation configuration profile to use. The ''default'' profile is always applied. On OpenShift, the ''openshift'' profile is also applied on top of ''default''. Must be one of: ambient, default, demo, empty, external, minimal, openshift-ambient, openshift, preview, remote, stable.'
-            displayName: Profile
-            path: profile
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:hidden
-          - description: Defines the update strategy to use when the version in the Istio CR is updated.
-            displayName: Update Strategy
-            path: updateStrategy
-          - description: Defines the values to be passed to the Helm charts when installing Istio.
-            displayName: Helm Values
-            path: values
-        version: v1alpha1
+    - kind: WasmPlugin
+      name: wasmplugins.extensions.istio.io
+      version: v1alpha1
+    - kind: DestinationRule
+      name: destinationrules.networking.istio.io
+      version: v1
+    - kind: DestinationRule
+      name: destinationrules.networking.istio.io
+      version: v1alpha3
+    - kind: DestinationRule
+      name: destinationrules.networking.istio.io
+      version: v1beta1
+    - kind: EnvoyFilter
+      name: envoyfilters.networking.istio.io
+      version: v1alpha3
+    - kind: Gateway
+      name: gateways.networking.istio.io
+      version: v1
+    - kind: Gateway
+      name: gateways.networking.istio.io
+      version: v1alpha3
+    - kind: Gateway
+      name: gateways.networking.istio.io
+      version: v1beta1
+    - kind: ProxyConfig
+      name: proxyconfigs.networking.istio.io
+      version: v1beta1
+    - kind: ServiceEntry
+      name: serviceentries.networking.istio.io
+      version: v1
+    - kind: ServiceEntry
+      name: serviceentries.networking.istio.io
+      version: v1alpha3
+    - kind: ServiceEntry
+      name: serviceentries.networking.istio.io
+      version: v1beta1
+    - kind: Sidecar
+      name: sidecars.networking.istio.io
+      version: v1
+    - kind: Sidecar
+      name: sidecars.networking.istio.io
+      version: v1alpha3
+    - kind: Sidecar
+      name: sidecars.networking.istio.io
+      version: v1beta1
+    - kind: VirtualService
+      name: virtualservices.networking.istio.io
+      version: v1
+    - kind: VirtualService
+      name: virtualservices.networking.istio.io
+      version: v1alpha3
+    - kind: VirtualService
+      name: virtualservices.networking.istio.io
+      version: v1beta1
+    - kind: WorkloadEntry
+      name: workloadentries.networking.istio.io
+      version: v1
+    - kind: WorkloadEntry
+      name: workloadentries.networking.istio.io
+      version: v1alpha3
+    - kind: WorkloadEntry
+      name: workloadentries.networking.istio.io
+      version: v1beta1
+    - kind: WorkloadGroup
+      name: workloadgroups.networking.istio.io
+      version: v1
+    - kind: WorkloadGroup
+      name: workloadgroups.networking.istio.io
+      version: v1alpha3
+    - kind: WorkloadGroup
+      name: workloadgroups.networking.istio.io
+      version: v1beta1
+    - kind: AuthorizationPolicy
+      name: authorizationpolicies.security.istio.io
+      version: v1
+    - kind: AuthorizationPolicy
+      name: authorizationpolicies.security.istio.io
+      version: v1beta1
+    - kind: PeerAuthentication
+      name: peerauthentications.security.istio.io
+      version: v1
+    - kind: PeerAuthentication
+      name: peerauthentications.security.istio.io
+      version: v1beta1
+    - kind: RequestAuthentication
+      name: requestauthentications.security.istio.io
+      version: v1
+    - kind: RequestAuthentication
+      name: requestauthentications.security.istio.io
+      version: v1beta1
+    - kind: Telemetry
+      name: telemetries.telemetry.istio.io
+      version: v1
+    - kind: Telemetry
+      name: telemetries.telemetry.istio.io
+      version: v1alpha1
+    - description: IstioCNI represents a deployment of the Istio CNI component.
+      displayName: Istio CNI
+      kind: IstioCNI
+      name: istiocnis.operator.istio.io
+      specDescriptors:
+      - description: 'Defines the version of Istio to install. Must be one of: v1.22.3,
+          v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0,
+          latest.'
+        displayName: Istio Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
+        - urn:alm:descriptor:com.tectonic.ui:select:latest
+      - description: Namespace to which the Istio CNI component should be installed.
+        displayName: Namespace
+        path: namespace
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Namespace
+      - description: 'The built-in installation configuration profile to use. The
+          ''default'' profile is always applied. On OpenShift, the ''openshift'' profile
+          is also applied on top of ''default''. Must be one of: ambient, default,
+          demo, empty, external, minimal, openshift-ambient, openshift, preview, remote,
+          stable.'
+        displayName: Profile
+        path: profile
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Defines the values to be passed to the Helm charts when installing
+          Istio CNI.
+        displayName: Helm Values
+        path: values
+      version: v1alpha1
+    - description: IstioRevision represents a single revision of an Istio Service
+        Mesh deployment. Users shouldn't create IstioRevision objects directly. Instead,
+        they should create an Istio object and allow the operator to create the underlying
+        IstioRevision object(s).
+      displayName: Istio Revision
+      kind: IstioRevision
+      name: istiorevisions.operator.istio.io
+      specDescriptors:
+      - description: 'Defines the version of Istio to install. Must be one of: v1.22.3,
+          v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0,
+          latest.'
+        displayName: Istio Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
+        - urn:alm:descriptor:com.tectonic.ui:select:latest
+      - description: Namespace to which the Istio components should be installed.
+        displayName: Namespace
+        path: namespace
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Namespace
+      - description: Defines the values to be passed to the Helm charts when installing
+          Istio.
+        displayName: Helm Values
+        path: values
+      version: v1alpha1
+    - description: Istio represents an Istio Service Mesh deployment consisting of
+        one or more control plane instances (represented by one or more IstioRevision
+        objects). To deploy an Istio Service Mesh, a user creates an Istio object
+        with the desired Istio version and configuration. The operator then creates
+        an IstioRevision object, which in turn creates the underlying Deployment objects
+        for istiod and other control plane components, similar to how a Deployment
+        object in Kubernetes creates ReplicaSets that create the Pods.
+      displayName: Istio
+      kind: Istio
+      name: istios.operator.istio.io
+      specDescriptors:
+      - description: "Type of strategy to use. Can be \"InPlace\" or \"RevisionBased\".
+          When the \"InPlace\" strategy is used, the existing Istio control plane
+          is updated in-place. The workloads therefore don't need to be moved from
+          one control plane instance to another. When the \"RevisionBased\" strategy
+          is used, a new Istio control plane instance is created for every change
+          to the Istio.spec.version field. The old control plane remains in place
+          until all workloads have been moved to the new control plane instance. \n
+          The \"InPlace\" strategy is the default.\tTODO: change default to \"RevisionBased\""
+        displayName: Type
+        path: updateStrategy.type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:InPlace
+        - urn:alm:descriptor:com.tectonic.ui:select:RevisionBased
+      - description: 'Defines the version of Istio to install. Must be one of: v1.22.3,
+          v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0,
+          latest.'
+        displayName: Istio Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
+        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
+        - urn:alm:descriptor:com.tectonic.ui:select:latest
+      - description: Defines how many seconds the operator should wait before removing
+          a non-active revision after all the workloads have stopped using it. You
+          may want to set this value on the order of minutes. The minimum and the
+          default value is 30.
+        displayName: Inactive Revision Deletion Grace Period (seconds)
+        path: updateStrategy.inactiveRevisionDeletionGracePeriodSeconds
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Defines whether the workloads should be moved from one control
+          plane instance to another automatically. If updateWorkloads is true, the
+          operator moves the workloads from the old control plane instance to the
+          new one after the new control plane is ready. If updateWorkloads is false,
+          the user must move the workloads manually by updating the istio.io/rev labels
+          on the namespace and/or the pods. Defaults to false.
+        displayName: Update Workloads Automatically
+        path: updateStrategy.updateWorkloads
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Namespace to which the Istio components should be installed.
+        displayName: Namespace
+        path: namespace
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Namespace
+      - description: 'The built-in installation configuration profile to use. The
+          ''default'' profile is always applied. On OpenShift, the ''openshift'' profile
+          is also applied on top of ''default''. Must be one of: ambient, default,
+          demo, empty, external, minimal, openshift-ambient, openshift, preview, remote,
+          stable.'
+        displayName: Profile
+        path: profile
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Defines the update strategy to use when the version in the Istio
+          CR is updated.
+        displayName: Update Strategy
+        path: updateStrategy
+      - description: Defines the values to be passed to the Helm charts when installing
+          Istio.
+        displayName: Helm Values
+        path: values
+      version: v1alpha1
   description: |-
     This is an experimental operator for installing Istio service mesh.
 
@@ -288,470 +330,470 @@ spec:
     [See this page](https://github.com/istio-ecosystem/sail-operator/blob/main/bundle/README.md) for instructions on how to use it.
   displayName: Sail Operator
   icon:
-    - base64data: iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAAAFiAAABYgFfJ9BTAAAHL0lEQVR4nO2du24bRxSGz5LL+01kaMuX2HShnmlSi2VUBM4bKG/gdGFnl+rsBwggvUHUsTT9AIGdnoWCIIWNIJZNWKLM5Uww1K4sC6JEQrP7z8yeDyDYCHuG3F/nNmeWnpSSTMXvD3tE9Ey9gp3e0NiFWkzGgqVvEtFLvz/c8/vDNQPW4xQ2CCBim4gO/P7wFzOW4wY2CUDRIKLnfn/4xu8PvzNgPdZjmwAiukT02u8Pn5mxHHuxVQART9kb3AzbBUDsDW6GFgEMRuNHwM8QobzBkCuF1dDlAfYGo/GeAULYDCuFHngd1qAzBKgy7c1gNEa74kbYN+CQsAS6cwD15T8djMZKCOj/QhUS9jkkXE1cSaBKzF4ORuMXg9EYeQMeE9GQq4TFxF0FPAnDAtIbdEMRcF5wCUmUgZ3QGyBjcpQX/Axcg5Ek2QeIcgNkpbDLyeHXJN0I6oYh4aeE7Z5HJYd7QPtGgegEKnf8OzgkbLMITkG2glVI2AdWCXMRpL1MRO8FzMs0pAjCCiG1IjBhM0jlBQeD0RhVq3fTLAJTdgMboSeAigBkG4pJ28FKBK8HozGqVu+mMTE0cR5gFyiC1FUHpg6EsAgSwuSJoN3t7+//ALK9nZbpY6NHwh7drf8qG+VjkPnnadg7MFoA+bxPYn2tBBTBrutbyVYMhc5FUMihzDs9T2DNVLB42D4GiUCVp862jO0ZC/e8knjYnlAGsmTVKHKyMrDrXIDnFWedW/+BRPDYxVkC+w6G5LItca/5L8i6miVAzjJox8qTQbJcaIt2/QPIvMoHTDgIowVrj4bJVrUhq8UjgGmVFO4D7MaC1WcDxd2mR7kswrTaOHqBMKwbuw+Hel5p9m0blRQ+cWHU3P7TwSopvFVHJYXWnzxy4Xg4yUa5DcwHrO4POCEAOs0HMsD+gLWloTMCUE0i8eAbVCiwtlXsjgBUKCjk2rJZnQBMWxsKnBKAQrRrAlQaWhkKnBMAeV5Z3GtxKFgS9wQQhQLMEIkKBVY1iJwUgELcbnigqmDbpgaRswKYVwV31t6CrFvjBdwVgAoF1eK6LBcQpru2TBU7LQCFuLOGSgif2ZAQOi8A8rOcEF6B+wLAJ4RGTxSnQgDzhLBVRU0QGe0F0iEAlRA2KzlQh3DT5LIwNQKYdwhvNbgsvEB6BBCWhcARMiPPGaZKAAqgFzDyTEHqBAD0Ah0TvUDqBEDsBb4ilQJgL/CFVAqA2AuckVoBsBc4JbUCUIhGBdUdNMYLpFoAslnJg/YIOqbMD6ZaAOpomawVUc8fMmJeIN0CmE8R1z+DTBuxR5B6AVA2o46Zo6zDk0EWwOmzBv4Gmd5GP2yCBaAEUMw/AJWEhPYCLIAQYEkITQZZACFyrSxAphvIxhALICKTaaYxGWQBnEM2yqhkcBM1PMoCOIesFB+AOoOEygVYABcAdgYhrWEWwAVEq4YSACQZZAFcJJdtAXsCiXsBFsAlyFrpPcj046Q7gyyASxBrlRnQfKJegAVwGX62nZbWMAtgAcAw0E2yJ8ACWIColxFPHo1IzAuwABaR9+8Dm0KJ5QEsgCsANoU6SYUBFsAVyGoR9XgZSioMsACuQP00DdB8ImGABXAVamoY94OViYQBFsA1yHoJdYRMEfvUMAvgGmSlGADNx54HsACuA1sOduPeG2ABLIEs55HmYw0DLIAlkNXiP0DzsVYDLIAlkKU8Mg9gDwAn53eAS2jEeYaQBbAkoKeOR7AA0MhKAdkPiC0PYAEsSymPOkZOYTkYy6PnWQBLon6HCLyEWMIAC2BZPK8EHBMjFoABADeGiAVgALJc+Au4iljyABbAKhRz6O9LuxdgAayAzPtV8BK0zwewAFYhk2mCV8AeAA24I7ip+4IsgFXJZVGTwnN0j4mxAFZEFnLvwEtgAUBxrBJgAayIzGZQTxOLYA8Axc/eAa+gq/Nivs6LOUMwe0tCBt7RSUBSFr1PJ+vqo3lHJ+oNWgZQmAgGO703Wq6l4yLWoW6wlBPv+LMf3ugOCUneZEok5h5+3fCPpMIAC2AhQrynmfjofQ4yNJ0J72R6m6azkjcNiKbzh3+YfoOvQ9uouJ0CkPKYgtk7byYyNJkKL5jVaTJt0kyQdzJVf9EMX66irRIwWQCv3n+ctLzDT/WzOPzlBpfU2Tn8EmE44QH+JKLDMJadvW9t1IbRH/z42x+9DNFL4BpNRZv44xSA2js/OPc6u9FbG7XDGO2mAjUqHuz0hjf9rLoEsBe+5jd8a6N2oOm6zGK0DIdoEcDWRm1Px3WYlVCl4P5NvzLuBNqLFg/AArAXLXsC3Ao2m0srJfUe7PS0JNIsACwXK6WzV7DTSySRZgHEy4fL/nuTvMHXwQK4Oa/CKwzP32hdu3VxwwK4notxeN580dGEMQEWwJc4HFuiZTJpEEAUh2GJlsm4IIBFiZY1cRiJLQI4n2iRa3EYBhH9D18eNW58bi76AAAAAElFTkSuQmCC
-      mediatype: image/png
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAAAFiAAABYgFfJ9BTAAAHL0lEQVR4nO2du24bRxSGz5LL+01kaMuX2HShnmlSi2VUBM4bKG/gdGFnl+rsBwggvUHUsTT9AIGdnoWCIIWNIJZNWKLM5Uww1K4sC6JEQrP7z8yeDyDYCHuG3F/nNmeWnpSSTMXvD3tE9Ey9gp3e0NiFWkzGgqVvEtFLvz/c8/vDNQPW4xQ2CCBim4gO/P7wFzOW4wY2CUDRIKLnfn/4xu8PvzNgPdZjmwAiukT02u8Pn5mxHHuxVQART9kb3AzbBUDsDW6GFgEMRuNHwM8QobzBkCuF1dDlAfYGo/GeAULYDCuFHngd1qAzBKgy7c1gNEa74kbYN+CQsAS6cwD15T8djMZKCOj/QhUS9jkkXE1cSaBKzF4ORuMXg9EYeQMeE9GQq4TFxF0FPAnDAtIbdEMRcF5wCUmUgZ3QGyBjcpQX/Axcg5Ek2QeIcgNkpbDLyeHXJN0I6oYh4aeE7Z5HJYd7QPtGgegEKnf8OzgkbLMITkG2glVI2AdWCXMRpL1MRO8FzMs0pAjCCiG1IjBhM0jlBQeD0RhVq3fTLAJTdgMboSeAigBkG4pJ28FKBK8HozGqVu+mMTE0cR5gFyiC1FUHpg6EsAgSwuSJoN3t7+//ALK9nZbpY6NHwh7drf8qG+VjkPnnadg7MFoA+bxPYn2tBBTBrutbyVYMhc5FUMihzDs9T2DNVLB42D4GiUCVp862jO0ZC/e8knjYnlAGsmTVKHKyMrDrXIDnFWedW/+BRPDYxVkC+w6G5LItca/5L8i6miVAzjJox8qTQbJcaIt2/QPIvMoHTDgIowVrj4bJVrUhq8UjgGmVFO4D7MaC1WcDxd2mR7kswrTaOHqBMKwbuw+Hel5p9m0blRQ+cWHU3P7TwSopvFVHJYXWnzxy4Xg4yUa5DcwHrO4POCEAOs0HMsD+gLWloTMCUE0i8eAbVCiwtlXsjgBUKCjk2rJZnQBMWxsKnBKAQrRrAlQaWhkKnBMAeV5Z3GtxKFgS9wQQhQLMEIkKBVY1iJwUgELcbnigqmDbpgaRswKYVwV31t6CrFvjBdwVgAoF1eK6LBcQpru2TBU7LQCFuLOGSgif2ZAQOi8A8rOcEF6B+wLAJ4RGTxSnQgDzhLBVRU0QGe0F0iEAlRA2KzlQh3DT5LIwNQKYdwhvNbgsvEB6BBCWhcARMiPPGaZKAAqgFzDyTEHqBAD0Ah0TvUDqBEDsBb4ilQJgL/CFVAqA2AuckVoBsBc4JbUCUIhGBdUdNMYLpFoAslnJg/YIOqbMD6ZaAOpomawVUc8fMmJeIN0CmE8R1z+DTBuxR5B6AVA2o46Zo6zDk0EWwOmzBv4Gmd5GP2yCBaAEUMw/AJWEhPYCLIAQYEkITQZZACFyrSxAphvIxhALICKTaaYxGWQBnEM2yqhkcBM1PMoCOIesFB+AOoOEygVYABcAdgYhrWEWwAVEq4YSACQZZAFcJJdtAXsCiXsBFsAlyFrpPcj046Q7gyyASxBrlRnQfKJegAVwGX62nZbWMAtgAcAw0E2yJ8ACWIColxFPHo1IzAuwABaR9+8Dm0KJ5QEsgCsANoU6SYUBFsAVyGoR9XgZSioMsACuQP00DdB8ImGABXAVamoY94OViYQBFsA1yHoJdYRMEfvUMAvgGmSlGADNx54HsACuA1sOduPeG2ABLIEs55HmYw0DLIAlkNXiP0DzsVYDLIAlkKU8Mg9gDwAn53eAS2jEeYaQBbAkoKeOR7AA0MhKAdkPiC0PYAEsSymPOkZOYTkYy6PnWQBLon6HCLyEWMIAC2BZPK8EHBMjFoABADeGiAVgALJc+Au4iljyABbAKhRz6O9LuxdgAayAzPtV8BK0zwewAFYhk2mCV8AeAA24I7ip+4IsgFXJZVGTwnN0j4mxAFZEFnLvwEtgAUBxrBJgAayIzGZQTxOLYA8Axc/eAa+gq/Nivs6LOUMwe0tCBt7RSUBSFr1PJ+vqo3lHJ+oNWgZQmAgGO703Wq6l4yLWoW6wlBPv+LMf3ugOCUneZEok5h5+3fCPpMIAC2AhQrynmfjofQ4yNJ0J72R6m6azkjcNiKbzh3+YfoOvQ9uouJ0CkPKYgtk7byYyNJkKL5jVaTJt0kyQdzJVf9EMX66irRIwWQCv3n+ctLzDT/WzOPzlBpfU2Tn8EmE44QH+JKLDMJadvW9t1IbRH/z42x+9DNFL4BpNRZv44xSA2js/OPc6u9FbG7XDGO2mAjUqHuz0hjf9rLoEsBe+5jd8a6N2oOm6zGK0DIdoEcDWRm1Px3WYlVCl4P5NvzLuBNqLFg/AArAXLXsC3Ao2m0srJfUe7PS0JNIsACwXK6WzV7DTSySRZgHEy4fL/nuTvMHXwQK4Oa/CKwzP32hdu3VxwwK4notxeN580dGEMQEWwJc4HFuiZTJpEEAUh2GJlsm4IIBFiZY1cRiJLQI4n2iRa3EYBhH9D18eNW58bi76AAAAAElFTkSuQmCC
+    mediatype: image/png
   install:
     spec:
       clusterPermissions:
-        - rules:
-            - apiGroups:
-                - authentication.k8s.io
-              resources:
-                - tokenreviews
-              verbs:
-                - create
-            - apiGroups:
-                - authorization.k8s.io
-              resources:
-                - subjectaccessreviews
-              verbs:
-                - create
-            - apiGroups:
-                - ""
-              resources:
-                - '*'
-              verbs:
-                - '*'
-            - apiGroups:
-                - admissionregistration.k8s.io
-              resources:
-                - mutatingwebhookconfigurations
-                - validatingwebhookconfigurations
-              verbs:
-                - '*'
-            - apiGroups:
-                - apiextensions.k8s.io
-              resources:
-                - customresourcedefinitions
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - apps
-              resources:
-                - daemonsets
-                - deployments
-              verbs:
-                - '*'
-            - apiGroups:
-                - autoscaling
-              resources:
-                - horizontalpodautoscalers
-              verbs:
-                - '*'
-            - apiGroups:
-                - k8s.cni.cncf.io
-              resources:
-                - network-attachment-definitions
-              verbs:
-                - '*'
-            - apiGroups:
-                - networking.istio.io
-              resources:
-                - envoyfilters
-              verbs:
-                - '*'
-            - apiGroups:
-                - networking.k8s.io
-              resources:
-                - networkpolicies
-              verbs:
-                - '*'
-            - apiGroups:
-                - operator.istio.io
-              resources:
-                - istiorevisions
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - operator.istio.io
-              resources:
-                - istiorevisions/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - operator.istio.io
-              resources:
-                - istiorevisions/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - operator.istio.io
-              resources:
-                - istiocnis
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - operator.istio.io
-              resources:
-                - istiocnis/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - operator.istio.io
-              resources:
-                - istiocnis/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - operator.istio.io
-              resources:
-                - istios
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - operator.istio.io
-              resources:
-                - istios/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - operator.istio.io
-              resources:
-                - istios/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - policy
-              resources:
-                - poddisruptionbudgets
-              verbs:
-                - '*'
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - clusterrolebindings
-                - clusterroles
-                - rolebindings
-                - roles
-              verbs:
-                - '*'
-            - apiGroups:
-                - security.openshift.io
-              resourceNames:
-                - privileged
-              resources:
-                - securitycontextconstraints
-              verbs:
-                - use
-          serviceAccountName: sail-operator
+      - rules:
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - '*'
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - networking.istio.io
+          resources:
+          - envoyfilters
+          verbs:
+          - '*'
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - '*'
+        - apiGroups:
+          - operator.istio.io
+          resources:
+          - istiorevisions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operator.istio.io
+          resources:
+          - istiorevisions/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - operator.istio.io
+          resources:
+          - istiorevisions/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - operator.istio.io
+          resources:
+          - istiocnis
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operator.istio.io
+          resources:
+          - istiocnis/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - operator.istio.io
+          resources:
+          - istiocnis/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - operator.istio.io
+          resources:
+          - istios
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operator.istio.io
+          resources:
+          - istios/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - operator.istio.io
+          resources:
+          - istios/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: sail-operator
       deployments:
-        - label:
-            app.kubernetes.io/component: manager
-            app.kubernetes.io/created-by: sailoperator
-            app.kubernetes.io/instance: sail-operator
-            app.kubernetes.io/managed-by: helm
-            app.kubernetes.io/name: deployment
-            app.kubernetes.io/part-of: sailoperator
-            control-plane: sail-operator
-          name: sail-operator
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
+      - label:
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: sailoperator
+          app.kubernetes.io/instance: sail-operator
+          app.kubernetes.io/managed-by: helm
+          app.kubernetes.io/name: deployment
+          app.kubernetes.io/part-of: sailoperator
+          control-plane: sail-operator
+        name: sail-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/created-by: sailoperator
+              app.kubernetes.io/part-of: sailoperator
+              control-plane: sail-operator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+                olm.relatedImage.latest.cni: gcr.io/istio-testing/install-cni:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+                olm.relatedImage.latest.pilot: gcr.io/istio-testing/pilot:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+                olm.relatedImage.latest.proxy: gcr.io/istio-testing/proxyv2:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+                olm.relatedImage.latest.ztunnel: gcr.io/istio-testing/ztunnel:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+                olm.relatedImage.v1_21_0.cni: docker.io/istio/install-cni:1.21.0
+                olm.relatedImage.v1_21_0.pilot: docker.io/istio/pilot:1.21.0
+                olm.relatedImage.v1_21_0.proxy: docker.io/istio/proxyv2:1.21.0
+                olm.relatedImage.v1_21_0.ztunnel: docker.io/istio/ztunnel:1.21.0
+                olm.relatedImage.v1_21_2.cni: docker.io/istio/install-cni:1.21.2
+                olm.relatedImage.v1_21_2.pilot: docker.io/istio/pilot:1.21.2
+                olm.relatedImage.v1_21_2.proxy: docker.io/istio/proxyv2:1.21.2
+                olm.relatedImage.v1_21_2.ztunnel: docker.io/istio/ztunnel:1.21.2
+                olm.relatedImage.v1_21_3.cni: docker.io/istio/install-cni:1.21.3
+                olm.relatedImage.v1_21_3.pilot: docker.io/istio/pilot:1.21.3
+                olm.relatedImage.v1_21_3.proxy: docker.io/istio/proxyv2:1.21.3
+                olm.relatedImage.v1_21_3.ztunnel: docker.io/istio/ztunnel:1.21.3
+                olm.relatedImage.v1_21_4.cni: docker.io/istio/install-cni:1.21.4
+                olm.relatedImage.v1_21_4.pilot: docker.io/istio/pilot:1.21.4
+                olm.relatedImage.v1_21_4.proxy: docker.io/istio/proxyv2:1.21.4
+                olm.relatedImage.v1_21_4.ztunnel: docker.io/istio/ztunnel:1.21.4
+                olm.relatedImage.v1_21_5.cni: docker.io/istio/install-cni:1.21.5
+                olm.relatedImage.v1_21_5.pilot: docker.io/istio/pilot:1.21.5
+                olm.relatedImage.v1_21_5.proxy: docker.io/istio/proxyv2:1.21.5
+                olm.relatedImage.v1_21_5.ztunnel: docker.io/istio/ztunnel:1.21.5
+                olm.relatedImage.v1_22_0.cni: docker.io/istio/install-cni:1.22.0
+                olm.relatedImage.v1_22_0.pilot: docker.io/istio/pilot:1.22.0
+                olm.relatedImage.v1_22_0.proxy: docker.io/istio/proxyv2:1.22.0
+                olm.relatedImage.v1_22_0.ztunnel: docker.io/istio/ztunnel:1.22.0
+                olm.relatedImage.v1_22_1.cni: docker.io/istio/install-cni:1.22.1
+                olm.relatedImage.v1_22_1.pilot: docker.io/istio/pilot:1.22.1
+                olm.relatedImage.v1_22_1.proxy: docker.io/istio/proxyv2:1.22.1
+                olm.relatedImage.v1_22_1.ztunnel: docker.io/istio/ztunnel:1.22.1
+                olm.relatedImage.v1_22_2.cni: docker.io/istio/install-cni:1.22.2
+                olm.relatedImage.v1_22_2.pilot: docker.io/istio/pilot:1.22.2
+                olm.relatedImage.v1_22_2.proxy: docker.io/istio/proxyv2:1.22.2
+                olm.relatedImage.v1_22_2.ztunnel: docker.io/istio/ztunnel:1.22.2
+                olm.relatedImage.v1_22_3.cni: docker.io/istio/install-cni:1.22.3
+                olm.relatedImage.v1_22_3.pilot: docker.io/istio/pilot:1.22.3
+                olm.relatedImage.v1_22_3.proxy: docker.io/istio/proxyv2:1.22.3
+                olm.relatedImage.v1_22_3.ztunnel: docker.io/istio/ztunnel:1.22.3
+              labels:
                 app.kubernetes.io/created-by: sailoperator
                 app.kubernetes.io/part-of: sailoperator
                 control-plane: sail-operator
-            strategy: {}
-            template:
-              metadata:
-                annotations:
-                  kubectl.kubernetes.io/default-container: manager
-                  olm.relatedImage.v1_22_3.ztunnel: docker.io/istio/ztunnel:1.22.3
-                  olm.relatedImage.v1_22_3.pilot: docker.io/istio/pilot:1.22.3
-                  olm.relatedImage.v1_22_3.proxy: docker.io/istio/proxyv2:1.22.3
-                  olm.relatedImage.v1_22_3.cni: docker.io/istio/install-cni:1.22.3
-                  olm.relatedImage.v1_22_2.ztunnel: docker.io/istio/ztunnel:1.22.2
-                  olm.relatedImage.v1_22_2.pilot: docker.io/istio/pilot:1.22.2
-                  olm.relatedImage.v1_22_2.proxy: docker.io/istio/proxyv2:1.22.2
-                  olm.relatedImage.v1_22_2.cni: docker.io/istio/install-cni:1.22.2
-                  olm.relatedImage.v1_22_1.ztunnel: docker.io/istio/ztunnel:1.22.1
-                  olm.relatedImage.v1_22_1.pilot: docker.io/istio/pilot:1.22.1
-                  olm.relatedImage.v1_22_1.proxy: docker.io/istio/proxyv2:1.22.1
-                  olm.relatedImage.v1_22_1.cni: docker.io/istio/install-cni:1.22.1
-                  olm.relatedImage.v1_22_0.ztunnel: docker.io/istio/ztunnel:1.22.0
-                  olm.relatedImage.v1_22_0.pilot: docker.io/istio/pilot:1.22.0
-                  olm.relatedImage.v1_22_0.proxy: docker.io/istio/proxyv2:1.22.0
-                  olm.relatedImage.v1_22_0.cni: docker.io/istio/install-cni:1.22.0
-                  olm.relatedImage.v1_21_5.ztunnel: docker.io/istio/ztunnel:1.21.5
-                  olm.relatedImage.v1_21_5.pilot: docker.io/istio/pilot:1.21.5
-                  olm.relatedImage.v1_21_5.proxy: docker.io/istio/proxyv2:1.21.5
-                  olm.relatedImage.v1_21_5.cni: docker.io/istio/install-cni:1.21.5
-                  olm.relatedImage.v1_21_4.ztunnel: docker.io/istio/ztunnel:1.21.4
-                  olm.relatedImage.v1_21_4.pilot: docker.io/istio/pilot:1.21.4
-                  olm.relatedImage.v1_21_4.proxy: docker.io/istio/proxyv2:1.21.4
-                  olm.relatedImage.v1_21_4.cni: docker.io/istio/install-cni:1.21.4
-                  olm.relatedImage.v1_21_3.ztunnel: docker.io/istio/ztunnel:1.21.3
-                  olm.relatedImage.v1_21_3.pilot: docker.io/istio/pilot:1.21.3
-                  olm.relatedImage.v1_21_3.proxy: docker.io/istio/proxyv2:1.21.3
-                  olm.relatedImage.v1_21_3.cni: docker.io/istio/install-cni:1.21.3
-                  olm.relatedImage.v1_21_2.ztunnel: docker.io/istio/ztunnel:1.21.2
-                  olm.relatedImage.v1_21_2.pilot: docker.io/istio/pilot:1.21.2
-                  olm.relatedImage.v1_21_2.proxy: docker.io/istio/proxyv2:1.21.2
-                  olm.relatedImage.v1_21_2.cni: docker.io/istio/install-cni:1.21.2
-                  olm.relatedImage.v1_21_0.ztunnel: docker.io/istio/ztunnel:1.21.0
-                  olm.relatedImage.v1_21_0.pilot: docker.io/istio/pilot:1.21.0
-                  olm.relatedImage.v1_21_0.proxy: docker.io/istio/proxyv2:1.21.0
-                  olm.relatedImage.v1_21_0.cni: docker.io/istio/install-cni:1.21.0
-                  olm.relatedImage.latest.ztunnel: gcr.io/istio-testing/ztunnel:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
-                  olm.relatedImage.latest.pilot: gcr.io/istio-testing/pilot:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
-                  olm.relatedImage.latest.proxy: gcr.io/istio-testing/proxyv2:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
-                  olm.relatedImage.latest.cni: gcr.io/istio-testing/install-cni:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
-                labels:
-                  app.kubernetes.io/created-by: sailoperator
-                  app.kubernetes.io/part-of: sailoperator
-                  control-plane: sail-operator
-              spec:
-                affinity:
-                  nodeAffinity:
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      nodeSelectorTerms:
-                        - matchExpressions:
-                            - key: kubernetes.io/arch
-                              operator: In
-                              values:
-                                - amd64
-                                - arm64
-                                - ppc64le
-                                - s390x
-                            - key: kubernetes.io/os
-                              operator: In
-                              values:
-                                - linux
-                containers:
-                  - args:
-                      - --secure-listen-address=0.0.0.0:8443
-                      - --upstream=http://127.0.0.1:8080/
-                      - --logtostderr=true
-                      - --v=0
-                    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
-                    name: kube-rbac-proxy
-                    ports:
-                      - containerPort: 8443
-                        name: https
-                        protocol: TCP
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 128Mi
-                      requests:
-                        cpu: 5m
-                        memory: 64Mi
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                        drop:
-                          - ALL
-                  - args:
-                      - --health-probe-bind-address=:8081
-                      - --metrics-bind-address=127.0.0.1:8080
-                      - --default-profile=openshift
-                    command:
-                      - /manager
-                    image: quay.io/maistra-dev/sail-operator:0.1-latest
-                    imagePullPolicy: Always
-                    livenessProbe:
-                      httpGet:
-                        path: /healthz
-                        port: 8081
-                      initialDelaySeconds: 15
-                      periodSeconds: 20
-                    name: manager
-                    readinessProbe:
-                      httpGet:
-                        path: /readyz
-                        port: 8081
-                      initialDelaySeconds: 5
-                      periodSeconds: 10
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 512Mi
-                      requests:
-                        cpu: 10m
-                        memory: 64Mi
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                        drop:
-                          - ALL
-                    volumeMounts:
-                      - mountPath: /etc/sail-operator
-                        name: operator-config
-                        readOnly: true
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - arm64
+                        - ppc64le
+                        - s390x
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                        - linux
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
                 securityContext:
-                  runAsNonRoot: true
-                serviceAccountName: sail-operator
-                terminationGracePeriodSeconds: 10
-                volumes:
-                  - downwardAPI:
-                      defaultMode: 420
-                      items:
-                        - fieldRef:
-                            fieldPath: metadata.annotations
-                          path: config.properties
-                    name: operator-config
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --default-profile=openshift
+                command:
+                - /manager
+                image: quay.io/maistra-dev/sail-operator:0.1-latest
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                volumeMounts:
+                - mountPath: /etc/sail-operator
+                  name: operator-config
+                  readOnly: true
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: sail-operator
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - downwardAPI:
+                  defaultMode: 420
+                  items:
+                  - fieldRef:
+                      fieldPath: metadata.annotations
+                    path: config.properties
+                name: operator-config
       permissions:
-        - rules:
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
-            - apiGroups:
-                - coordination.k8s.io
-              resources:
-                - leases
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
-            - apiGroups:
-                - ""
-              resources:
-                - events
-              verbs:
-                - create
-                - patch
-          serviceAccountName: sail-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: sail-operator
     strategy: deployment
   installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
   keywords:
-    - istio
-    - servicemesh
-    - envoy
+  - istio
+  - servicemesh
+  - envoy
   links:
-    - name: Istio Project
-      url: https://istio.io
+  - name: Istio Project
+    url: https://istio.io
   maintainers:
-    - email: istio-feedback@redhat.com
-      name: OpenShift Service Mesh Team
+  - email: istio-feedback@redhat.com
+    name: OpenShift Service Mesh Team
   maturity: alpha
   provider:
     name: Red Hat, Inc.
-  version: 0.1.0
   relatedImages:
-    - name: latest.cni
-      image: gcr.io/istio-testing/install-cni:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
-    - name: latest.pilot
-      image: gcr.io/istio-testing/pilot:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
-    - name: latest.proxy
-      image: gcr.io/istio-testing/proxyv2:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
-    - name: latest.ztunnel
-      image: gcr.io/istio-testing/ztunnel:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
-    - name: v1_21_0.cni
-      image: docker.io/istio/install-cni:1.21.0
-    - name: v1_21_0.pilot
-      image: docker.io/istio/pilot:1.21.0
-    - name: v1_21_0.proxy
-      image: docker.io/istio/proxyv2:1.21.0
-    - name: v1_21_0.ztunnel
-      image: docker.io/istio/ztunnel:1.21.0
-    - name: v1_21_2.cni
-      image: docker.io/istio/install-cni:1.21.2
-    - name: v1_21_2.pilot
-      image: docker.io/istio/pilot:1.21.2
-    - name: v1_21_2.proxy
-      image: docker.io/istio/proxyv2:1.21.2
-    - name: v1_21_2.ztunnel
-      image: docker.io/istio/ztunnel:1.21.2
-    - name: v1_21_3.cni
-      image: docker.io/istio/install-cni:1.21.3
-    - name: v1_21_3.pilot
-      image: docker.io/istio/pilot:1.21.3
-    - name: v1_21_3.proxy
-      image: docker.io/istio/proxyv2:1.21.3
-    - name: v1_21_3.ztunnel
-      image: docker.io/istio/ztunnel:1.21.3
-    - name: v1_21_4.cni
-      image: docker.io/istio/install-cni:1.21.4
-    - name: v1_21_4.pilot
-      image: docker.io/istio/pilot:1.21.4
-    - name: v1_21_4.proxy
-      image: docker.io/istio/proxyv2:1.21.4
-    - name: v1_21_4.ztunnel
-      image: docker.io/istio/ztunnel:1.21.4
-    - name: v1_21_5.cni
-      image: docker.io/istio/install-cni:1.21.5
-    - name: v1_21_5.pilot
-      image: docker.io/istio/pilot:1.21.5
-    - name: v1_21_5.proxy
-      image: docker.io/istio/proxyv2:1.21.5
-    - name: v1_21_5.ztunnel
-      image: docker.io/istio/ztunnel:1.21.5
-    - name: v1_22_0.cni
-      image: docker.io/istio/install-cni:1.22.0
-    - name: v1_22_0.pilot
-      image: docker.io/istio/pilot:1.22.0
-    - name: v1_22_0.proxy
-      image: docker.io/istio/proxyv2:1.22.0
-    - name: v1_22_0.ztunnel
-      image: docker.io/istio/ztunnel:1.22.0
-    - name: v1_22_1.cni
-      image: docker.io/istio/install-cni:1.22.1
-    - name: v1_22_1.pilot
-      image: docker.io/istio/pilot:1.22.1
-    - name: v1_22_1.proxy
-      image: docker.io/istio/proxyv2:1.22.1
-    - name: v1_22_1.ztunnel
-      image: docker.io/istio/ztunnel:1.22.1
-    - name: v1_22_2.cni
-      image: docker.io/istio/install-cni:1.22.2
-    - name: v1_22_2.pilot
-      image: docker.io/istio/pilot:1.22.2
-    - name: v1_22_2.proxy
-      image: docker.io/istio/proxyv2:1.22.2
-    - name: v1_22_2.ztunnel
-      image: docker.io/istio/ztunnel:1.22.2
-    - name: v1_22_3.cni
-      image: docker.io/istio/install-cni:1.22.3
-    - name: v1_22_3.pilot
-      image: docker.io/istio/pilot:1.22.3
-    - name: v1_22_3.proxy
-      image: docker.io/istio/proxyv2:1.22.3
-    - name: v1_22_3.ztunnel
-      image: docker.io/istio/ztunnel:1.22.3
+  - image: gcr.io/istio-testing/install-cni:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+    name: latest.cni
+  - image: gcr.io/istio-testing/pilot:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+    name: latest.pilot
+  - image: gcr.io/istio-testing/proxyv2:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+    name: latest.proxy
+  - image: gcr.io/istio-testing/ztunnel:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+    name: latest.ztunnel
+  - image: docker.io/istio/install-cni:1.21.0
+    name: v1_21_0.cni
+  - image: docker.io/istio/pilot:1.21.0
+    name: v1_21_0.pilot
+  - image: docker.io/istio/proxyv2:1.21.0
+    name: v1_21_0.proxy
+  - image: docker.io/istio/ztunnel:1.21.0
+    name: v1_21_0.ztunnel
+  - image: docker.io/istio/install-cni:1.21.2
+    name: v1_21_2.cni
+  - image: docker.io/istio/pilot:1.21.2
+    name: v1_21_2.pilot
+  - image: docker.io/istio/proxyv2:1.21.2
+    name: v1_21_2.proxy
+  - image: docker.io/istio/ztunnel:1.21.2
+    name: v1_21_2.ztunnel
+  - image: docker.io/istio/install-cni:1.21.3
+    name: v1_21_3.cni
+  - image: docker.io/istio/pilot:1.21.3
+    name: v1_21_3.pilot
+  - image: docker.io/istio/proxyv2:1.21.3
+    name: v1_21_3.proxy
+  - image: docker.io/istio/ztunnel:1.21.3
+    name: v1_21_3.ztunnel
+  - image: docker.io/istio/install-cni:1.21.4
+    name: v1_21_4.cni
+  - image: docker.io/istio/pilot:1.21.4
+    name: v1_21_4.pilot
+  - image: docker.io/istio/proxyv2:1.21.4
+    name: v1_21_4.proxy
+  - image: docker.io/istio/ztunnel:1.21.4
+    name: v1_21_4.ztunnel
+  - image: docker.io/istio/install-cni:1.21.5
+    name: v1_21_5.cni
+  - image: docker.io/istio/pilot:1.21.5
+    name: v1_21_5.pilot
+  - image: docker.io/istio/proxyv2:1.21.5
+    name: v1_21_5.proxy
+  - image: docker.io/istio/ztunnel:1.21.5
+    name: v1_21_5.ztunnel
+  - image: docker.io/istio/install-cni:1.22.0
+    name: v1_22_0.cni
+  - image: docker.io/istio/pilot:1.22.0
+    name: v1_22_0.pilot
+  - image: docker.io/istio/proxyv2:1.22.0
+    name: v1_22_0.proxy
+  - image: docker.io/istio/ztunnel:1.22.0
+    name: v1_22_0.ztunnel
+  - image: docker.io/istio/install-cni:1.22.1
+    name: v1_22_1.cni
+  - image: docker.io/istio/pilot:1.22.1
+    name: v1_22_1.pilot
+  - image: docker.io/istio/proxyv2:1.22.1
+    name: v1_22_1.proxy
+  - image: docker.io/istio/ztunnel:1.22.1
+    name: v1_22_1.ztunnel
+  - image: docker.io/istio/install-cni:1.22.2
+    name: v1_22_2.cni
+  - image: docker.io/istio/pilot:1.22.2
+    name: v1_22_2.pilot
+  - image: docker.io/istio/proxyv2:1.22.2
+    name: v1_22_2.proxy
+  - image: docker.io/istio/ztunnel:1.22.2
+    name: v1_22_2.ztunnel
+  - image: docker.io/istio/install-cni:1.22.3
+    name: v1_22_3.cni
+  - image: docker.io/istio/pilot:1.22.3
+    name: v1_22_3.pilot
+  - image: docker.io/istio/proxyv2:1.22.3
+    name: v1_22_3.proxy
+  - image: docker.io/istio/ztunnel:1.22.3
+    name: v1_22_3.ztunnel
+  version: 0.1.0

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -57,260 +57,218 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: WasmPlugin
-      name: wasmplugins.extensions.istio.io
-      version: v1alpha1
-    - kind: DestinationRule
-      name: destinationrules.networking.istio.io
-      version: v1
-    - kind: DestinationRule
-      name: destinationrules.networking.istio.io
-      version: v1alpha3
-    - kind: DestinationRule
-      name: destinationrules.networking.istio.io
-      version: v1beta1
-    - kind: EnvoyFilter
-      name: envoyfilters.networking.istio.io
-      version: v1alpha3
-    - kind: Gateway
-      name: gateways.networking.istio.io
-      version: v1
-    - kind: Gateway
-      name: gateways.networking.istio.io
-      version: v1alpha3
-    - kind: Gateway
-      name: gateways.networking.istio.io
-      version: v1beta1
-    - kind: ProxyConfig
-      name: proxyconfigs.networking.istio.io
-      version: v1beta1
-    - kind: ServiceEntry
-      name: serviceentries.networking.istio.io
-      version: v1
-    - kind: ServiceEntry
-      name: serviceentries.networking.istio.io
-      version: v1alpha3
-    - kind: ServiceEntry
-      name: serviceentries.networking.istio.io
-      version: v1beta1
-    - kind: Sidecar
-      name: sidecars.networking.istio.io
-      version: v1
-    - kind: Sidecar
-      name: sidecars.networking.istio.io
-      version: v1alpha3
-    - kind: Sidecar
-      name: sidecars.networking.istio.io
-      version: v1beta1
-    - kind: VirtualService
-      name: virtualservices.networking.istio.io
-      version: v1
-    - kind: VirtualService
-      name: virtualservices.networking.istio.io
-      version: v1alpha3
-    - kind: VirtualService
-      name: virtualservices.networking.istio.io
-      version: v1beta1
-    - kind: WorkloadEntry
-      name: workloadentries.networking.istio.io
-      version: v1
-    - kind: WorkloadEntry
-      name: workloadentries.networking.istio.io
-      version: v1alpha3
-    - kind: WorkloadEntry
-      name: workloadentries.networking.istio.io
-      version: v1beta1
-    - kind: WorkloadGroup
-      name: workloadgroups.networking.istio.io
-      version: v1
-    - kind: WorkloadGroup
-      name: workloadgroups.networking.istio.io
-      version: v1alpha3
-    - kind: WorkloadGroup
-      name: workloadgroups.networking.istio.io
-      version: v1beta1
-    - kind: AuthorizationPolicy
-      name: authorizationpolicies.security.istio.io
-      version: v1
-    - kind: AuthorizationPolicy
-      name: authorizationpolicies.security.istio.io
-      version: v1beta1
-    - kind: PeerAuthentication
-      name: peerauthentications.security.istio.io
-      version: v1
-    - kind: PeerAuthentication
-      name: peerauthentications.security.istio.io
-      version: v1beta1
-    - kind: RequestAuthentication
-      name: requestauthentications.security.istio.io
-      version: v1
-    - kind: RequestAuthentication
-      name: requestauthentications.security.istio.io
-      version: v1beta1
-    - kind: Telemetry
-      name: telemetries.telemetry.istio.io
-      version: v1
-    - kind: Telemetry
-      name: telemetries.telemetry.istio.io
-      version: v1alpha1
-    - description: IstioCNI represents a deployment of the Istio CNI component.
-      displayName: Istio CNI
-      kind: IstioCNI
-      name: istiocnis.operator.istio.io
-      specDescriptors:
-      - description: 'Defines the version of Istio to install. Must be one of: v1.22.3,
-          v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0,
-          latest.'
-        displayName: Istio Version
-        path: version
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
-        - urn:alm:descriptor:com.tectonic.ui:select:latest
-      - description: Namespace to which the Istio CNI component should be installed.
-        displayName: Namespace
-        path: namespace
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes:Namespace
-      - description: 'The built-in installation configuration profile to use. The
-          ''default'' profile is always applied. On OpenShift, the ''openshift'' profile
-          is also applied on top of ''default''. Must be one of: ambient, default,
-          demo, empty, external, minimal, openshift-ambient, openshift, preview, remote,
-          stable.'
-        displayName: Profile
-        path: profile
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Defines the values to be passed to the Helm charts when installing
-          Istio CNI.
-        displayName: Helm Values
-        path: values
-      version: v1alpha1
-    - description: IstioRevision represents a single revision of an Istio Service
-        Mesh deployment. Users shouldn't create IstioRevision objects directly. Instead,
-        they should create an Istio object and allow the operator to create the underlying
-        IstioRevision object(s).
-      displayName: Istio Revision
-      kind: IstioRevision
-      name: istiorevisions.operator.istio.io
-      specDescriptors:
-      - description: 'Defines the version of Istio to install. Must be one of: v1.22.3,
-          v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0,
-          latest.'
-        displayName: Istio Version
-        path: version
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
-        - urn:alm:descriptor:com.tectonic.ui:select:latest
-      - description: Namespace to which the Istio components should be installed.
-        displayName: Namespace
-        path: namespace
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes:Namespace
-      - description: Defines the values to be passed to the Helm charts when installing
-          Istio.
-        displayName: Helm Values
-        path: values
-      version: v1alpha1
-    - description: Istio represents an Istio Service Mesh deployment consisting of
-        one or more control plane instances (represented by one or more IstioRevision
-        objects). To deploy an Istio Service Mesh, a user creates an Istio object
-        with the desired Istio version and configuration. The operator then creates
-        an IstioRevision object, which in turn creates the underlying Deployment objects
-        for istiod and other control plane components, similar to how a Deployment
-        object in Kubernetes creates ReplicaSets that create the Pods.
-      displayName: Istio
-      kind: Istio
-      name: istios.operator.istio.io
-      specDescriptors:
-      - description: "Type of strategy to use. Can be \"InPlace\" or \"RevisionBased\".
-          When the \"InPlace\" strategy is used, the existing Istio control plane
-          is updated in-place. The workloads therefore don't need to be moved from
-          one control plane instance to another. When the \"RevisionBased\" strategy
-          is used, a new Istio control plane instance is created for every change
-          to the Istio.spec.version field. The old control plane remains in place
-          until all workloads have been moved to the new control plane instance. \n
-          The \"InPlace\" strategy is the default.\tTODO: change default to \"RevisionBased\""
-        displayName: Type
-        path: updateStrategy.type
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:select:InPlace
-        - urn:alm:descriptor:com.tectonic.ui:select:RevisionBased
-      - description: 'Defines the version of Istio to install. Must be one of: v1.22.3,
-          v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0,
-          latest.'
-        displayName: Istio Version
-        path: version
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
-        - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
-        - urn:alm:descriptor:com.tectonic.ui:select:latest
-      - description: Defines how many seconds the operator should wait before removing
-          a non-active revision after all the workloads have stopped using it. You
-          may want to set this value on the order of minutes. The minimum and the
-          default value is 30.
-        displayName: Inactive Revision Deletion Grace Period (seconds)
-        path: updateStrategy.inactiveRevisionDeletionGracePeriodSeconds
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Defines whether the workloads should be moved from one control
-          plane instance to another automatically. If updateWorkloads is true, the
-          operator moves the workloads from the old control plane instance to the
-          new one after the new control plane is ready. If updateWorkloads is false,
-          the user must move the workloads manually by updating the istio.io/rev labels
-          on the namespace and/or the pods. Defaults to false.
-        displayName: Update Workloads Automatically
-        path: updateStrategy.updateWorkloads
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Namespace to which the Istio components should be installed.
-        displayName: Namespace
-        path: namespace
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes:Namespace
-      - description: 'The built-in installation configuration profile to use. The
-          ''default'' profile is always applied. On OpenShift, the ''openshift'' profile
-          is also applied on top of ''default''. Must be one of: ambient, default,
-          demo, empty, external, minimal, openshift-ambient, openshift, preview, remote,
-          stable.'
-        displayName: Profile
-        path: profile
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Defines the update strategy to use when the version in the Istio
-          CR is updated.
-        displayName: Update Strategy
-        path: updateStrategy
-      - description: Defines the values to be passed to the Helm charts when installing
-          Istio.
-        displayName: Helm Values
-        path: values
-      version: v1alpha1
+      - kind: WasmPlugin
+        name: wasmplugins.extensions.istio.io
+        version: v1alpha1
+      - kind: DestinationRule
+        name: destinationrules.networking.istio.io
+        version: v1
+      - kind: DestinationRule
+        name: destinationrules.networking.istio.io
+        version: v1alpha3
+      - kind: DestinationRule
+        name: destinationrules.networking.istio.io
+        version: v1beta1
+      - kind: EnvoyFilter
+        name: envoyfilters.networking.istio.io
+        version: v1alpha3
+      - kind: Gateway
+        name: gateways.networking.istio.io
+        version: v1
+      - kind: Gateway
+        name: gateways.networking.istio.io
+        version: v1alpha3
+      - kind: Gateway
+        name: gateways.networking.istio.io
+        version: v1beta1
+      - kind: ProxyConfig
+        name: proxyconfigs.networking.istio.io
+        version: v1beta1
+      - kind: ServiceEntry
+        name: serviceentries.networking.istio.io
+        version: v1
+      - kind: ServiceEntry
+        name: serviceentries.networking.istio.io
+        version: v1alpha3
+      - kind: ServiceEntry
+        name: serviceentries.networking.istio.io
+        version: v1beta1
+      - kind: Sidecar
+        name: sidecars.networking.istio.io
+        version: v1
+      - kind: Sidecar
+        name: sidecars.networking.istio.io
+        version: v1alpha3
+      - kind: Sidecar
+        name: sidecars.networking.istio.io
+        version: v1beta1
+      - kind: VirtualService
+        name: virtualservices.networking.istio.io
+        version: v1
+      - kind: VirtualService
+        name: virtualservices.networking.istio.io
+        version: v1alpha3
+      - kind: VirtualService
+        name: virtualservices.networking.istio.io
+        version: v1beta1
+      - kind: WorkloadEntry
+        name: workloadentries.networking.istio.io
+        version: v1
+      - kind: WorkloadEntry
+        name: workloadentries.networking.istio.io
+        version: v1alpha3
+      - kind: WorkloadEntry
+        name: workloadentries.networking.istio.io
+        version: v1beta1
+      - kind: WorkloadGroup
+        name: workloadgroups.networking.istio.io
+        version: v1
+      - kind: WorkloadGroup
+        name: workloadgroups.networking.istio.io
+        version: v1alpha3
+      - kind: WorkloadGroup
+        name: workloadgroups.networking.istio.io
+        version: v1beta1
+      - kind: AuthorizationPolicy
+        name: authorizationpolicies.security.istio.io
+        version: v1
+      - kind: AuthorizationPolicy
+        name: authorizationpolicies.security.istio.io
+        version: v1beta1
+      - kind: PeerAuthentication
+        name: peerauthentications.security.istio.io
+        version: v1
+      - kind: PeerAuthentication
+        name: peerauthentications.security.istio.io
+        version: v1beta1
+      - kind: RequestAuthentication
+        name: requestauthentications.security.istio.io
+        version: v1
+      - kind: RequestAuthentication
+        name: requestauthentications.security.istio.io
+        version: v1beta1
+      - kind: Telemetry
+        name: telemetries.telemetry.istio.io
+        version: v1
+      - kind: Telemetry
+        name: telemetries.telemetry.istio.io
+        version: v1alpha1
+      - description: IstioCNI represents a deployment of the Istio CNI component.
+        displayName: Istio CNI
+        kind: IstioCNI
+        name: istiocnis.operator.istio.io
+        specDescriptors:
+          - description: 'Defines the version of Istio to install. Must be one of: v1.22.3, v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0, latest.'
+            displayName: Istio Version
+            path: version
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
+              - urn:alm:descriptor:com.tectonic.ui:select:latest
+          - description: Namespace to which the Istio CNI component should be installed.
+            displayName: Namespace
+            path: namespace
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Namespace
+          - description: 'The built-in installation configuration profile to use. The ''default'' profile is always applied. On OpenShift, the ''openshift'' profile is also applied on top of ''default''. Must be one of: ambient, default, demo, empty, external, minimal, openshift-ambient, openshift, preview, remote, stable.'
+            displayName: Profile
+            path: profile
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Defines the values to be passed to the Helm charts when installing Istio CNI.
+            displayName: Helm Values
+            path: values
+        version: v1alpha1
+      - description: IstioRevision represents a single revision of an Istio Service Mesh deployment. Users shouldn't create IstioRevision objects directly. Instead, they should create an Istio object and allow the operator to create the underlying IstioRevision object(s).
+        displayName: Istio Revision
+        kind: IstioRevision
+        name: istiorevisions.operator.istio.io
+        specDescriptors:
+          - description: 'Defines the version of Istio to install. Must be one of: v1.22.3, v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0, latest.'
+            displayName: Istio Version
+            path: version
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
+              - urn:alm:descriptor:com.tectonic.ui:select:latest
+          - description: Namespace to which the Istio components should be installed.
+            displayName: Namespace
+            path: namespace
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Namespace
+          - description: Defines the values to be passed to the Helm charts when installing Istio.
+            displayName: Helm Values
+            path: values
+        version: v1alpha1
+      - description: Istio represents an Istio Service Mesh deployment consisting of one or more control plane instances (represented by one or more IstioRevision objects). To deploy an Istio Service Mesh, a user creates an Istio object with the desired Istio version and configuration. The operator then creates an IstioRevision object, which in turn creates the underlying Deployment objects for istiod and other control plane components, similar to how a Deployment object in Kubernetes creates ReplicaSets that create the Pods.
+        displayName: Istio
+        kind: Istio
+        name: istios.operator.istio.io
+        specDescriptors:
+          - description: "Type of strategy to use. Can be \"InPlace\" or \"RevisionBased\". When the \"InPlace\" strategy is used, the existing Istio control plane is updated in-place. The workloads therefore don't need to be moved from one control plane instance to another. When the \"RevisionBased\" strategy is used, a new Istio control plane instance is created for every change to the Istio.spec.version field. The old control plane remains in place until all workloads have been moved to the new control plane instance. \n The \"InPlace\" strategy is the default.\tTODO: change default to \"RevisionBased\""
+            displayName: Type
+            path: updateStrategy.type
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:select:InPlace
+              - urn:alm:descriptor:com.tectonic.ui:select:RevisionBased
+          - description: 'Defines the version of Istio to install. Must be one of: v1.22.3, v1.22.2, v1.22.1, v1.22.0, v1.21.5, v1.21.4, v1.21.3, v1.21.2, v1.21.0, latest.'
+            displayName: Istio Version
+            path: version
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.3
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.2
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.1
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.22.0
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.5
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.4
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.3
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.2
+              - urn:alm:descriptor:com.tectonic.ui:select:v1.21.0
+              - urn:alm:descriptor:com.tectonic.ui:select:latest
+          - description: Defines how many seconds the operator should wait before removing a non-active revision after all the workloads have stopped using it. You may want to set this value on the order of minutes. The minimum and the default value is 30.
+            displayName: Inactive Revision Deletion Grace Period (seconds)
+            path: updateStrategy.inactiveRevisionDeletionGracePeriodSeconds
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+          - description: Defines whether the workloads should be moved from one control plane instance to another automatically. If updateWorkloads is true, the operator moves the workloads from the old control plane instance to the new one after the new control plane is ready. If updateWorkloads is false, the user must move the workloads manually by updating the istio.io/rev labels on the namespace and/or the pods. Defaults to false.
+            displayName: Update Workloads Automatically
+            path: updateStrategy.updateWorkloads
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: Namespace to which the Istio components should be installed.
+            displayName: Namespace
+            path: namespace
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Namespace
+          - description: 'The built-in installation configuration profile to use. The ''default'' profile is always applied. On OpenShift, the ''openshift'' profile is also applied on top of ''default''. Must be one of: ambient, default, demo, empty, external, minimal, openshift-ambient, openshift, preview, remote, stable.'
+            displayName: Profile
+            path: profile
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Defines the update strategy to use when the version in the Istio CR is updated.
+            displayName: Update Strategy
+            path: updateStrategy
+          - description: Defines the values to be passed to the Helm charts when installing Istio.
+            displayName: Helm Values
+            path: values
+        version: v1alpha1
   description: |-
     This is an experimental operator for installing Istio service mesh.
 
@@ -330,349 +288,470 @@ spec:
     [See this page](https://github.com/istio-ecosystem/sail-operator/blob/main/bundle/README.md) for instructions on how to use it.
   displayName: Sail Operator
   icon:
-  - base64data: iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAAAFiAAABYgFfJ9BTAAAHL0lEQVR4nO2du24bRxSGz5LL+01kaMuX2HShnmlSi2VUBM4bKG/gdGFnl+rsBwggvUHUsTT9AIGdnoWCIIWNIJZNWKLM5Uww1K4sC6JEQrP7z8yeDyDYCHuG3F/nNmeWnpSSTMXvD3tE9Ey9gp3e0NiFWkzGgqVvEtFLvz/c8/vDNQPW4xQ2CCBim4gO/P7wFzOW4wY2CUDRIKLnfn/4xu8PvzNgPdZjmwAiukT02u8Pn5mxHHuxVQART9kb3AzbBUDsDW6GFgEMRuNHwM8QobzBkCuF1dDlAfYGo/GeAULYDCuFHngd1qAzBKgy7c1gNEa74kbYN+CQsAS6cwD15T8djMZKCOj/QhUS9jkkXE1cSaBKzF4ORuMXg9EYeQMeE9GQq4TFxF0FPAnDAtIbdEMRcF5wCUmUgZ3QGyBjcpQX/Axcg5Ek2QeIcgNkpbDLyeHXJN0I6oYh4aeE7Z5HJYd7QPtGgegEKnf8OzgkbLMITkG2glVI2AdWCXMRpL1MRO8FzMs0pAjCCiG1IjBhM0jlBQeD0RhVq3fTLAJTdgMboSeAigBkG4pJ28FKBK8HozGqVu+mMTE0cR5gFyiC1FUHpg6EsAgSwuSJoN3t7+//ALK9nZbpY6NHwh7drf8qG+VjkPnnadg7MFoA+bxPYn2tBBTBrutbyVYMhc5FUMihzDs9T2DNVLB42D4GiUCVp862jO0ZC/e8knjYnlAGsmTVKHKyMrDrXIDnFWedW/+BRPDYxVkC+w6G5LItca/5L8i6miVAzjJox8qTQbJcaIt2/QPIvMoHTDgIowVrj4bJVrUhq8UjgGmVFO4D7MaC1WcDxd2mR7kswrTaOHqBMKwbuw+Hel5p9m0blRQ+cWHU3P7TwSopvFVHJYXWnzxy4Xg4yUa5DcwHrO4POCEAOs0HMsD+gLWloTMCUE0i8eAbVCiwtlXsjgBUKCjk2rJZnQBMWxsKnBKAQrRrAlQaWhkKnBMAeV5Z3GtxKFgS9wQQhQLMEIkKBVY1iJwUgELcbnigqmDbpgaRswKYVwV31t6CrFvjBdwVgAoF1eK6LBcQpru2TBU7LQCFuLOGSgif2ZAQOi8A8rOcEF6B+wLAJ4RGTxSnQgDzhLBVRU0QGe0F0iEAlRA2KzlQh3DT5LIwNQKYdwhvNbgsvEB6BBCWhcARMiPPGaZKAAqgFzDyTEHqBAD0Ah0TvUDqBEDsBb4ilQJgL/CFVAqA2AuckVoBsBc4JbUCUIhGBdUdNMYLpFoAslnJg/YIOqbMD6ZaAOpomawVUc8fMmJeIN0CmE8R1z+DTBuxR5B6AVA2o46Zo6zDk0EWwOmzBv4Gmd5GP2yCBaAEUMw/AJWEhPYCLIAQYEkITQZZACFyrSxAphvIxhALICKTaaYxGWQBnEM2yqhkcBM1PMoCOIesFB+AOoOEygVYABcAdgYhrWEWwAVEq4YSACQZZAFcJJdtAXsCiXsBFsAlyFrpPcj046Q7gyyASxBrlRnQfKJegAVwGX62nZbWMAtgAcAw0E2yJ8ACWIColxFPHo1IzAuwABaR9+8Dm0KJ5QEsgCsANoU6SYUBFsAVyGoR9XgZSioMsACuQP00DdB8ImGABXAVamoY94OViYQBFsA1yHoJdYRMEfvUMAvgGmSlGADNx54HsACuA1sOduPeG2ABLIEs55HmYw0DLIAlkNXiP0DzsVYDLIAlkKU8Mg9gDwAn53eAS2jEeYaQBbAkoKeOR7AA0MhKAdkPiC0PYAEsSymPOkZOYTkYy6PnWQBLon6HCLyEWMIAC2BZPK8EHBMjFoABADeGiAVgALJc+Au4iljyABbAKhRz6O9LuxdgAayAzPtV8BK0zwewAFYhk2mCV8AeAA24I7ip+4IsgFXJZVGTwnN0j4mxAFZEFnLvwEtgAUBxrBJgAayIzGZQTxOLYA8Axc/eAa+gq/Nivs6LOUMwe0tCBt7RSUBSFr1PJ+vqo3lHJ+oNWgZQmAgGO703Wq6l4yLWoW6wlBPv+LMf3ugOCUneZEok5h5+3fCPpMIAC2AhQrynmfjofQ4yNJ0J72R6m6azkjcNiKbzh3+YfoOvQ9uouJ0CkPKYgtk7byYyNJkKL5jVaTJt0kyQdzJVf9EMX66irRIwWQCv3n+ctLzDT/WzOPzlBpfU2Tn8EmE44QH+JKLDMJadvW9t1IbRH/z42x+9DNFL4BpNRZv44xSA2js/OPc6u9FbG7XDGO2mAjUqHuz0hjf9rLoEsBe+5jd8a6N2oOm6zGK0DIdoEcDWRm1Px3WYlVCl4P5NvzLuBNqLFg/AArAXLXsC3Ao2m0srJfUe7PS0JNIsACwXK6WzV7DTSySRZgHEy4fL/nuTvMHXwQK4Oa/CKwzP32hdu3VxwwK4notxeN580dGEMQEWwJc4HFuiZTJpEEAUh2GJlsm4IIBFiZY1cRiJLQI4n2iRa3EYBhH9D18eNW58bi76AAAAAElFTkSuQmCC
-    mediatype: image/png
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAAAFiAAABYgFfJ9BTAAAHL0lEQVR4nO2du24bRxSGz5LL+01kaMuX2HShnmlSi2VUBM4bKG/gdGFnl+rsBwggvUHUsTT9AIGdnoWCIIWNIJZNWKLM5Uww1K4sC6JEQrP7z8yeDyDYCHuG3F/nNmeWnpSSTMXvD3tE9Ey9gp3e0NiFWkzGgqVvEtFLvz/c8/vDNQPW4xQ2CCBim4gO/P7wFzOW4wY2CUDRIKLnfn/4xu8PvzNgPdZjmwAiukT02u8Pn5mxHHuxVQART9kb3AzbBUDsDW6GFgEMRuNHwM8QobzBkCuF1dDlAfYGo/GeAULYDCuFHngd1qAzBKgy7c1gNEa74kbYN+CQsAS6cwD15T8djMZKCOj/QhUS9jkkXE1cSaBKzF4ORuMXg9EYeQMeE9GQq4TFxF0FPAnDAtIbdEMRcF5wCUmUgZ3QGyBjcpQX/Axcg5Ek2QeIcgNkpbDLyeHXJN0I6oYh4aeE7Z5HJYd7QPtGgegEKnf8OzgkbLMITkG2glVI2AdWCXMRpL1MRO8FzMs0pAjCCiG1IjBhM0jlBQeD0RhVq3fTLAJTdgMboSeAigBkG4pJ28FKBK8HozGqVu+mMTE0cR5gFyiC1FUHpg6EsAgSwuSJoN3t7+//ALK9nZbpY6NHwh7drf8qG+VjkPnnadg7MFoA+bxPYn2tBBTBrutbyVYMhc5FUMihzDs9T2DNVLB42D4GiUCVp862jO0ZC/e8knjYnlAGsmTVKHKyMrDrXIDnFWedW/+BRPDYxVkC+w6G5LItca/5L8i6miVAzjJox8qTQbJcaIt2/QPIvMoHTDgIowVrj4bJVrUhq8UjgGmVFO4D7MaC1WcDxd2mR7kswrTaOHqBMKwbuw+Hel5p9m0blRQ+cWHU3P7TwSopvFVHJYXWnzxy4Xg4yUa5DcwHrO4POCEAOs0HMsD+gLWloTMCUE0i8eAbVCiwtlXsjgBUKCjk2rJZnQBMWxsKnBKAQrRrAlQaWhkKnBMAeV5Z3GtxKFgS9wQQhQLMEIkKBVY1iJwUgELcbnigqmDbpgaRswKYVwV31t6CrFvjBdwVgAoF1eK6LBcQpru2TBU7LQCFuLOGSgif2ZAQOi8A8rOcEF6B+wLAJ4RGTxSnQgDzhLBVRU0QGe0F0iEAlRA2KzlQh3DT5LIwNQKYdwhvNbgsvEB6BBCWhcARMiPPGaZKAAqgFzDyTEHqBAD0Ah0TvUDqBEDsBb4ilQJgL/CFVAqA2AuckVoBsBc4JbUCUIhGBdUdNMYLpFoAslnJg/YIOqbMD6ZaAOpomawVUc8fMmJeIN0CmE8R1z+DTBuxR5B6AVA2o46Zo6zDk0EWwOmzBv4Gmd5GP2yCBaAEUMw/AJWEhPYCLIAQYEkITQZZACFyrSxAphvIxhALICKTaaYxGWQBnEM2yqhkcBM1PMoCOIesFB+AOoOEygVYABcAdgYhrWEWwAVEq4YSACQZZAFcJJdtAXsCiXsBFsAlyFrpPcj046Q7gyyASxBrlRnQfKJegAVwGX62nZbWMAtgAcAw0E2yJ8ACWIColxFPHo1IzAuwABaR9+8Dm0KJ5QEsgCsANoU6SYUBFsAVyGoR9XgZSioMsACuQP00DdB8ImGABXAVamoY94OViYQBFsA1yHoJdYRMEfvUMAvgGmSlGADNx54HsACuA1sOduPeG2ABLIEs55HmYw0DLIAlkNXiP0DzsVYDLIAlkKU8Mg9gDwAn53eAS2jEeYaQBbAkoKeOR7AA0MhKAdkPiC0PYAEsSymPOkZOYTkYy6PnWQBLon6HCLyEWMIAC2BZPK8EHBMjFoABADeGiAVgALJc+Au4iljyABbAKhRz6O9LuxdgAayAzPtV8BK0zwewAFYhk2mCV8AeAA24I7ip+4IsgFXJZVGTwnN0j4mxAFZEFnLvwEtgAUBxrBJgAayIzGZQTxOLYA8Axc/eAa+gq/Nivs6LOUMwe0tCBt7RSUBSFr1PJ+vqo3lHJ+oNWgZQmAgGO703Wq6l4yLWoW6wlBPv+LMf3ugOCUneZEok5h5+3fCPpMIAC2AhQrynmfjofQ4yNJ0J72R6m6azkjcNiKbzh3+YfoOvQ9uouJ0CkPKYgtk7byYyNJkKL5jVaTJt0kyQdzJVf9EMX66irRIwWQCv3n+ctLzDT/WzOPzlBpfU2Tn8EmE44QH+JKLDMJadvW9t1IbRH/z42x+9DNFL4BpNRZv44xSA2js/OPc6u9FbG7XDGO2mAjUqHuz0hjf9rLoEsBe+5jd8a6N2oOm6zGK0DIdoEcDWRm1Px3WYlVCl4P5NvzLuBNqLFg/AArAXLXsC3Ao2m0srJfUe7PS0JNIsACwXK6WzV7DTSySRZgHEy4fL/nuTvMHXwQK4Oa/CKwzP32hdu3VxwwK4notxeN580dGEMQEWwJc4HFuiZTJpEEAUh2GJlsm4IIBFiZY1cRiJLQI4n2iRa3EYBhH9D18eNW58bi76AAAAAElFTkSuQmCC
+      mediatype: image/png
   install:
     spec:
       clusterPermissions:
-      - rules:
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
-        - apiGroups:
-          - ""
-          resources:
-          - '*'
-          verbs:
-          - '*'
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - mutatingwebhookconfigurations
-          - validatingwebhookconfigurations
-          verbs:
-          - '*'
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          - deployments
-          verbs:
-          - '*'
-        - apiGroups:
-          - autoscaling
-          resources:
-          - horizontalpodautoscalers
-          verbs:
-          - '*'
-        - apiGroups:
-          - k8s.cni.cncf.io
-          resources:
-          - network-attachment-definitions
-          verbs:
-          - '*'
-        - apiGroups:
-          - networking.istio.io
-          resources:
-          - envoyfilters
-          verbs:
-          - '*'
-        - apiGroups:
-          - networking.k8s.io
-          resources:
-          - networkpolicies
-          verbs:
-          - '*'
-        - apiGroups:
-          - operator.istio.io
-          resources:
-          - istiorevisions
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - operator.istio.io
-          resources:
-          - istiorevisions/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - operator.istio.io
-          resources:
-          - istiorevisions/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - operator.istio.io
-          resources:
-          - istiocnis
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - operator.istio.io
-          resources:
-          - istiocnis/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - operator.istio.io
-          resources:
-          - istiocnis/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - operator.istio.io
-          resources:
-          - istios
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - operator.istio.io
-          resources:
-          - istios/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - operator.istio.io
-          resources:
-          - istios/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - policy
-          resources:
-          - poddisruptionbudgets
-          verbs:
-          - '*'
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterrolebindings
-          - clusterroles
-          - rolebindings
-          - roles
-          verbs:
-          - '*'
-        - apiGroups:
-          - security.openshift.io
-          resourceNames:
-          - privileged
-          resources:
-          - securitycontextconstraints
-          verbs:
-          - use
-        serviceAccountName: sail-operator
+        - rules:
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+            - apiGroups:
+                - ""
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+                - validatingwebhookconfigurations
+              verbs:
+                - '*'
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+                - deployments
+              verbs:
+                - '*'
+            - apiGroups:
+                - autoscaling
+              resources:
+                - horizontalpodautoscalers
+              verbs:
+                - '*'
+            - apiGroups:
+                - k8s.cni.cncf.io
+              resources:
+                - network-attachment-definitions
+              verbs:
+                - '*'
+            - apiGroups:
+                - networking.istio.io
+              resources:
+                - envoyfilters
+              verbs:
+                - '*'
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - '*'
+            - apiGroups:
+                - operator.istio.io
+              resources:
+                - istiorevisions
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.istio.io
+              resources:
+                - istiorevisions/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.istio.io
+              resources:
+                - istiorevisions/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - operator.istio.io
+              resources:
+                - istiocnis
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.istio.io
+              resources:
+                - istiocnis/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.istio.io
+              resources:
+                - istiocnis/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - operator.istio.io
+              resources:
+                - istios
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.istio.io
+              resources:
+                - istios/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.istio.io
+              resources:
+                - istios/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - '*'
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+                - rolebindings
+                - roles
+              verbs:
+                - '*'
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - privileged
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+          serviceAccountName: sail-operator
       deployments:
-      - label:
-          app.kubernetes.io/component: manager
-          app.kubernetes.io/created-by: sailoperator
-          app.kubernetes.io/instance: sail-operator
-          app.kubernetes.io/managed-by: helm
-          app.kubernetes.io/name: deployment
-          app.kubernetes.io/part-of: sailoperator
-          control-plane: sail-operator
-        name: sail-operator
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              app.kubernetes.io/created-by: sailoperator
-              app.kubernetes.io/part-of: sailoperator
-              control-plane: sail-operator
-          strategy: {}
-          template:
-            metadata:
-              annotations:
-                kubectl.kubernetes.io/default-container: manager
-              labels:
+        - label:
+            app.kubernetes.io/component: manager
+            app.kubernetes.io/created-by: sailoperator
+            app.kubernetes.io/instance: sail-operator
+            app.kubernetes.io/managed-by: helm
+            app.kubernetes.io/name: deployment
+            app.kubernetes.io/part-of: sailoperator
+            control-plane: sail-operator
+          name: sail-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 app.kubernetes.io/created-by: sailoperator
                 app.kubernetes.io/part-of: sailoperator
                 control-plane: sail-operator
-            spec:
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: kubernetes.io/arch
-                        operator: In
-                        values:
-                        - amd64
-                        - arm64
-                        - ppc64le
-                        - s390x
-                      - key: kubernetes.io/os
-                        operator: In
-                        values:
-                        - linux
-              containers:
-              - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 5m
-                    memory: 64Mi
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                  olm.relatedImage.v1_22_3.ztunnel: docker.io/istio/ztunnel:1.22.3
+                  olm.relatedImage.v1_22_3.pilot: docker.io/istio/pilot:1.22.3
+                  olm.relatedImage.v1_22_3.proxy: docker.io/istio/proxyv2:1.22.3
+                  olm.relatedImage.v1_22_3.cni: docker.io/istio/install-cni:1.22.3
+                  olm.relatedImage.v1_22_2.ztunnel: docker.io/istio/ztunnel:1.22.2
+                  olm.relatedImage.v1_22_2.pilot: docker.io/istio/pilot:1.22.2
+                  olm.relatedImage.v1_22_2.proxy: docker.io/istio/proxyv2:1.22.2
+                  olm.relatedImage.v1_22_2.cni: docker.io/istio/install-cni:1.22.2
+                  olm.relatedImage.v1_22_1.ztunnel: docker.io/istio/ztunnel:1.22.1
+                  olm.relatedImage.v1_22_1.pilot: docker.io/istio/pilot:1.22.1
+                  olm.relatedImage.v1_22_1.proxy: docker.io/istio/proxyv2:1.22.1
+                  olm.relatedImage.v1_22_1.cni: docker.io/istio/install-cni:1.22.1
+                  olm.relatedImage.v1_22_0.ztunnel: docker.io/istio/ztunnel:1.22.0
+                  olm.relatedImage.v1_22_0.pilot: docker.io/istio/pilot:1.22.0
+                  olm.relatedImage.v1_22_0.proxy: docker.io/istio/proxyv2:1.22.0
+                  olm.relatedImage.v1_22_0.cni: docker.io/istio/install-cni:1.22.0
+                  olm.relatedImage.v1_21_5.ztunnel: docker.io/istio/ztunnel:1.21.5
+                  olm.relatedImage.v1_21_5.pilot: docker.io/istio/pilot:1.21.5
+                  olm.relatedImage.v1_21_5.proxy: docker.io/istio/proxyv2:1.21.5
+                  olm.relatedImage.v1_21_5.cni: docker.io/istio/install-cni:1.21.5
+                  olm.relatedImage.v1_21_4.ztunnel: docker.io/istio/ztunnel:1.21.4
+                  olm.relatedImage.v1_21_4.pilot: docker.io/istio/pilot:1.21.4
+                  olm.relatedImage.v1_21_4.proxy: docker.io/istio/proxyv2:1.21.4
+                  olm.relatedImage.v1_21_4.cni: docker.io/istio/install-cni:1.21.4
+                  olm.relatedImage.v1_21_3.ztunnel: docker.io/istio/ztunnel:1.21.3
+                  olm.relatedImage.v1_21_3.pilot: docker.io/istio/pilot:1.21.3
+                  olm.relatedImage.v1_21_3.proxy: docker.io/istio/proxyv2:1.21.3
+                  olm.relatedImage.v1_21_3.cni: docker.io/istio/install-cni:1.21.3
+                  olm.relatedImage.v1_21_2.ztunnel: docker.io/istio/ztunnel:1.21.2
+                  olm.relatedImage.v1_21_2.pilot: docker.io/istio/pilot:1.21.2
+                  olm.relatedImage.v1_21_2.proxy: docker.io/istio/proxyv2:1.21.2
+                  olm.relatedImage.v1_21_2.cni: docker.io/istio/install-cni:1.21.2
+                  olm.relatedImage.v1_21_0.ztunnel: docker.io/istio/ztunnel:1.21.0
+                  olm.relatedImage.v1_21_0.pilot: docker.io/istio/pilot:1.21.0
+                  olm.relatedImage.v1_21_0.proxy: docker.io/istio/proxyv2:1.21.0
+                  olm.relatedImage.v1_21_0.cni: docker.io/istio/install-cni:1.21.0
+                  olm.relatedImage.latest.ztunnel: gcr.io/istio-testing/ztunnel:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+                  olm.relatedImage.latest.pilot: gcr.io/istio-testing/pilot:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+                  olm.relatedImage.latest.proxy: gcr.io/istio-testing/proxyv2:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+                  olm.relatedImage.latest.cni: gcr.io/istio-testing/install-cni:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+                labels:
+                  app.kubernetes.io/created-by: sailoperator
+                  app.kubernetes.io/part-of: sailoperator
+                  control-plane: sail-operator
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - arm64
+                                - ppc64le
+                                - s390x
+                            - key: kubernetes.io/os
+                              operator: In
+                              values:
+                                - linux
+                containers:
+                  - args:
+                      - --secure-listen-address=0.0.0.0:8443
+                      - --upstream=http://127.0.0.1:8080/
+                      - --logtostderr=true
+                      - --v=0
+                    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+                    name: kube-rbac-proxy
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                        protocol: TCP
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 5m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                  - args:
+                      - --health-probe-bind-address=:8081
+                      - --metrics-bind-address=127.0.0.1:8080
+                      - --default-profile=openshift
+                    command:
+                      - /manager
+                    image: quay.io/maistra-dev/sail-operator:0.1-latest
+                    imagePullPolicy: Always
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 512Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                    volumeMounts:
+                      - mountPath: /etc/sail-operator
+                        name: operator-config
+                        readOnly: true
                 securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-              - args:
-                - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
-                - --default-profile=openshift
-                command:
-                - /manager
-                image: quay.io/maistra-dev/sail-operator:0.1-latest
-                imagePullPolicy: Always
-                livenessProbe:
-                  httpGet:
-                    path: /healthz
-                    port: 8081
-                  initialDelaySeconds: 15
-                  periodSeconds: 20
-                name: manager
-                readinessProbe:
-                  httpGet:
-                    path: /readyz
-                    port: 8081
-                  initialDelaySeconds: 5
-                  periodSeconds: 10
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 512Mi
-                  requests:
-                    cpu: 10m
-                    memory: 64Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-                volumeMounts:
-                - mountPath: /etc/sail-operator
-                  name: operator-config
-                  readOnly: true
-              securityContext:
-                runAsNonRoot: true
-              serviceAccountName: sail-operator
-              terminationGracePeriodSeconds: 10
-              volumes:
-              - downwardAPI:
-                  defaultMode: 420
-                  items:
-                  - fieldRef:
-                      fieldPath: metadata.annotations
-                    path: config.properties
-                name: operator-config
+                  runAsNonRoot: true
+                serviceAccountName: sail-operator
+                terminationGracePeriodSeconds: 10
+                volumes:
+                  - downwardAPI:
+                      defaultMode: 420
+                      items:
+                        - fieldRef:
+                            fieldPath: metadata.annotations
+                          path: config.properties
+                    name: operator-config
       permissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-        serviceAccountName: sail-operator
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: sail-operator
     strategy: deployment
   installModes:
-  - supported: false
-    type: OwnNamespace
-  - supported: false
-    type: SingleNamespace
-  - supported: false
-    type: MultiNamespace
-  - supported: true
-    type: AllNamespaces
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
   keywords:
-  - istio
-  - servicemesh
-  - envoy
+    - istio
+    - servicemesh
+    - envoy
   links:
-  - name: Istio Project
-    url: https://istio.io
+    - name: Istio Project
+      url: https://istio.io
   maintainers:
-  - email: istio-feedback@redhat.com
-    name: OpenShift Service Mesh Team
+    - email: istio-feedback@redhat.com
+      name: OpenShift Service Mesh Team
   maturity: alpha
   provider:
     name: Red Hat, Inc.
   version: 0.1.0
+  relatedImages:
+    - name: latest.cni
+      image: gcr.io/istio-testing/install-cni:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+    - name: latest.pilot
+      image: gcr.io/istio-testing/pilot:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+    - name: latest.proxy
+      image: gcr.io/istio-testing/proxyv2:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+    - name: latest.ztunnel
+      image: gcr.io/istio-testing/ztunnel:1.24-alpha.52c9097444fc8e7fe04be557ebffe55bd31120db
+    - name: v1_21_0.cni
+      image: docker.io/istio/install-cni:1.21.0
+    - name: v1_21_0.pilot
+      image: docker.io/istio/pilot:1.21.0
+    - name: v1_21_0.proxy
+      image: docker.io/istio/proxyv2:1.21.0
+    - name: v1_21_0.ztunnel
+      image: docker.io/istio/ztunnel:1.21.0
+    - name: v1_21_2.cni
+      image: docker.io/istio/install-cni:1.21.2
+    - name: v1_21_2.pilot
+      image: docker.io/istio/pilot:1.21.2
+    - name: v1_21_2.proxy
+      image: docker.io/istio/proxyv2:1.21.2
+    - name: v1_21_2.ztunnel
+      image: docker.io/istio/ztunnel:1.21.2
+    - name: v1_21_3.cni
+      image: docker.io/istio/install-cni:1.21.3
+    - name: v1_21_3.pilot
+      image: docker.io/istio/pilot:1.21.3
+    - name: v1_21_3.proxy
+      image: docker.io/istio/proxyv2:1.21.3
+    - name: v1_21_3.ztunnel
+      image: docker.io/istio/ztunnel:1.21.3
+    - name: v1_21_4.cni
+      image: docker.io/istio/install-cni:1.21.4
+    - name: v1_21_4.pilot
+      image: docker.io/istio/pilot:1.21.4
+    - name: v1_21_4.proxy
+      image: docker.io/istio/proxyv2:1.21.4
+    - name: v1_21_4.ztunnel
+      image: docker.io/istio/ztunnel:1.21.4
+    - name: v1_21_5.cni
+      image: docker.io/istio/install-cni:1.21.5
+    - name: v1_21_5.pilot
+      image: docker.io/istio/pilot:1.21.5
+    - name: v1_21_5.proxy
+      image: docker.io/istio/proxyv2:1.21.5
+    - name: v1_21_5.ztunnel
+      image: docker.io/istio/ztunnel:1.21.5
+    - name: v1_22_0.cni
+      image: docker.io/istio/install-cni:1.22.0
+    - name: v1_22_0.pilot
+      image: docker.io/istio/pilot:1.22.0
+    - name: v1_22_0.proxy
+      image: docker.io/istio/proxyv2:1.22.0
+    - name: v1_22_0.ztunnel
+      image: docker.io/istio/ztunnel:1.22.0
+    - name: v1_22_1.cni
+      image: docker.io/istio/install-cni:1.22.1
+    - name: v1_22_1.pilot
+      image: docker.io/istio/pilot:1.22.1
+    - name: v1_22_1.proxy
+      image: docker.io/istio/proxyv2:1.22.1
+    - name: v1_22_1.ztunnel
+      image: docker.io/istio/ztunnel:1.22.1
+    - name: v1_22_2.cni
+      image: docker.io/istio/install-cni:1.22.2
+    - name: v1_22_2.pilot
+      image: docker.io/istio/pilot:1.22.2
+    - name: v1_22_2.proxy
+      image: docker.io/istio/proxyv2:1.22.2
+    - name: v1_22_2.ztunnel
+      image: docker.io/istio/ztunnel:1.22.2
+    - name: v1_22_3.cni
+      image: docker.io/istio/install-cni:1.22.3
+    - name: v1_22_3.pilot
+      image: docker.io/istio/pilot:1.22.3
+    - name: v1_22_3.proxy
+      image: docker.io/istio/proxyv2:1.22.3
+    - name: v1_22_3.ztunnel
+      image: docker.io/istio/ztunnel:1.22.3

--- a/hack/patch-csv.sh
+++ b/hack/patch-csv.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+VERSIONS_YAML_FILE=${VERSIONS_YAML_FILE:-"versions.yaml"}
+
+: "${YQ:=yq}"
+
+# Map containing all components
+declare -A COMPONENTS=( 
+  ["istiod"]="pilot"
+  ["proxy"]="proxy"
+  ["cni"]="cni"
+  ["ztunnel"]="ztunnel"
+)
+
+function is_empty_or_null() {
+  if [ $# -ne 1 ]; then
+    echo "Usage: is_empty_or_null <field>"
+    exit 1
+  fi
+  field="${1}"
+  [ -z "${field}" ] || [ "${field}" = "null" ]
+}
+
+function get_field() {
+  if [ $# -ne 3 ]; then
+    echo "Usage: get_field <version> <field_name> <component_name>"
+    exit 1
+  fi
+
+  local version="${1}"
+  local field_name="${2}"
+  local component_name="${3}"
+
+  component_dir="${component_name}"
+  if [ "${component_name}" = "proxy" ]; then
+    component_dir="istiod"
+  fi
+
+  # Set if non null order .defaults.<field> 
+  #                  then .defaults.<component>.<field> 
+  #                  then .defaults.global.<field> 
+  #               finally .defaults.global.<component>.<field>
+  # Example:
+  #   .defaults.hub == null
+  #   .defaults.istiod.hub == ""
+  #   .defaults.global.hub == "gcr.io/istio-testing"
+  #   .defaults.global.istiod.hub == null
+  field="$(${YQ} ".defaults.${field_name}" resources/"${version}"/charts/"${component_dir}"/values.yaml)"
+  if is_empty_or_null "${field}"; then
+    field="$(${YQ} ".defaults.${COMPONENTS[$component_name]}.${field_name}" resources/"${version}"/charts/"${component_dir}"/values.yaml)"
+    if is_empty_or_null "${field}"; then
+      field="$(${YQ} ".defaults.global.${field_name}" resources/"${version}"/charts/"${component_dir}"/values.yaml)"
+      if is_empty_or_null "${field}"; then
+        field="$(${YQ} ".defaults.global.${COMPONENTS[$component_name]}.${field_name}" resources/"${version}"/charts/"${component_dir}"/values.yaml)"
+      fi
+    fi
+  fi
+
+  echo "${field}"
+}
+
+## MAIN
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <clusterserviceversion_file_path>"
+  exit 1
+fi
+clusterserviceversion_file_path="$1"
+
+versions="$( ${YQ} '.versions[].name' "${VERSIONS_YAML_FILE}" )"
+
+for version in ${versions}; do
+  version_underscore=${version//./_}
+  for component_name in "${!COMPONENTS[@]}"; do    
+    name="${version_underscore}.${COMPONENTS[$component_name]}"
+    hub=$(get_field "${version}" "hub" "${component_name}")
+    image=$(get_field "${version}" "image" "${component_name}")
+    tag=$(get_field "${version}" "tag" "${component_name}")
+
+    # Add .spec.install.spec.deployments[0].spec.template.metadata.annotations with olm.relatedImage
+    ${YQ} -i '.spec.install.spec.deployments[0].spec.template.metadata.annotations |= (. + {"olm.relatedImage.'"${name}"'": "'"${hub}"'/'"${image}"':'"${tag}"'"})' "${clusterserviceversion_file_path}"
+
+    # Add .spec.relatedImages for every Istio components in all supported versions
+    # BUG: yq indents the arrays with 2 more spaces (cf. https://mikefarah.gitbook.io/yq/usage/output-format#indent)
+    ${YQ} -i ".spec.relatedImages |= (. + [ {\"name\": \"${name}\", \"image\": \"${hub}/${image}:${tag}\"} ] | unique | sort_by(.name))" "${clusterserviceversion_file_path}"
+  done
+done


### PR DESCRIPTION
We want to add `relatedImages` to the Sail Operator `ClusterServiceVersion` ( cf. #216 )