### PR TITLE
Add README file for Helm charts section

### DIFF
--- a/bundle/README.md
+++ b/bundle/README.md
@@ -151,53 +151,7 @@ Alternatively, refer to [Istio's artifacthub chart documentation](https://artifa
 The `istioctl` tool is a configuration command line utility that allows service 
 operators to debug and diagnose Istio service mesh deployments.
 
-
-### Prerequisites
-
-Use an `istioctl` version that is the same version as the Istio control plane 
-for the Service Mesh deployment. See [Istio Releases](https://github.com/istio/istio/releases) for a list of valid 
-releases, including Beta releases.
-
-
-### Procedure
-
-1. Confirm if you have `istioctl` installed, and if so which version, by running 
-the following command at the terminal:
-
-    ```sh
-    $ istioctl version
-    ```
-
-1. Confirm the version of Istio you are using by running the following command 
-at the terminal:
-
-    ```sh
-    $ oc -n istio-system get istio
-    ```
-
-1. Install `istioctl` by running the following command at the terminal: 
-
-    ```sh
-    $ curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=<version> sh -
-    ```
-    Replace `<version>` with the version of Istio you are using.
-
-1. Put the `istioctl` directory on path by running the following command at the terminal:
-  
-    ```sh
-    $ export PATH=$HOME/.istioctl/bin:$PATH
-    ```
-
-1. Confirm that the `istioctl` client version and the Istio control plane 
-version now match (or are within one version) by running the following command
-at the terminal:
-  
-    ```sh
-    $ istioctl version
-    ```
-
-
-*Note*: `istioctl install` is not supported. The Sail Operator installs Istio.
+For installation steps, refer to the following [link](../docs/common/install-istioctl-tool.md).
 
 ## Installing the Bookinfo Application
 
@@ -205,30 +159,7 @@ You can use the `bookinfo` example application to explore service mesh features.
 Using the `bookinfo` application, you can easily confirm that requests from a 
 web browser pass through the mesh and reach the application.
 
-The `bookinfo` application displays information about a book, similar to a 
-single catalog entry of an online book store. The application displays a page 
-that describes the book, lists book details (ISBN, number of pages, and other 
-information), and book reviews.
-
-The `bookinfo` application is exposed through the mesh, and the mesh configuration 
-determines how the microservices comprising the application are used to serve 
-requests. The review information comes from one of three services: `reviews-v1`, 
-`reviews-v2` or `reviews-v3`. If you deploy the `bookinfo` application without 
-defining the `reviews` virtual service, then the mesh uses a round-robin rule to 
-route requests to a service.
-
-By deploying the `reviews` virtual service, you can specify a different behavior. 
-For example, you can specify that if a user logs into the `bookinfo` application, 
-then the mesh routes requests to the `reviews-v2` service, and the application 
-displays reviews with black stars. If a user does not log into the `bookinfo` 
-application, then the mesh routes requests to the `reviews-v3` service, and the 
-application displays reviews with red stars.
-
-For more information, see [Bookinfo Application](https://istio.io/latest/docs/examples/bookinfo/) in the upstream Istio documentation.
-
-After following the instructions for [Deploying the application](https://istio.io/latest/docs/examples/bookinfo/#start-the-application-services), **you 
-will need to create and configure a gateway** for the `bookinfo` application to 
-be accessible outside the cluster.
+For installation steps, refer to the following [link](../docs/common/install-bookinfo-app.md).
 
 
 ## Creating and Configuring Gateways
@@ -240,81 +171,7 @@ contains the control plane.
 
 You can deploy gateways using either the Gateway API or Gateway Injection methods. 
 
-
-### Option 1: Istio Gateway Injection
-
-Gateway Injection uses the same mechanisms as Istio sidecar injection to create 
-a gateway from a `Deployment` resource that is paired with a `Service` resource 
-that can be made accessible from outside the cluster. For more information, see 
-[Installing Gateways](https://preliminary.istio.io/latest/docs/setup/additional-setup/gateway/#deploying-a-gateway).
-
-To configure gateway injection with the `bookinfo` application, we have provided 
-a [sample gateway configuration](../chart/samples/ingress-gateway.yaml?raw=1) that should be applied in the namespace 
-where the application is installed:
-
-1. Create the `istio-ingressgateway` deployment and service:
-
-    ```sh
-    $ oc apply -f -n <app-namespace> ingress-gateway.yaml
-    ```
-
-2. Configure the `bookinfo` application with the new gateway:
-
-    ```sh
-    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/networking/bookinfo-gateway.yaml
-    ```
-
-3. On OpenShift, you can use a [Route](https://docs.openshift.com/container-platform/4.13/networking/routes/route-configuration.html) to expose the gateway externally: 
-
-    ```sh
-    $ oc expose service istio-ingressgateway
-    ```
-
-4. Finally, obtain the gateway host name and the URL of the product page:
-
-    ```sh
-    $ HOST=$(oc get route istio-ingressgateway -o jsonpath='{.spec.host}')
-    $ echo http://$HOST/productpage
-    ```
-
-Verify that the `productpage` is accessible from a web browser. 
-
-
-### Option 2: Kubernetes Gateway API
-
-Istio includes support for Kubernetes [Gateway API](https://gateway-api.sigs.k8s.io/) and intends to make it 
-the default API for [traffic management in the future](https://istio.io/latest/blog/2022/gateway-api-beta/). For more 
-information, see Istio's [Kubernetes Gateway API](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/) page.
-
-As of Kubernetes 1.28 and OpenShift 4.14, the Kubernetes Gateway API CRDs are 
-not available by default and must be enabled to be used. This can be done with 
-the command:
-
-```sh
-$ oc get crd gateways.gateway.networking.k8s.io &> /dev/null ||  { oc kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.0.0" | oc apply -f -; }
-```
-
-To configure `bookinfo` with a gateway using `Gateway API`:
-
-1. Create and configure a gateway using a `Gateway` and `HTTPRoute` resource:
-
-    ```sh
-    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/gateway-api/bookinfo-gateway.yaml
-    ```
-
-2. Retrieve the host, port and gateway URL:
-
-    ```sh
-    $ export INGRESS_HOST=$(oc get gtw bookinfo-gateway -o jsonpath='{.status.addresses[0].value}')
-    $ export INGRESS_PORT=$(oc get gtw bookinfo-gateway -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
-    $ export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
-    ```
-
-3. Obtain the `productpage` URL and check that you can visit it from a browser:
-
-   ```sh
-    $ echo "http://${GATEWAY_URL}/productpage"
-    ```
+For installation steps, refer to the following [link](../docs/common/create-and-configure-gateways.md).
 
 
 ## Istio Addons Integrations
@@ -324,118 +181,7 @@ Istio can be integrated with other software to provide additional functionality
 The following addons are for demonstration or development purposes only and 
 should not be used in production environments:
 
-
-### Prometheus
-
-`Prometheus` is an open-source systems monitoring and alerting toolkit. You can 
-use `Prometheus` with the Sail Operator to keep an eye on how healthy Istio and 
-the apps in the service mesh are, for more information, see [Prometheus](https://istio.io/latest/docs/ops/integrations/prometheus/). 
-
-To install Prometheus, perform the following steps:
-
-1. Deploy `Prometheus`:
-
-    ```sh
-    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/prometheus.yaml
-    ```
-2. Access to `Prometheus`console:
-
-    * Expose the `Prometheus` service externally:
-    
-    ```sh
-    $ oc expose service prometheus -n istio-system
-    ```
-    * Get the route of the service and open the URL in the web browser
-    
-    ```sh
-    $ oc get route prometheus -o jsonpath='{.spec.host}' -n istio-system
-    ```
-
-
-### Grafana
-
-`Grafana` is an open-source platform for monitoring and observability. You can 
-use `Grafana` with the Sail Operator to configure dashboards for istio, see 
-[Grafana](https://istio.io/latest/docs/ops/integrations/grafana/) for more information. 
-
-To install Grafana, perform the following steps:
-
-1. Deploy `Grafana`:
-    
-    ```sh
-    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/grafana.yaml
-    ```
-
-2. Access to `Grafana`console:
-
-    * Expose the `Grafana` service externally
-    
-    ```sh
-    $ oc expose service grafana -n istio-system
-    ```
-    * Get the route of the service and open the URL in the web browser
-    
-    ```sh
-    $ oc get route grafana -o jsonpath='{.spec.host}' -n istio-system
-    ```
-
-
-### Jaeger
-
-`Jaeger` is an open-source end-to-end distributed tracing system. You can use 
-`Jaeger` with the Sail Operator to monitor and troubleshoot transactions in 
-complex distributed systems, see [Jaeger](https://istio.io/latest/docs/ops/integrations/jaeger/) for more information. 
-
-To install Jaeger, perform the following steps:
-
-1. Deploy `Jaeger`:
-    
-    ```sh
-    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/jaeger.yaml
-    ```
-2. Access to `Jaeger` console:
-
-    * Expose the `Jaeger` service externally:
-
-        ```sh
-        $ oc expose svc/tracing -n istio-system
-        ```
-
-    * Get the route of the service and open the URL in the web browser
-
-        ```sh
-        $ oc get route tracing -o jsonpath='{.spec.host}' -n istio-system
-        ```
-*Note*: if you want to see some traces you can refresh several times the product 
-page of bookinfo app to start generating traces.
-
-
-### Kiali
-
-`Kiali` is an open-source project that provides a graphical user interface to 
-visualize the service mesh topology, see [Kiali](https://istio.io/latest/docs/ops/integrations/kiali/) for more information. 
-
-To install Kiali, perform the following steps:
-
-1. Deploy `Kiali`:
-    
-    ```sh
-    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/kiali.yaml
-    ```
-
-2. Access to `Kiali` console:
-
-    * Expose the `Kiali` service externally:
-
-        ```sh
-        $ oc expose service kiali -n istio-system
-        ```
-
-    * Get the route of the service and open the URL in the web browser
-
-        ```sh
-        $ oc get route kiali -o jsonpath='{.spec.host}' -n istio-system
-        ```
+For installation steps, refer to the following [link](../docs/common/istio-addons-integrations.md).
 
 
 ## Undeploying Istio and the Sail Operator

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,248 @@
+# Deploy Sail Operator by using Helm charts
+
+Follow this guide to install and configure Sail Operator by using [Helm](https://helm.sh/docs/)
+
+## Prerequisites
+
+Kubernetes:
+* You have deployed a cluster on Kubernetes platform 1.27 or later.
+* You are logged in to the Kubernetes cluster with admin permissions level user.
+
+OpenShift:
+* You have deployed a cluster on OpenShift Container Platform 4.14 or later.  
+* You are logged in to the OpenShift Container Platform web console as a user with the `cluster-admin` role.
+
+[Install the Helm client](https://helm.sh/docs/intro/install/), version 3.6 or above.
+
+## Prepare the Helm charts
+
+**Note** - `Sail Operator` could be installed by downloading the release artifacts from the [release page](https://github.com/istio-ecosystem/sail-operator/releases).
+
+* Download the required release artifact
+* Extract it locally.
+
+    ```sh
+    $ tar -xvf /tmp/sail-operator-<release-number>.tgz
+    ```
+
+The extract command will create the `sail-operator` directory with the helm charts in it.
+
+## Installation steps
+
+This section describes the procedure to install `Sail Operator` using Helm. The general syntax for helm installation is:
+
+    ```sh
+    helm install <release> <chart> --create-namespace --namespace <namespace> [--set <other_parameters>]
+    ```
+
+The variables specified in the command are as follows:
+* `<release>` - A name to identify and manage the Helm chart once installed.
+* `<chart>` - A path to a packaged chart, a path to an unpacked chart directory or a URL.
+* `<namespace>` - The namespace in which the chart is to be installed.
+
+Default configuration values can be changed using one or more `--set <parameter>=<value>` arguments. Alternatively, you can specify several parameters in a custom values file using the `--values <file>` argument.
+
+1. Create the namespace, `sail-operator`, for the Sail Operator components:
+
+    ```sh
+    $ kubectl create namespace sail-operator
+    ```
+
+**Note** - This step could be skipped by using the `--create-namespace` argument in step 2.
+
+2. Install the Sail Operator base charts which will manage all the Custom Resource Definitions(CRDs) to be able to deploy the Istio control plane:
+
+* Kubernetes
+
+    ```sh
+    $ helm install sail-operator sail-operator/ --namespace sail-operator
+    ```
+
+* OpenShift
+
+    ```sh
+    $ helm install sail-operator sail-operator/ --namespace sail-operator --set platform=openshift
+    ```
+
+3. Validate the CRD installation with the `helm ls` command:
+
+    ```sh
+    $ helm ls -n sail-operator
+
+    NAME         	NAMESPACE    	REVISION	UPDATED                                	STATUS  	CHART                   	APP VERSION
+    sail-operator	sail-operator	1       	2024-09-16 12:43:18.786846217 +0300 IDT	deployed	sail-operator-0.1.0-rc.1	0.1.0-rc.1
+    ```
+
+4. Get the status of the installed helm chart to ensure it is deployed:
+
+    ```bash
+    $ helm status sail-operator -n sail-operator
+
+    NAME: sail-operator
+    LAST DEPLOYED: Mon Sep 16 12:43:18 2024
+    NAMESPACE: sail-operator
+    STATUS: deployed
+    REVISION: 1
+    TEST SUITE: None
+    ```
+
+5. Check `sail-operator` deployment is successfully installed and its pods are running:
+
+    ```sh
+    $ kubectl -n sail-operator get deployment --output wide
+
+    NAME            READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS                IMAGES                                                                                    SELECTOR
+    sail-operator   1/1     1            1           19m   kube-rbac-proxy,manager   gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0,quay.io/maistra-dev/sail-operator:0.1.0-rc.1   app.kubernetes.io/created-by=sailoperator,app.kubernetes.io/part-of=sailoperator,control-plane=sail-operator
+
+    $ kubectl -n sail-operator get pods -o wide
+
+    NAME                             READY   STATUS    RESTARTS   AGE   IP           NODE                 NOMINATED NODE   READINESS GATES
+    sail-operator-666f84b6f4-9hw4t   2/2     Running   0          43s   10.244.0.8   sail-control-plane   <none>           <none>
+    ```
+
+## Deploying Istio
+
+To deploy Istio, you must create the following resources:
+* `Istio`.
+* If you are using OpenShift, the `IstioCNI` must also be created.
+
+The `Istio` resource deploys and configures the Istio Control Plane, whereas the `IstioCNI` resource (in OpenShift) deploys and configures the Istio CNI plugin. You should create these resources in separate projects.
+
+### Create a namespace for Istio project.
+
+* Kubernetes
+
+    ```sh
+    $ kubectl create namespace istio-system
+    ```
+
+* OpenShift
+
+    ```sh
+    $ kubectl create namespace istio-system
+    $ kubectl create namespace istio-cni
+    ```
+
+### Create the Istio resource
+
+The `sail-operator` charts directory contains `samples` directory, which contains manifests that could be used for Istio deployment.
+
+* Kubernetes
+
+    ```sh
+    $ kubectl apply -f sail-operator/samples/istio-sample-kubernetes.yaml
+    ```
+
+* OpenShift
+
+    ```sh
+    $ kubectl apply -f sail-operator/samples/istio-sample-openshift.yaml
+    $ kubectl apply -f sail-operator/samples/istiocni-sample.yaml
+    ```
+
+**Note** - The version can be specified by modifying the `version` field within `Istio` and `IstioCNI` manifests.
+
+### Customizing Istio configuration
+
+The `spec.values` field of the `Istio` and `IstioCNI` resource can be used to customize Istio and Istio CNI plugin configuration using Istio's `Helm` configuration values.
+
+An example configuration:
+
+    ```yaml
+    apiVersion: sailoperator.io/v1alpha1
+    kind: Istio
+    metadata:
+    name: example
+    spec:
+    version: v1.23.0
+    values:
+        global:
+        mtls:
+            enabled: true
+        trustDomainAliases:
+        - example.net
+        meshConfig:
+        trustDomain: example.com
+        trustDomainAliases:
+        - example.net
+    ```
+
+For a list of available configuration for the `spec.values` field, run the following command:
+
+    ```sh
+    $ kubectl explain istio.spec.values
+    ```
+
+For the `IstioCNI` resource, replace `istio` with `istiocni` in the command above.
+
+Alternatively, refer to [Istio's artifacthub chart documentation](https://artifacthub.io/packages/search?org=istio&sort=relevance&page=1) for:
+
+- [Base parameters](https://artifacthub.io/packages/helm/istio-official/base?modal=values)
+- [Istiod parameters](https://artifacthub.io/packages/helm/istio-official/istiod?modal=values)
+- [Gateway parameters](https://artifacthub.io/packages/helm/istio-official/gateway?modal=values)
+- [CNI parameters](https://artifacthub.io/packages/helm/istio-official/cni?modal=values)
+- [ZTunnel parameters](https://artifacthub.io/packages/helm/istio-official/ztunnel?modal=values)
+
+## Installing the istioctl tool
+
+The `istioctl` tool is a configuration command line utility that allows service 
+operators to debug and diagnose Istio service mesh deployments.
+
+For installation steps, refer to the following [link](../docs/common/install-istioctl-tool.md).
+
+## Installing the Bookinfo Application
+
+You can use the `bookinfo` example application to explore service mesh features. 
+Using the `bookinfo` application, you can easily confirm that requests from a 
+web browser pass through the mesh and reach the application.
+
+For installation steps, refer to the following [link](../docs/common/install-bookinfo-app.md).
+
+## Creating and Configuring Gateways
+
+The Sail Operator does not deploy Ingress or Egress Gateways. Gateways are not 
+part of the control plane. As a security best-practice, Ingress and Egress 
+Gateways should be deployed in a different namespace than the namespace that 
+contains the control plane.
+
+You can deploy gateways using either the Gateway API or Gateway Injection methods. 
+
+For installation steps, refer to the following [link](../docs/common/create-and-configure-gateways.md).
+
+## Istio Addons Integrations
+
+Istio can be integrated with other software to provide additional functionality 
+(More information can be found in: https://istio.io/latest/docs/ops/integrations/). 
+The following addons are for demonstration or development purposes only and 
+should not be used in production environments:
+
+For installation steps, refer to the following [link](../docs/common/istio-addons-integrations.md).
+
+
+## Undeploying Istio and the Sail Operator
+
+### Deleting Istio
+
+    ```sh
+    $ kubectl -n istio-system delete istio default
+    ```
+
+### Deleting IstioCNI (in OpenShift cluster platform)
+
+    ```sh
+    $ kubectl -n istio-cni delete istiocni default
+    ```
+
+### Uninstall the Sail Operator using Helm
+
+    ```sh
+    $ helm uninstall sail-operator --namespace sail-operator
+    ```
+ 
+### Deleting the Project namespaces
+
+    ```sh
+    $ kubectl delete namespace istio-system
+    $ kubectl delete namespace istio-cni
+    $ kubectl delete namespace sail-operator
+    ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -260,7 +260,7 @@ When the `InPlace` strategy is used, the existing Istio control plane is replace
 
 Prerequisites:
 * Sail Operator is installed.
-* `istioctl` is installed.
+* `istioctl` is [installed](common/istio-addons-integrations.md).
 
 Steps:
 1. Create the `istio-system` namespace.
@@ -336,7 +336,7 @@ When the `RevisionBased` strategy is used, a new Istio control plane instance is
 
 Prerequisites:
 * Sail Operator is installed.
-* `istioctl` is installed.
+* `istioctl` is [installed](common/istio-addons-integrations.md).
 
 Steps:
 

--- a/docs/common/create-and-configure-gateways.md
+++ b/docs/common/create-and-configure-gateways.md
@@ -1,0 +1,84 @@
+## Creating and Configuring Gateways
+
+The Sail Operator does not deploy Ingress or Egress Gateways. Gateways are not 
+part of the control plane. As a security best-practice, Ingress and Egress 
+Gateways should be deployed in a different namespace than the namespace that 
+contains the control plane.
+
+You can deploy gateways using either the Gateway API or Gateway Injection methods. 
+
+
+### Option 1: Istio Gateway Injection
+
+Gateway Injection uses the same mechanisms as Istio sidecar injection to create 
+a gateway from a `Deployment` resource that is paired with a `Service` resource 
+that can be made accessible from outside the cluster. For more information, see 
+[Installing Gateways](https://preliminary.istio.io/latest/docs/setup/additional-setup/gateway/#deploying-a-gateway).
+
+To configure gateway injection with the `bookinfo` application, we have provided 
+a [sample gateway configuration](../chart/samples/ingress-gateway.yaml?raw=1) that should be applied in the namespace 
+where the application is installed:
+
+1. Create the `istio-ingressgateway` deployment and service:
+
+    ```sh
+    $ oc apply -f -n <app-namespace> ingress-gateway.yaml
+    ```
+
+2. Configure the `bookinfo` application with the new gateway:
+
+    ```sh
+    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/networking/bookinfo-gateway.yaml
+    ```
+
+3. On OpenShift, you can use a [Route](https://docs.openshift.com/container-platform/4.13/networking/routes/route-configuration.html) to expose the gateway externally: 
+
+    ```sh
+    $ oc expose service istio-ingressgateway
+    ```
+
+4. Finally, obtain the gateway host name and the URL of the product page:
+
+    ```sh
+    $ HOST=$(oc get route istio-ingressgateway -o jsonpath='{.spec.host}')
+    $ echo http://$HOST/productpage
+    ```
+
+Verify that the `productpage` is accessible from a web browser. 
+
+
+### Option 2: Kubernetes Gateway API
+
+Istio includes support for Kubernetes [Gateway API](https://gateway-api.sigs.k8s.io/) and intends to make it 
+the default API for [traffic management in the future](https://istio.io/latest/blog/2022/gateway-api-beta/). For more 
+information, see Istio's [Kubernetes Gateway API](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/) page.
+
+As of Kubernetes 1.28 and OpenShift 4.14, the Kubernetes Gateway API CRDs are 
+not available by default and must be enabled to be used. This can be done with 
+the command:
+
+```sh
+$ oc get crd gateways.gateway.networking.k8s.io &> /dev/null ||  { oc kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.0.0" | oc apply -f -; }
+```
+
+To configure `bookinfo` with a gateway using `Gateway API`:
+
+1. Create and configure a gateway using a `Gateway` and `HTTPRoute` resource:
+
+    ```sh
+    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/gateway-api/bookinfo-gateway.yaml
+    ```
+
+2. Retrieve the host, port and gateway URL:
+
+    ```sh
+    $ export INGRESS_HOST=$(oc get gtw bookinfo-gateway -o jsonpath='{.status.addresses[0].value}')
+    $ export INGRESS_PORT=$(oc get gtw bookinfo-gateway -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
+    $ export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
+    ```
+
+3. Obtain the `productpage` URL and check that you can visit it from a browser:
+
+   ```sh
+    $ echo "http://${GATEWAY_URL}/productpage"
+    ```

--- a/docs/common/install-bookinfo-app.md
+++ b/docs/common/install-bookinfo-app.md
@@ -1,0 +1,30 @@
+## Installing the Bookinfo Application
+
+You can use the `bookinfo` example application to explore service mesh features. 
+Using the `bookinfo` application, you can easily confirm that requests from a 
+web browser pass through the mesh and reach the application.
+
+The `bookinfo` application displays information about a book, similar to a 
+single catalog entry of an online book store. The application displays a page 
+that describes the book, lists book details (ISBN, number of pages, and other 
+information), and book reviews.
+
+The `bookinfo` application is exposed through the mesh, and the mesh configuration 
+determines how the microservices comprising the application are used to serve 
+requests. The review information comes from one of three services: `reviews-v1`, 
+`reviews-v2` or `reviews-v3`. If you deploy the `bookinfo` application without 
+defining the `reviews` virtual service, then the mesh uses a round-robin rule to 
+route requests to a service.
+
+By deploying the `reviews` virtual service, you can specify a different behavior. 
+For example, you can specify that if a user logs into the `bookinfo` application, 
+then the mesh routes requests to the `reviews-v2` service, and the application 
+displays reviews with black stars. If a user does not log into the `bookinfo` 
+application, then the mesh routes requests to the `reviews-v3` service, and the 
+application displays reviews with red stars.
+
+For more information, see [Bookinfo Application](https://istio.io/latest/docs/examples/bookinfo/) in the upstream Istio documentation.
+
+After following the instructions for [Deploying the application](https://istio.io/latest/docs/examples/bookinfo/#start-the-application-services), **you 
+will need to create and configure a gateway** for the `bookinfo` application to 
+be accessible outside the cluster.

--- a/docs/common/install-istioctl-tool.md
+++ b/docs/common/install-istioctl-tool.md
@@ -1,0 +1,52 @@
+## Installing the istioctl tool
+
+The `istioctl` tool is a configuration command line utility that allows service 
+operators to debug and diagnose Istio service mesh deployments.
+
+
+### Prerequisites
+
+Use an `istioctl` version that is the same version as the Istio control plane 
+for the Service Mesh deployment. See [Istio Releases](https://github.com/istio/istio/releases) for a list of valid 
+releases, including Beta releases.
+
+
+### Procedure
+
+1. Confirm if you have `istioctl` installed, and if so which version, by running 
+the following command at the terminal:
+
+    ```sh
+    $ istioctl version
+    ```
+
+2. Confirm the version of Istio you are using by running the following command 
+at the terminal:
+
+    ```sh
+    $ oc -n istio-system get istio
+    ```
+
+3. Install `istioctl` by running the following command at the terminal: 
+
+    ```sh
+    $ curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=<version> sh -
+    ```
+    Replace `<version>` with the version of Istio you are using.
+
+4. Put the `istioctl` directory on path by running the following command at the terminal:
+  
+    ```sh
+    $ export PATH=$HOME/.istioctl/bin:$PATH
+    ```
+
+5. Confirm that the `istioctl` client version and the Istio control plane 
+version now match (or are within one version) by running the following command
+at the terminal:
+
+    ```sh
+    $ istioctl version
+    ```
+
+
+*Note*: `istioctl install` is not supported. The Sail Operator installs Istio.

--- a/docs/common/istio-addons-integrations.md
+++ b/docs/common/istio-addons-integrations.md
@@ -1,0 +1,119 @@
+## Istio Addons Integrations
+
+Istio can be integrated with other software to provide additional functionality 
+(More information can be found in: https://istio.io/latest/docs/ops/integrations/). 
+The following addons are for demonstration or development purposes only and 
+should not be used in production environments:
+
+
+### Prometheus
+
+`Prometheus` is an open-source systems monitoring and alerting toolkit. You can 
+use `Prometheus` with the Sail Operator to keep an eye on how healthy Istio and 
+the apps in the service mesh are, for more information, see [Prometheus](https://istio.io/latest/docs/ops/integrations/prometheus/). 
+
+To install Prometheus, perform the following steps:
+
+1. Deploy `Prometheus`:
+
+    ```sh
+    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/prometheus.yaml
+    ```
+2. Access to `Prometheus`console:
+
+    * Expose the `Prometheus` service externally:
+    
+    ```sh
+    $ oc expose service prometheus -n istio-system
+    ```
+    * Get the route of the service and open the URL in the web browser
+    
+    ```sh
+    $ oc get route prometheus -o jsonpath='{.spec.host}' -n istio-system
+    ```
+
+
+### Grafana
+
+`Grafana` is an open-source platform for monitoring and observability. You can 
+use `Grafana` with the Sail Operator to configure dashboards for istio, see 
+[Grafana](https://istio.io/latest/docs/ops/integrations/grafana/) for more information. 
+
+To install Grafana, perform the following steps:
+
+1. Deploy `Grafana`:
+    
+    ```sh
+    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/grafana.yaml
+    ```
+
+2. Access to `Grafana`console:
+
+    * Expose the `Grafana` service externally
+    
+    ```sh
+    $ oc expose service grafana -n istio-system
+    ```
+    * Get the route of the service and open the URL in the web browser
+    
+    ```sh
+    $ oc get route grafana -o jsonpath='{.spec.host}' -n istio-system
+    ```
+
+
+### Jaeger
+
+`Jaeger` is an open-source end-to-end distributed tracing system. You can use 
+`Jaeger` with the Sail Operator to monitor and troubleshoot transactions in 
+complex distributed systems, see [Jaeger](https://istio.io/latest/docs/ops/integrations/jaeger/) for more information. 
+
+To install Jaeger, perform the following steps:
+
+1. Deploy `Jaeger`:
+    
+    ```sh
+    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/jaeger.yaml
+    ```
+2. Access to `Jaeger` console:
+
+    * Expose the `Jaeger` service externally:
+
+        ```sh
+        $ oc expose svc/tracing -n istio-system
+        ```
+
+    * Get the route of the service and open the URL in the web browser
+
+        ```sh
+        $ oc get route tracing -o jsonpath='{.spec.host}' -n istio-system
+        ```
+*Note*: if you want to see some traces you can refresh several times the product 
+page of bookinfo app to start generating traces.
+
+
+### Kiali
+
+`Kiali` is an open-source project that provides a graphical user interface to 
+visualize the service mesh topology, see [Kiali](https://istio.io/latest/docs/ops/integrations/kiali/) for more information. 
+
+To install Kiali, perform the following steps:
+
+1. Deploy `Kiali`:
+    
+    ```sh
+    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/kiali.yaml
+    ```
+
+2. Access to `Kiali` console:
+
+    * Expose the `Kiali` service externally:
+
+        ```sh
+        $ oc expose service kiali -n istio-system
+        ```
+
+    * Get the route of the service and open the URL in the web browser
+
+        ```sh
+        $ oc get route kiali -o jsonpath='{.spec.host}' -n istio-system
+        ```


### PR DESCRIPTION
- Add instructions on deploying the sail-operator by using the helm charts defined within the repository.
- Rearrange the following guides to avoid duplication.
  Place them within 'docs/common' directory and reference them from the relevant docs guides.
    - create-and-configure-gateways.md
    - install-bookinfo-app.md
    - install-istioctl-tool.md
    - istio-addons-integrations.md

Fixes https://github.com/istio-ecosystem/sail-operator/issues/314