### PR TITLE
Adding default value for IP_FAMILY

### DIFF
--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -120,6 +120,7 @@ initialize_variables() {
   ISTIOCTL="${ISTIOCTL:-"istioctl"}"
   LOCALBIN="${LOCALBIN:-${HOME}/bin}"
   OPERATOR_SDK=${LOCALBIN}/operator-sdk
+  IP_FAMILY=${IP_FAMILY:-ipv4}
 
   if [ "${OCP}" == "true" ]; then
     COMMAND="oc"


### PR DESCRIPTION
This fixing ./tests/e2e/common-operator-integ-suite.sh: line 287: IP_FAMILY: unbound variable
