### PR TITLE
Issue 296: Adding OLM deploy for operator e2e

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -299,7 +299,7 @@ deploy-yaml-openshift: verify-kubeconfig helm ## Output YAML manifests used by `
 .PHONY: deploy-olm
 deploy-olm: verify-kubeconfig bundle bundle-build bundle-push ## Build and push the operator OLM bundle and deploy the operator using OLM.
 	kubectl create ns ${NAMESPACE} || echo "namespace ${NAMESPACE} already exists"
-	$(OPERATOR_SDK) run bundle $(BUNDLE_IMG) -n ${NAMESPACE}
+	$(OPERATOR_SDK) run bundle $(BUNDLE_IMG) -n ${NAMESPACE} --skip-tls
 
 .PHONY: undeploy
 undeploy: verify-kubeconfig ## Undeploy controller from an existing cluster.
@@ -483,9 +483,10 @@ gitleaks: $(GITLEAKS) ## Download gitleaks to bin directory.
 $(GITLEAKS): $(LOCALBIN)
 	@test -s $(LOCALBIN)/gitleaks || GOBIN=$(LOCALBIN) go install github.com/zricethezav/gitleaks/v8@${GITLEAKS_VERSION}
 
+HELM_PLATFORM ?= openshift
 .PHONY: bundle
 bundle: gen-all-except-bundle helm operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
-	$(HELM) template chart chart $(HELM_TEMPL_DEF_FLAGS) --set image='$(IMAGE)' --set platform=openshift --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(HELM) template chart chart $(HELM_TEMPL_DEF_FLAGS) --set image='$(IMAGE)' --set platform=$(HELM_PLATFORM) --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 
 ifeq ($(GENERATE_RELATED_IMAGES), true)
 	@hack/patch-csv.sh bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -489,10 +489,12 @@ OPENSHIFT_PLATFORM ?= true
 
 .PHONY: bundle
 bundle: gen-all-except-bundle helm operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
-ifeq ($(OPENSHIFT_PLATFORM), true)
-	HELM_TEMPL_DEF_FLAGS := $(HELM_TEMPL_DEF_FLAGS) --set platform=openshift
-endif
-	$(HELM) template chart chart $(HELM_TEMPL_DEF_FLAGS) --set image='$(IMAGE)' --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	@TEMPL_FLAGS="$(HELM_TEMPL_DEF_FLAGS)"; \
+	if [ "$(OPENSHIFT_PLATFORM)" = "true" ]; then \
+		TEMPL_FLAGS="$$TEMPL_FLAGS --set platform=openshift"; \
+	fi; \
+	$(HELM) template chart chart $$TEMPL_FLAGS --set image='$(IMAGE)' --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+
 ifeq ($(GENERATE_RELATED_IMAGES), true)
 	@hack/patch-csv.sh bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 endif

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -209,6 +209,7 @@ The following environment variables define the behavior of the test run:
 * IMAGE=quay.io/maistra-dev/sail-operator:latest - The operator image to be used to deploy the operator and run the test. This is useful when you want to test a specific operator image.
 * SKIP_DEPLOY=false - If set to true, the test will skip the deployment of the operator. This is useful when the operator is already deployed in the cluster, and you want to run the test only.
 * OCP=false - If set to true, the test will be configured to run on an OCP cluster and use the `oc` command to interact with it. If set to false, the test will run in a KinD cluster and use `kubectl`.
+* OLM=false - If set to true, the test will use the OLM (Operator Lifecycle Manager) to install the operator. If set to false, the test will use Helm to install the operator.
 * NAMESPACE=sail-operator - The namespace where the operator will be deployed and the test will run.
 * CONTROL_PLANE_NS=istio-system - The namespace where the control plane will be deployed.
 * DEPLOYMENT_NAME=sail-operator - The name of the operator deployment.

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -91,7 +91,7 @@ parse_flags() {
   if [ "${OLM}" == "true" ]; then
     echo "OLM deployment enabled"
     if [ "${OCP}" == "true" ]; then
-      echo "OLM deploy test is being skipped on OCP due errors with the workaround to avoid the certificate issue"
+      echo "Skipping operator deployment using OLM on OCP clusters due to certificate issues with the internal registry."
       exit 1
     fi
   fi

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -238,12 +238,12 @@ if [ "${SKIP_BUILD}" == "false" ]; then
     make bundle bundle-build bundle-push
 
     # Create operator namespace
-    ${COMMAND} create ns ${NAMESPACE} || echo "namespace ${NAMESPACE} already exists"
+    ${COMMAND} create ns "${NAMESPACE}" || echo "namespace ${NAMESPACE} already exists"
     # Deploy the operator using OLM
-	  ${OPERATOR_SDK} run bundle ${BUNDLE_IMG} -n ${NAMESPACE} --skip-tls
+	  ${OPERATOR_SDK} run bundle "${BUNDLE_IMG}" -n "${NAMESPACE}" --skip-tls
 
     # Wait for the operator to be ready
-    ${COMMAND} wait --for=condition=available deployment/${DEPLOYMENT_NAME} -n "${NAMESPACE}" --timeout=5m
+    ${COMMAND} wait --for=condition=available deployment/"${DEPLOYMENT_NAME}" -n "${NAMESPACE}" --timeout=5m
 
     # Set SKIP_DEPLOY to true to avoid deploying the operator again
     SKIP_DEPLOY=true

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -226,7 +226,7 @@ if [ "${SKIP_BUILD}" == "false" ]; then
   if [ "${OLM}" == "true" ] && [ "${SKIP_DEPLOY}" == "false" ]; then
     # Set the platform to Kubernetes by default.
     # We are skipping the deploy via OLM test on OCP because the workaround to avoid the certificate issue is not working.
-    # Jora ticket related to the limitation: https://issues.redhat.com/browse/OSSM-7993
+    # Jira ticket related to the limitation: https://issues.redhat.com/browse/OSSM-7993
     HELM_PLATFORM="kubernetes"
     
     # Install OLM in the cluster because it's not available by default in kind.

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -223,7 +223,7 @@ if [ "${SKIP_BUILD}" == "false" ]; then
   build_and_push_operator_image
 
   # If OLM is enabled, deploy the operator using OLM
-  if [ "${OLM}" == "true" ] && [ "${SKIP_DEPLOY}" == "false"]; then
+  if [ "${OLM}" == "true" ] && [ "${SKIP_DEPLOY}" == "false" ]; then
     # Set the platform to Kubernetes by default.
     # We are skipping the deploy via OLM test on OCP because the workaround to avoid the certificate issue is not working.
     # Jora ticket related to the limitation: https://issues.redhat.com/browse/OSSM-7993
@@ -244,7 +244,7 @@ if [ "${SKIP_BUILD}" == "false" ]; then
     make bundle bundle-build bundle-push
 
     # Create operator namespace
-    ${COMMAND} create ns "${NAMESPACE}" || echo "namespace ${NAMESPACE} already exists"
+    ${COMMAND} create ns "${NAMESPACE}" || echo "Creation of namespace ${NAMESPACE} failed with the message: $?"
     # Deploy the operator using OLM
     ${OPERATOR_SDK} run bundle "${BUNDLE_IMG}" -n "${NAMESPACE}" --skip-tls
 

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -108,14 +108,8 @@ initialize_variables() {
   COMMAND="kubectl"
   ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"
   KUBECONFIG="${KUBECONFIG:-"${ARTIFACTS}/config"}"
-  # Set the location to install dependencies
-  LOCALBIN="${LOCALBIN:-$(pwd)/bin}"
-
-  # Create the directory if it doesn't exist
-  mkdir -p "${LOCALBIN}"
-
-  # Define the path for the operator-sdk binary
-  OPERATOR_SDK="${LOCALBIN}/operator-sdk"
+  LOCALBIN="${LOCALBIN:-${HOME}/bin}"
+  OPERATOR_SDK=${LOCALBIN}/operator-sdk
 
   if [ "${OCP}" == "true" ]; then
     COMMAND="oc"
@@ -228,20 +222,16 @@ if [ "${SKIP_BUILD}" == "false" ]; then
   if [ "${OLM}" == "true" ] && [ "${SKIP_DEPLOY}" == "false" ]; then   
     # Install OLM in the cluster because it's not available by default in kind.
     ${OPERATOR_SDK} olm install
-
+    
     # Set image-related variables
     IMAGE_TAG_BASE="${HUB}/${IMAGE_BASE}"
     BUNDLE_IMG="${IMAGE_TAG_BASE}-bundle:v${VERSION}"
-
-    # If platform is different to openshift, the --set platform=<platform> flag is not added to the helm template command.
-    # We set it to kubernetes because the operator is going to be deployed in a kubernetes cluster and we need to avoid changes in the helm chart that are specific to OCP.
-    HELM_PLATFORM="kubernetes"
 
     # Deploy the operator using OLM
     IMAGE="${HUB}/${IMAGE_BASE}:${TAG}" \
     IMAGE_TAG_BASE="${IMAGE_TAG_BASE}" \
     BUNDLE_IMG="${BUNDLE_IMG}" \
-    HELM_PLATFORM="${HELM_PLATFORM}" \
+    OPENSHIFT_PLATFORM=false \
     make bundle bundle-build bundle-push
 
     # Create operator namespace

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -27,6 +27,7 @@ check_arguments() {
 parse_flags() {
   SKIP_BUILD=${SKIP_BUILD:-false}
   SKIP_DEPLOY=${SKIP_DEPLOY:-false}
+  OLM=${OLM:-false}
   DESCRIBE=false
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -47,6 +48,10 @@ parse_flags() {
         # no point building if we don't deploy
         SKIP_BUILD=true
         SKIP_DEPLOY=true
+        ;;
+      --olm)
+        shift
+        OLM=true
         ;;
       --describe)
         shift
@@ -74,6 +79,22 @@ parse_flags() {
   else
     echo "Running on kind"
   fi
+
+  if [ "${SKIP_BUILD}" == "true" ]; then
+    echo "Skipping build"
+  fi
+
+  if [ "${SKIP_DEPLOY}" == "true" ]; then
+    echo "Skipping deploy"
+  fi
+
+  if [ "${OLM}" == "true" ]; then
+    echo "OLM deployment enabled"
+    if [ "${OCP}" == "true" ]; then
+      # OLM deploy test is being skipped on OCP due errors with the workaround to avoid the certificate issue
+      exit 1
+    fi
+  fi
 }
 
 initialize_variables() {
@@ -87,6 +108,8 @@ initialize_variables() {
   COMMAND="kubectl"
   ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"
   KUBECONFIG="${KUBECONFIG:-"${ARTIFACTS}/config"}"
+  LOCALBIN="${LOCALBIN:-"${HOME}/.local/bin"}"
+  OPERATOR_SDK="${LOCALBIN}/operator-sdk"
 
   if [ "${OCP}" == "true" ]; then
     COMMAND="oc"
@@ -191,16 +214,48 @@ if [ "${SKIP_BUILD}" == "false" ]; then
     get_internal_registry
   fi
 
-  # BUILD AND PUSH IMAGE
+  # BUILD AND PUSH OPERATOR IMAGE
   build_and_push_image
 
-  if [ "${OCP}" == "true" ]; then
-    # This is a workaround
-    # To avoid errors of certificates meanwhile we are pulling the operator image from the internal registry
-    # We need to set image $HUB to a fixed known value after the push
-    # This value always will be equal to the svc url of the internal registry
-    HUB="image-registry.openshift-image-registry.svc:5000/sail-operator"
+  # If OLM is enabled, deploy the operator using OLM
+  if [ "${OLM}" == "true" ]; then
+    # Set the platform to Kubernetes by default.
+    # We are skipping the deploy via OLM test on OCP because the workaround to avoid the certificate issue is not working.
+    HELM_PLATFORM="kubernetes"
+    
+    # Install OLM in the cluster because it's not available by default in kind.
+    ${OPERATOR_SDK} olm install
+
+    # Set image-related variables
+    IMAGE_TAG_BASE="${HUB}/${IMAGE_BASE}"
+    BUNDLE_IMG="${IMAGE_TAG_BASE}-bundle:v${VERSION}"
+
+    # Deploy the operator using OLM
+    IMAGE="${HUB}/${IMAGE_BASE}:${TAG}" \
+    IMAGE_TAG_BASE="${IMAGE_TAG_BASE}" \
+    BUNDLE_IMG="${BUNDLE_IMG}" \
+    HELM_PLATFORM="${HELM_PLATFORM}" \
+    make bundle bundle-build bundle-push
+
+    # Create operator namespace
+    ${COMMAND} create ns ${NAMESPACE} || echo "namespace ${NAMESPACE} already exists"
+    # Deploy the operator using OLM
+	  ${OPERATOR_SDK} run bundle ${BUNDLE_IMG} -n ${NAMESPACE} --skip-tls
+
+    # Wait for the operator to be ready
+    ${COMMAND} wait --for=condition=available deployment/${DEPLOYMENT_NAME} -n "${NAMESPACE}" --timeout=5m
+
+    # Set SKIP_DEPLOY to true to avoid deploying the operator again
+    SKIP_DEPLOY=true
   fi
+fi
+
+if [ "${OCP}" == "true" ]; then
+  # This is a workaround
+  # To avoid errors of certificates meanwhile we are pulling the operator image from the internal registry
+  # We need to set image $HUB to a fixed known value after the push
+  # This value always will be equal to the svc url of the internal registry
+  HUB="image-registry.openshift-image-registry.svc:5000/sail-operator"
 fi
 
 # Run the go test passing the env variables defined that are going to be used in the operator tests

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -223,18 +223,19 @@ if [ "${SKIP_BUILD}" == "false" ]; then
   build_and_push_operator_image
 
   # If OLM is enabled, deploy the operator using OLM
-  if [ "${OLM}" == "true" ] && [ "${SKIP_DEPLOY}" == "false" ]; then
-    # Set the platform to Kubernetes by default.
-    # We are skipping the deploy via OLM test on OCP because the workaround to avoid the certificate issue is not working.
-    # Jira ticket related to the limitation: https://issues.redhat.com/browse/OSSM-7993
-    HELM_PLATFORM="kubernetes"
-    
+  # We are skipping the deploy via OLM test on OCP because the workaround to avoid the certificate issue is not working.
+  # Jira ticket related to the limitation: https://issues.redhat.com/browse/OSSM-7993
+  if [ "${OLM}" == "true" ] && [ "${SKIP_DEPLOY}" == "false" ]; then   
     # Install OLM in the cluster because it's not available by default in kind.
     ${OPERATOR_SDK} olm install
 
     # Set image-related variables
     IMAGE_TAG_BASE="${HUB}/${IMAGE_BASE}"
     BUNDLE_IMG="${IMAGE_TAG_BASE}-bundle:v${VERSION}"
+
+    # If platform is different to openshift, the --set platform=<platform> flag is not added to the helm template command.
+    # We set it to kubernetes because the operator is going to be deployed in a kubernetes cluster and we need to avoid changes in the helm chart that are specific to OCP.
+    HELM_PLATFORM="kubernetes"
 
     # Deploy the operator using OLM
     IMAGE="${HUB}/${IMAGE_BASE}:${TAG}" \

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -240,7 +240,7 @@ if [ "${SKIP_BUILD}" == "false" ]; then
     # Create operator namespace
     ${COMMAND} create ns "${NAMESPACE}" || echo "namespace ${NAMESPACE} already exists"
     # Deploy the operator using OLM
-	  ${OPERATOR_SDK} run bundle "${BUNDLE_IMG}" -n "${NAMESPACE}" --skip-tls
+${OPERATOR_SDK} run bundle "${BUNDLE_IMG}" -n "${NAMESPACE}" --skip-tls
 
     # Wait for the operator to be ready
     ${COMMAND} wait --for=condition=available deployment/"${DEPLOYMENT_NAME}" -n "${NAMESPACE}" --timeout=5m

--- a/tests/e2e/config/default.yaml
+++ b/tests/e2e/config/default.yaml
@@ -32,3 +32,4 @@ networking:
   # our prow cluster uses serviceSubnet 10.96.0.0/12, so the kind cluster must use other subnet to correctly route traffic;
   # in this case, address 10.224.0.0 is chosen randomly from available set of subnets.
   serviceSubnet: "10.224.0.0/12"
+  ipFamily: ipv4


### PR DESCRIPTION
Fixes #296 

Adding:

- `--skip-tls` to `deploy-olm` target because we can run this target pushing the images to an insecure registry like kind-registry
- `HELM_PLATFORM ?= openshift` to `bundle` make target because we had hardcoded openshift, and we can install the operator via OLM on the Kubernetes cluster also if OLM is available in the cluster
- Adding OLM operator deployment to run the e2e test against the operator installed using OLM