### PR TITLE
Increase run operator-sdk run bundle timeout in OLM deploy

### DIFF
--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -237,7 +237,7 @@ if [ "${SKIP_BUILD}" == "false" ]; then
     # Create operator namespace
     ${COMMAND} create ns "${NAMESPACE}" || echo "Creation of namespace ${NAMESPACE} failed with the message: $?"
     # Deploy the operator using OLM
-    ${OPERATOR_SDK} run bundle "${BUNDLE_IMG}" -n "${NAMESPACE}" --skip-tls
+    ${OPERATOR_SDK} run bundle "${BUNDLE_IMG}" -n "${NAMESPACE}" --skip-tls --timeout 5m
 
     # Wait for the operator to be ready
     ${COMMAND} wait --for=condition=available deployment/"${DEPLOYMENT_NAME}" -n "${NAMESPACE}" --timeout=5m


### PR DESCRIPTION
Fixes #344

Checking the failure seems to be that we are hitting the default timeout (2m) sometimes when we deploy the operator using operator-sdk in the olm kind e2e tests run.

```
time="2024-09-18T10:57:26Z" level=info msg="Creating a File-Based Catalog of the bundle \"localhost:5000/sail-operator-bundle:v0.2.0\""
time="2024-09-18T10:57:26Z" level=info msg="Generated a valid File-Based Catalog"
time="2024-09-18T10:57:33Z" level=info msg="Created registry pod: localhost-5000-sail-operator-bundle-v0-2-0"
time="2024-09-18T10:57:34Z" level=info msg="Created CatalogSource: sailoperator-catalog"
time="2024-09-18T10:57:34Z" level=info msg="OperatorGroup \"operator-sdk-og\" created"
time="2024-09-18T10:57:34Z" level=info msg="Created Subscription: sailoperator-v0-2-0-sub"
time="2024-09-18T10:59:17Z" level=fatal msg="Failed to run bundle: install plan is not available for the subscription sailoperator-v0-2-0-sub: context deadline exceeded\n"
```

I'm increasing the timeout to wait more time for the run bundle to finish