### PR TITLE
Add CODE-OF-CONDUCT to the project

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,7 @@
+# Sail Operator Community Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+All members of the Sail Operator community must abide by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+Only by respecting each other can we develop a productive, collaborative community.
+


### PR DESCRIPTION
In order to follow the project community standards, adding the CODE-OF-CONDACT to the repository.