### PR TITLE
Use Kubernetes defaults for imagePullPolicy

### DIFF
--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/sail-operator:0.2-latest
-    createdAt: "2024-09-19T14:41:31Z"
+    createdAt: "2024-09-22T10:00:56Z"
     description: Experimental operator for installing Istio service mesh
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -643,7 +643,6 @@ spec:
                 - --logtostderr=true
                 - --v=0
                 image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
-                imagePullPolicy: Always
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -668,7 +667,6 @@ spec:
                 command:
                 - /manager
                 image: quay.io/maistra-dev/sail-operator:0.2-latest
-                imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -54,7 +54,9 @@ spec:
         - --logtostderr=true
         - --v=0
         image: {{ .Values.proxy.image }}
+{{- if .Values.proxy.imagePullPolicy }}
         imagePullPolicy: {{ .Values.proxy.imagePullPolicy }}
+{{- end }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -81,7 +83,9 @@ spec:
         command:
         - /manager
         image: {{ .Values.image }}
+{{- if .Values.proxy.imagePullPolicy }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+{{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -43,10 +43,12 @@ csv:
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
 image: quay.io/maistra-dev/sail-operator:0.2-latest
-imagePullPolicy: Always
+# We're commenting out the imagePullPolicy to use k8s defaults
+# imagePullPolicy: Always
 proxy:
   image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
-  imagePullPolicy: Always
+  # We're commenting out the imagePullPolicy to use k8s defaults
+  # imagePullPolicy: IfNotPresent
 
 # setting this to true will add resources required to generate the bundle using operator-sdk
 bundleGeneration: false


### PR DESCRIPTION
As per [Marko's comment on another PR](https://github.com/istio-ecosystem/sail-operator/pull/339#discussion_r1761227825). I think this makes sense.