### PR TITLE
Fetch Istio CRDs from Istio version specified in go.mod

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -359,8 +359,8 @@ gen-charts: ## Pull charts from istio repository.
 	@# update the urn:alm:descriptor:com.tectonic.ui:select entries in istio_types.go to match the supported versions of the Helm charts
 	@hack/update-version-list.sh
 
-	@# calls copy-crds.sh with the version specified in the .crdSourceVersion field in versions.yaml
-	@hack/copy-crds.sh "resources/$$(yq eval '.crdSourceVersion' $(VERSIONS_YAML_FILE))/charts"
+	@# extract the Istio CRD YAMLs from the istio.io/istio dependency in go.mod into ./chart/crds
+	@hack/extract-istio-crds.sh
 
 .PHONY: gen
 gen: gen-all-except-bundle bundle ## Generate everything.

--- a/hack/extract-istio-crds.sh
+++ b/hack/extract-istio-crds.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-: "${CHARTS_DIR:=$1}"
+INPUT_FILE="$(go list -m -f '{{.Dir}}' istio.io/istio)/manifests/charts/base/crds/crd-all.gen.yaml"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$(dirname "${SCRIPT_DIR}")
@@ -24,9 +24,9 @@ OPERATOR_CHART_DIR="${REPO_ROOT}/chart"
 
 function copyCRDs() {
   # Split the YAML file into separate CRD files
-  csplit -s --suppress-matched -f "${OPERATOR_CHART_DIR}/crds/istio-crd" -z "${CHARTS_DIR}/base/crds/crd-all.gen.yaml" '/^---$/' '{*}'
+  csplit -s --suppress-matched -f "${OPERATOR_CHART_DIR}/crds/istio-crd" -z "${INPUT_FILE}" '/^---$/' '{*}'
 
-  # To hide istio CRDs in the OpenShift Console, we add them to the intenral-objects annotation in the CSV
+  # To hide istio CRDs in the OpenShift Console, we add them to the internal-objects annotation in the CSV
   internalObjects=""
 
   # Rename the split files to <api group>_<resource name>.yaml

--- a/pkg/test/util/supportedversion/supportedversion.go
+++ b/pkg/test/util/supportedversion/supportedversion.go
@@ -56,8 +56,7 @@ func init() {
 }
 
 type Versions struct {
-	CRDSourceVersion string        `json:"crdSourceVersion"`
-	Versions         []VersionInfo `json:"versions"`
+	Versions []VersionInfo `json:"versions"`
 }
 
 type VersionInfo struct {

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,14 +1,15 @@
 # This file defines all the Istio versions supported by this operator.
 
-# Since you can't install multiple versions of the same CRD, only one of the
-# versions specified below can be the source of the CRDs. Because CRDs are
-# typically backwards-compatible, the following field should point to the
-# most recent version.
-crdSourceVersion: latest
 # The list of versions to support. Each item specifies the name of the version,
 # the Git repository and commit hash for retrieving the profiles, and
 # a list of URLs for retrieving the charts.
 # The first item in the list is the default version.
+#
+# IMPORTANT: in addition to the versions specified here, the versions of the
+# istio.io/istio and istio.io/api dependencies defined in go.mod must also be
+# updated to match the most recent version specified here. The versions in
+# go.mod affect the generated API schema for the Sail CRDs (e.g. IstioRevision),
+# as well as all the Istio CRDs (e.g. VirtualService).
 versions:
   - name: v1.23.0
     version: 1.23.0


### PR DESCRIPTION
Previously, the version of Istio CRDs was determined by the `crdSourceVersion` field in `versions.yaml`. This change ensures that Istio CRDs are now pulled directly from the istio.io/istio version specified in the go.mod file.