### PR TITLE
Ensure controller-gen make target honors CONTROLLER_TOOLS_VERSION

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -462,8 +462,7 @@ $(OPERATOR_SDK): $(LOCALBIN)
 	chmod +x $(LOCALBIN)/operator-sdk;
 
 .PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen to bin directory. If wrong version is installed, it will be overwritten.
-$(CONTROLLER_GEN): $(LOCALBIN)
+controller-gen: $(LOCALBIN) ## Download controller-gen to bin directory. If wrong version is installed, it will be overwritten.
 	@test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 


### PR DESCRIPTION
Previously, bumping `CONTROLLER_TOOLS_VERSION` didn't cause an existing `controller-gen` binary to be updated. This was because the `controller-gen` make target had a dependency on the `$(CONTROLLER_GEN)` target. Since `$(CONTROLLER_GEN)` points to `bin/controller-gen`, the make target isn't invoked when the file exists. Because of this, the `controller-gen --version` check in the `$(CONTROLLER_GEN)` target was never executed and thus the binary was never updated.

Now, the `controller-gen` target will always perform the version check.