### PR TITLE
Update/Fix Istioctl links and docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -260,7 +260,7 @@ When the `InPlace` strategy is used, the existing Istio control plane is replace
 
 Prerequisites:
 * Sail Operator is installed.
-* `istioctl` is [installed](common/istio-addons-integrations.md).
+* `istioctl` is [installed](common/install-istioctl-tool.md).
 
 Steps:
 1. Create the `istio-system` namespace.
@@ -336,7 +336,7 @@ When the `RevisionBased` strategy is used, a new Istio control plane instance is
 
 Prerequisites:
 * Sail Operator is installed.
-* `istioctl` is [installed](common/istio-addons-integrations.md).
+* `istioctl` is [installed](common/install-istioctl-tool.md).
 
 Steps:
 
@@ -476,7 +476,7 @@ You can use the Sail Operator and the Sail CRDs to manage a multi-cluster Istio 
 
 Each deployment model requires you to install the Sail Operator and the Sail CRDs to every cluster that is part of the mesh.
 
-- Install [istioctl](https://istio.io/latest/docs/setup/install/istioctl) and have it included in your `$PATH`.
+- Install [istioctl](common/install-istioctl-tool.md).
 - Two kubernetes clusters with external lb support. (If using kind, `cloud-provider-kind` is running in the background)
 - kubeconfig file with a context for each cluster.
 

--- a/docs/common/install-istioctl-tool.md
+++ b/docs/common/install-istioctl-tool.md
@@ -8,7 +8,9 @@ operators to debug and diagnose Istio service mesh deployments.
 
 Use an `istioctl` version that is the same version as the Istio control plane 
 for the Service Mesh deployment. See [Istio Releases](https://github.com/istio/istio/releases) for a list of valid 
-releases, including Beta releases.
+releases, including Beta releases. 
+
+These instructions assume that the Sail Operator has installed `Istio` in the `istio-system` namespace.
 
 
 ### Procedure
@@ -47,6 +49,6 @@ at the terminal:
     ```sh
     $ istioctl version
     ```
-
+For more information on usage, see the [Istioctl documentation](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/).
 
 *Note*: `istioctl install` is not supported. The Sail Operator installs Istio.

--- a/docs/common/install-istioctl-tool.md
+++ b/docs/common/install-istioctl-tool.md
@@ -10,9 +10,6 @@ Use an `istioctl` version that is the same version as the Istio control plane
 for the Service Mesh deployment. See [Istio Releases](https://github.com/istio/istio/releases) for a list of valid 
 releases, including Beta releases. 
 
-These instructions assume that the Sail Operator has installed `Istio` in the `istio-system` namespace.
-
-
 ### Procedure
 
 1. Confirm if you have `istioctl` installed, and if so which version, by running 
@@ -26,7 +23,7 @@ the following command at the terminal:
 at the terminal:
 
     ```sh
-    $ oc -n istio-system get istio
+    $ oc get istio
     ```
 
 3. Install `istioctl` by running the following command at the terminal: 


### PR DESCRIPTION
A few minor updates to the user doc to update/fix istioctl links to point to the install-istioctl-tool.md, which provides istioctl installation instructions with the assumption that the sail-operator has installed Istio (and not istioctl).