### PR TITLE
Issue 230: adding bookinfo deploy to e2e framework

### DIFF
--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -39,6 +39,7 @@ var (
 	image                 = env.Get("IMAGE", "quay.io/maistra-dev/sail-operator:latest")
 	skipDeploy            = env.GetBool("SKIP_DEPLOY", false)
 	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io")
+	bookinfoNamespace     = env.Get("BOOKINFO_NAMESPACE", "bookinfo")
 )
 
 func TestInstall(t *testing.T) {

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -247,7 +247,6 @@ spec:
 					bookinfoPods := &corev1.PodList{}
 
 					It("updates the pods status to Running", func(ctx SpecContext) {
-
 						cl.List(ctx, bookinfoPods, client.InNamespace(bookinfoNamespace))
 						Expect(bookinfoPods.Items).ToNot(BeEmpty(), "No pods found in bookinfo namespace")
 

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -269,7 +269,6 @@ spec:
 						Expect(kubectl.DeleteNamespace(bookinfoNamespace)).To(Succeed(), "Bookinfo namespace failed to be deleted")
 						Success("Bookinfo deleted")
 					})
-
 				})
 
 				When("the Istio CR is deleted", func() {
@@ -397,12 +396,12 @@ func forceDeleteIstioResources() error {
 func getBookinfoYAML(version supportedversion.VersionInfo) (string, error) {
 	// Bookinfo YAML for the current version can be found from istio/istio repository
 	// If the version is latest, we need to get the latest version from the master branch
-	bookinfoUrl := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/bookinfo/platform/kube/bookinfo.yaml", version.Version)
+	bookinfoURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/bookinfo/platform/kube/bookinfo.yaml", version.Version)
 	if version.Name == "latest" {
-		bookinfoUrl = "https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/platform/kube/bookinfo.yaml"
+		bookinfoURL = "https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/platform/kube/bookinfo.yaml"
 	}
 
-	response, err := http.Get(bookinfoUrl)
+	response, err := http.Get(bookinfoURL)
 	if err != nil {
 		return "", fmt.Errorf("error getting bookinfo YAML: %w", err)
 	}
@@ -427,7 +426,10 @@ func deployBookinfo(version supportedversion.VersionInfo) error {
 }
 
 func getProxyVersion(podName, namespace string) (string, error) {
-	proxyVersion, err := kubectl.Exec(namespace, podName, "istio-proxy", `curl -s http://localhost:15000/server_info | grep "ISTIO_VERSION" | awk -F '"' '{print $4}'`)
+	proxyVersion, err := kubectl.Exec(namespace,
+		podName,
+		"istio-proxy",
+		`curl -s http://localhost:15000/server_info | grep "ISTIO_VERSION" | awk -F '"' '{print $4}'`)
 	if err != nil {
 		return "", fmt.Errorf("error getting sidecar version: %w", err)
 	}

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -51,8 +51,8 @@ func CreateFromString(yamlString string) error {
 }
 
 // ApplyString applies the given yaml string to the cluster
-func ApplyString(yamlString string) error {
-	cmd := kubectl("apply --server-side -f -")
+func ApplyString(ns, yamlString string) error {
+	cmd := kubectl("apply -n %s --server-side -f -", ns)
 	_, err := shell.ExecuteCommandWithInput(cmd, yamlString)
 	if err != nil {
 		return fmt.Errorf("error applying yaml: %w", err)
@@ -198,9 +198,9 @@ func sinceFlag(since *time.Duration) string {
 	return "--since=" + since.String()
 }
 
-// Exec executes a command in the pod.
-func Exec(ns, pod string, command string) (string, error) {
-	cmd := kubectl("exec %s %s -- %s", pod, nsflag(ns), command)
+// Exec executes a command in the pod or specific container
+func Exec(ns, pod, container, command string) (string, error) {
+	cmd := kubectl("exec %s %s %s -- %s", pod, containerflag(container), nsflag(ns), command)
 	output, err := shell.ExecuteCommand(cmd)
 	if err != nil {
 		return "", err
@@ -221,4 +221,11 @@ func nsflag(ns string) string {
 		return "--all-namespaces"
 	}
 	return "-n " + ns
+}
+
+func containerflag(container string) string {
+	if container == "" {
+		return ""
+	}
+	return "-c " + container
 }

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -61,6 +61,17 @@ func ApplyString(ns, yamlString string) error {
 	return nil
 }
 
+// Apply applies the given yaml file to the cluster
+func Apply(ns, yamlFile string) error {
+	cmd := kubectl("apply -n %s -f %s", ns, yamlFile)
+	_, err := shell.ExecuteCommand(cmd)
+	if err != nil {
+		return fmt.Errorf("error applying yaml: %w", err)
+	}
+
+	return nil
+}
+
 // CreateNamespace creates a namespace
 // If the namespace already exists, it will return nil
 func CreateNamespace(ns string) error {


### PR DESCRIPTION
Fixes #230 

Adding bookinfo deploy to validate proxy injection and proxy Istio version are successful. 

Tested on both kind and ocp
