### PR TITLE
Show name of active revision in Istio/RemoteIstio status

### DIFF
--- a/api/v1alpha1/istio_types.go
+++ b/api/v1alpha1/istio_types.go
@@ -114,6 +114,9 @@ type IstioStatus struct {
 	// Reports the current state of the object.
 	State IstioConditionReason `json:"state,omitempty"`
 
+	// The name of the active revision.
+	ActiveRevisionName string `json:"activeRevisionName,omitempty"`
+
 	// Reports information about the underlying IstioRevisions.
 	Revisions RevisionSummary `json:"revisions,omitempty"`
 }
@@ -238,7 +241,8 @@ const (
 // +kubebuilder:printcolumn:name="Revisions",type="string",JSONPath=".status.revisions.total",description="Total number of IstioRevision objects currently associated with this object."
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.revisions.ready",description="Number of revisions that are ready."
 // +kubebuilder:printcolumn:name="In use",type="string",JSONPath=".status.revisions.inUse",description="Number of revisions that are currently being used by workloads."
-// +kubebuilder:printcolumn:name="Active Revision",type="string",JSONPath=".status.state",description="The current state of the active revision."
+// +kubebuilder:printcolumn:name="Active Revision",type="string",JSONPath=".status.activeRevisionName",description="The name of the currently active revision."
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="The current state of the active revision."
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.version",description="The version of the control plane installation."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the object"
 

--- a/api/v1alpha1/remoteistio_types.go
+++ b/api/v1alpha1/remoteistio_types.go
@@ -71,6 +71,9 @@ type RemoteIstioStatus struct {
 	// Reports the current state of the object.
 	State RemoteIstioConditionReason `json:"state,omitempty"`
 
+	// The name of the active revision.
+	ActiveRevisionName string `json:"activeRevisionName,omitempty"`
+
 	// Reports information about the underlying IstioRevisions.
 	Revisions RevisionSummary `json:"revisions,omitempty"`
 }
@@ -183,7 +186,8 @@ const (
 // +kubebuilder:printcolumn:name="Revisions",type="string",JSONPath=".status.revisions.total",description="Total number of IstioRevision objects currently associated with this object."
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.revisions.ready",description="Number of revisions that are ready."
 // +kubebuilder:printcolumn:name="In use",type="string",JSONPath=".status.revisions.inUse",description="Number of revisions that are currently being used by workloads."
-// +kubebuilder:printcolumn:name="Active Revision",type="string",JSONPath=".status.state",description="The current state of the active revision."
+// +kubebuilder:printcolumn:name="Active Revision",type="string",JSONPath=".status.activeRevisionName",description="The name of the currently active revision."
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="The current state of the active revision."
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.version",description="The version of the control plane installation."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the object"
 

--- a/bundle/manifests/sailoperator.io_istios.yaml
+++ b/bundle/manifests/sailoperator.io_istios.yaml
@@ -30,9 +30,13 @@ spec:
       jsonPath: .status.revisions.inUse
       name: In use
       type: string
+    - description: The name of the currently active revision.
+      jsonPath: .status.activeRevisionName
+      name: Active Revision
+      type: string
     - description: The current state of the active revision.
       jsonPath: .status.state
-      name: Active Revision
+      name: Status
       type: string
     - description: The version of the control plane installation.
       jsonPath: .spec.version
@@ -8001,6 +8005,9 @@ spec:
           status:
             description: IstioStatus defines the observed state of Istio
             properties:
+              activeRevisionName:
+                description: The name of the active revision.
+                type: string
               conditions:
                 description: Represents the latest available observations of the object's
                   current state.

--- a/bundle/manifests/sailoperator.io_remoteistios.yaml
+++ b/bundle/manifests/sailoperator.io_remoteistios.yaml
@@ -30,9 +30,13 @@ spec:
       jsonPath: .status.revisions.inUse
       name: In use
       type: string
+    - description: The name of the currently active revision.
+      jsonPath: .status.activeRevisionName
+      name: Active Revision
+      type: string
     - description: The current state of the active revision.
       jsonPath: .status.state
-      name: Active Revision
+      name: Status
       type: string
     - description: The version of the control plane installation.
       jsonPath: .spec.version
@@ -7996,6 +8000,9 @@ spec:
           status:
             description: RemoteIstioStatus defines the observed state of RemoteIstio
             properties:
+              activeRevisionName:
+                description: The name of the active revision.
+                type: string
               conditions:
                 description: Represents the latest available observations of the object's
                   current state.

--- a/chart/crds/sailoperator.io_istios.yaml
+++ b/chart/crds/sailoperator.io_istios.yaml
@@ -30,9 +30,13 @@ spec:
       jsonPath: .status.revisions.inUse
       name: In use
       type: string
+    - description: The name of the currently active revision.
+      jsonPath: .status.activeRevisionName
+      name: Active Revision
+      type: string
     - description: The current state of the active revision.
       jsonPath: .status.state
-      name: Active Revision
+      name: Status
       type: string
     - description: The version of the control plane installation.
       jsonPath: .spec.version
@@ -8001,6 +8005,9 @@ spec:
           status:
             description: IstioStatus defines the observed state of Istio
             properties:
+              activeRevisionName:
+                description: The name of the active revision.
+                type: string
               conditions:
                 description: Represents the latest available observations of the object's
                   current state.

--- a/chart/crds/sailoperator.io_remoteistios.yaml
+++ b/chart/crds/sailoperator.io_remoteistios.yaml
@@ -30,9 +30,13 @@ spec:
       jsonPath: .status.revisions.inUse
       name: In use
       type: string
+    - description: The name of the currently active revision.
+      jsonPath: .status.activeRevisionName
+      name: Active Revision
+      type: string
     - description: The current state of the active revision.
       jsonPath: .status.state
-      name: Active Revision
+      name: Status
       type: string
     - description: The version of the control plane installation.
       jsonPath: .spec.version
@@ -7996,6 +8000,9 @@ spec:
           status:
             description: RemoteIstioStatus defines the observed state of RemoteIstio
             properties:
+              activeRevisionName:
+                description: The name of the active revision.
+                type: string
               conditions:
                 description: Represents the latest available observations of the object's
                   current state.

--- a/controllers/istio/istio_controller.go
+++ b/controllers/istio/istio_controller.go
@@ -207,6 +207,7 @@ func (r *Reconciler) determineStatus(ctx context.Context, istio *v1alpha1.Istio,
 		})
 		status.State = v1alpha1.IstioReasonReconcileError
 	} else {
+		status.ActiveRevisionName = getActiveRevisionName(istio)
 		rev, err := r.getActiveRevision(ctx, istio)
 		if apierrors.IsNotFound(err) {
 			revisionNotFound := func(conditionType v1alpha1.IstioConditionType) v1alpha1.IstioCondition {

--- a/controllers/istio/istio_controller_test.go
+++ b/controllers/istio/istio_controller_test.go
@@ -367,6 +367,7 @@ func TestDetermineStatus(t *testing.T) {
 						Message: "ready message",
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 				Revisions: v1alpha1.RevisionSummary{
 					Total: 2,
 					Ready: 1,
@@ -398,6 +399,7 @@ func TestDetermineStatus(t *testing.T) {
 						Status: metav1.ConditionTrue,
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 				Revisions: v1alpha1.RevisionSummary{
 					Total: 3,
 					Ready: 2,
@@ -425,6 +427,7 @@ func TestDetermineStatus(t *testing.T) {
 						Message: "active IstioRevision not found",
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 			},
 		},
 		{
@@ -455,7 +458,8 @@ func TestDetermineStatus(t *testing.T) {
 						Message: "failed to get active IstioRevision: get failed: simulated error",
 					},
 				},
-				Revisions: v1alpha1.RevisionSummary{},
+				ActiveRevisionName: istioKey.Name,
+				Revisions:          v1alpha1.RevisionSummary{},
 			},
 		},
 		{
@@ -486,6 +490,7 @@ func TestDetermineStatus(t *testing.T) {
 						Message: "active IstioRevision not found",
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 				Revisions: v1alpha1.RevisionSummary{
 					Total: -1,
 					Ready: -1,
@@ -587,6 +592,7 @@ func TestUpdateStatus(t *testing.T) {
 						Message: "active IstioRevision not found",
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 				Revisions: v1alpha1.RevisionSummary{
 					Total: -1,
 					Ready: -1,
@@ -625,6 +631,7 @@ func TestUpdateStatus(t *testing.T) {
 							LastTransitionTime: *oneMinuteAgo,
 						},
 					},
+					ActiveRevisionName: istioKey.Name,
 				},
 			},
 			revisions: []v1alpha1.IstioRevision{
@@ -673,6 +680,7 @@ func TestUpdateStatus(t *testing.T) {
 						Message: "ready message",
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 			},
 			disallowWrites: true,
 			wantErr:        false,

--- a/controllers/remoteistio/remoteistio_controller.go
+++ b/controllers/remoteistio/remoteistio_controller.go
@@ -206,6 +206,7 @@ func (r *Reconciler) determineStatus(ctx context.Context, istio *v1alpha1.Remote
 		})
 		status.State = v1alpha1.RemoteIstioReasonReconcileError
 	} else {
+		status.ActiveRevisionName = getActiveRevisionName(istio)
 		rev, err := r.getActiveRevision(ctx, istio)
 		if apierrors.IsNotFound(err) {
 			revisionNotFound := func(conditionType v1alpha1.RemoteIstioConditionType) v1alpha1.RemoteIstioCondition {

--- a/controllers/remoteistio/remoteistio_controller_test.go
+++ b/controllers/remoteistio/remoteistio_controller_test.go
@@ -367,6 +367,7 @@ func TestDetermineStatus(t *testing.T) {
 						Message: "ready message",
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 				Revisions: v1alpha1.RevisionSummary{
 					Total: 2,
 					Ready: 1,
@@ -398,6 +399,7 @@ func TestDetermineStatus(t *testing.T) {
 						Status: metav1.ConditionTrue,
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 				Revisions: v1alpha1.RevisionSummary{
 					Total: 3,
 					Ready: 2,
@@ -425,6 +427,7 @@ func TestDetermineStatus(t *testing.T) {
 						Message: "active IstioRevision not found",
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 			},
 		},
 		{
@@ -455,7 +458,8 @@ func TestDetermineStatus(t *testing.T) {
 						Message: "failed to get active IstioRevision: get failed: simulated error",
 					},
 				},
-				Revisions: v1alpha1.RevisionSummary{},
+				ActiveRevisionName: istioKey.Name,
+				Revisions:          v1alpha1.RevisionSummary{},
 			},
 		},
 		{
@@ -486,6 +490,7 @@ func TestDetermineStatus(t *testing.T) {
 						Message: "active IstioRevision not found",
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 				Revisions: v1alpha1.RevisionSummary{
 					Total: -1,
 					Ready: -1,
@@ -587,6 +592,7 @@ func TestUpdateStatus(t *testing.T) {
 						Message: "active IstioRevision not found",
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 				Revisions: v1alpha1.RevisionSummary{
 					Total: -1,
 					Ready: -1,
@@ -625,6 +631,7 @@ func TestUpdateStatus(t *testing.T) {
 							LastTransitionTime: *oneMinuteAgo,
 						},
 					},
+					ActiveRevisionName: istioKey.Name,
 				},
 			},
 			revisions: []v1alpha1.IstioRevision{
@@ -673,6 +680,7 @@ func TestUpdateStatus(t *testing.T) {
 						Message: "ready message",
 					},
 				},
+				ActiveRevisionName: istioKey.Name,
 			},
 			disallowWrites: true,
 			wantErr:        false,

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -928,6 +928,7 @@ _Appears in:_
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this Istio object. It corresponds to the object's generation, which is updated on mutation by the API Server. The information in the status pertains to this particular generation of the object. |  |  |
 | `conditions` _[IstioCondition](#istiocondition) array_ | Represents the latest available observations of the object's current state. |  |  |
 | `state` _[IstioConditionReason](#istioconditionreason)_ | Reports the current state of the object. |  |  |
+| `activeRevisionName` _string_ | The name of the active revision. |  |  |
 | `revisions` _[RevisionSummary](#revisionsummary)_ | Reports information about the underlying IstioRevisions. |  |  |
 
 
@@ -2533,6 +2534,7 @@ _Appears in:_
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this RemoteIstio object. It corresponds to the object's generation, which is updated on mutation by the API Server. The information in the status pertains to this particular generation of the object. |  |  |
 | `conditions` _[RemoteIstioCondition](#remoteistiocondition) array_ | Represents the latest available observations of the object's current state. |  |  |
 | `state` _[RemoteIstioConditionReason](#remoteistioconditionreason)_ | Reports the current state of the object. |  |  |
+| `activeRevisionName` _string_ | The name of the active revision. |  |  |
 | `revisions` _[RevisionSummary](#revisionsummary)_ | Reports information about the underlying IstioRevisions. |  |  |
 
 


### PR DESCRIPTION
This helps users know the name of the currently active revision. Previously, the users had to just know that for the InPlace strategy, the name of the revision is the same as the name of the Istio/RemoteIstio resource, and for the RevisionBased strategy, the revision name is the Istio/RemoteIstio name + version.

Examples:
```
$ kubectl get istio
NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
default   1           1       0        default           Healthy   v1.23.0   6m33s

$ kubectl get istio
NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS           VERSION   AGE
default   1           0       0        default-v1-23-0   IstiodNotReady   v1.23.0   7m12s
```

