### PR TITLE
Add ability to specify resources in helm chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -101,11 +101,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: {{ or .Values.operator.resources.limits.cpu "500m" }}
-            memory: {{ or .Values.operator.resources.limits.memory "512Mi" }}
+            cpu: {{ .Values.operator.resources.limits.cpu }}
+            memory: {{ .Values.operator.resources.limits.memory }}
           requests:
-            cpu: {{ or .Values.operator.resources.requests.cpu "10m" }}
-            memory: {{ or .Values.operator.resources.requests.memory "64Mi" }}
+            cpu: {{ .Values.operator.resources.requests.cpu }}
+            memory: {{ .Values.operator.resources.requests.memory }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -64,11 +64,11 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 500m
-            memory: 128Mi
+            cpu: {{ or .Values.proxy.resources.limits.cpu "500m" }}
+            memory: {{ or .Values.proxy.resources.limits.memory "128Mi" }}
           requests:
-            cpu: 5m
-            memory: 64Mi
+            cpu: {{ or .Values.proxy.resources.requests.cpu "5m" }}
+            memory: {{ or .Values.proxy.resources.requests.memory "64Mi" }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -101,11 +101,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: {{ or .Values.operator.resources.limits.cpu "500m" }}
+            memory: {{ or .Values.operator.resources.limits.memory "512Mi" }}
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: {{ or .Values.operator.resources.requests.cpu "10m" }}
+            memory: {{ or .Values.operator.resources.requests.memory "64Mi" }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -64,11 +64,11 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: {{ or .Values.proxy.resources.limits.cpu "500m" }}
-            memory: {{ or .Values.proxy.resources.limits.memory "128Mi" }}
+            cpu: {{ .Values.proxy.resources.limits.cpu }}
+            memory: {{ .Values.proxy.resources.limits.memory }}
           requests:
-            cpu: {{ or .Values.proxy.resources.requests.cpu "5m" }}
-            memory: {{ or .Values.proxy.resources.requests.memory "64Mi" }}
+            cpu: {{ .Values.proxy.resources.requests.cpu }}
+            memory: {{ .Values.proxy.resources.requests.memory }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -49,6 +49,21 @@ proxy:
   image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
   # We're commenting out the imagePullPolicy to use k8s defaults
   # imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 5m
+      memory: 64Mi
+operator:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
 
 # setting this to true will add resources required to generate the bundle using operator-sdk
 bundleGeneration: false


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [x] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

This PR adds the ability to specify `cpu/memory` resource `requests` and `limits` for the `proxy` and `operator` containers. Configurable resources are an important part of any production-ready helm chart.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes https://github.com/istio-ecosystem/sail-operator/issues/358

#### Special notes for your reviewer:
```text
N/A
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds ability to configure container resources.
```

#### Additional documentation:
```text
N/A
```

#### Does this PR introduce a breaking change?
```text
N/A
```

#### Other information:
```text
N/A
```
