### PR TITLE
Simplify supportedversion.go and add unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ go 1.22.0
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/elastic/crd-ref-docs v0.1.0
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
@@ -15,6 +16,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.17.3
 	github.com/onsi/gomega v1.33.1
 	github.com/prometheus/common v0.55.0
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/mod v0.19.0
 	golang.org/x/text v0.16.0
 	golang.org/x/tools v0.23.0
@@ -38,7 +40,6 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
@@ -121,6 +122,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc6 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/hack/update-istio.sh
+++ b/hack/update-istio.sh
@@ -110,22 +110,19 @@ function update_latest() {
     done
     echo
 
-    FULL_VERSION=$(curl -sSfL "${URL}")
-    echo Full version: "${FULL_VERSION}"
-
-    PARTIAL_VERSION="${FULL_VERSION%.*}"
-    echo Partial version: "${PARTIAL_VERSION}"
+    VERSION=$(curl -sSfL "${URL}")
+    echo Version: "${VERSION}"
 
     yq -i '
-        (.versions[] | select(.name == "latest") | .version) = "'"${PARTIAL_VERSION}"'" |
+        (.versions[] | select(.name == "latest") | .version) = "'"${VERSION}"'" |
         (.versions[] | select(.name == "latest") | .commit) = "'"${COMMIT}"'" |
         (.versions[] | select(.name == "latest") | .charts) = [
-            "https://storage.googleapis.com/istio-build/dev/'"${FULL_VERSION}"'/helm/base-'"${FULL_VERSION}"'.tgz",
-            "https://storage.googleapis.com/istio-build/dev/'"${FULL_VERSION}"'/helm/cni-'"${FULL_VERSION}"'.tgz",
-            "https://storage.googleapis.com/istio-build/dev/'"${FULL_VERSION}"'/helm/gateway-'"${FULL_VERSION}"'.tgz",
-            "https://storage.googleapis.com/istio-build/dev/'"${FULL_VERSION}"'/helm/istiod-'"${FULL_VERSION}"'.tgz",
-            "https://storage.googleapis.com/istio-build/dev/'"${FULL_VERSION}"'/helm/istiod-remote-'"${FULL_VERSION}"'.tgz",
-            "https://storage.googleapis.com/istio-build/dev/'"${FULL_VERSION}"'/helm/ztunnel-'"${FULL_VERSION}"'.tgz"
+            "https://storage.googleapis.com/istio-build/dev/'"${VERSION}"'/helm/base-'"${VERSION}"'.tgz",
+            "https://storage.googleapis.com/istio-build/dev/'"${VERSION}"'/helm/cni-'"${VERSION}"'.tgz",
+            "https://storage.googleapis.com/istio-build/dev/'"${VERSION}"'/helm/gateway-'"${VERSION}"'.tgz",
+            "https://storage.googleapis.com/istio-build/dev/'"${VERSION}"'/helm/istiod-'"${VERSION}"'.tgz",
+            "https://storage.googleapis.com/istio-build/dev/'"${VERSION}"'/helm/istiod-remote-'"${VERSION}"'.tgz",
+            "https://storage.googleapis.com/istio-build/dev/'"${VERSION}"'/helm/ztunnel-'"${VERSION}"'.tgz"
         ]' "${VERSIONS_YAML_FILE}"
 }
 

--- a/pkg/test/util/supportedversion/supportedversion.go
+++ b/pkg/test/util/supportedversion/supportedversion.go
@@ -17,15 +17,15 @@ package supportedversion
 import (
 	"os"
 	"path/filepath"
-	"regexp"
-	"strconv"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
 	"gopkg.in/yaml.v3"
 )
 
 var (
 	List    []VersionInfo
+	Map     map[string]VersionInfo
 	Default string
 	Old     string
 	New     string
@@ -43,40 +43,28 @@ func init() {
 		panic(err)
 	}
 
+	List, Default, Old, New = mustParseVersionsYaml(versionsBytes)
+
+	Map = make(map[string]VersionInfo)
+	for _, v := range List {
+		Map[v.Name] = v
+	}
+}
+
+func mustParseVersionsYaml(yamlBytes []byte) (list []VersionInfo, defaultVersion string, oldVersion string, newVersion string) {
 	versions := Versions{}
-	err = yaml.Unmarshal(versionsBytes, &versions)
+	err := yaml.Unmarshal(yamlBytes, &versions)
 	if err != nil {
 		panic(err)
 	}
 
-	// Major, Minor and Patch needs to be set from parsing the version string
-	for i := range versions.Versions {
-		v := &versions.Versions[i]
-		v.Major, v.Minor, v.Patch = parseVersion(v.Version)
+	list = versions.Versions
+	defaultVersion = list[0].Name
+	if len(list) > 1 {
+		oldVersion = list[1].Name
 	}
-
-	List = versions.Versions
-	Default = List[0].Name
-	if len(List) > 1 {
-		Old = List[1].Name
-	}
-	New = List[0].Name
-}
-
-func parseVersion(version string) (int, int, int) {
-	// The version can have this formats: "1.22.2", "1.23.0-rc.1", "1.24-alpha"
-	re := regexp.MustCompile(`^(\d+)\.(\d+)\.?(\d*)`)
-
-	matches := re.FindStringSubmatch(version)
-	if len(matches) < 4 {
-		return 0, 0, 0
-	}
-
-	major, _ := strconv.Atoi(matches[1])
-	minor, _ := strconv.Atoi(matches[2])
-	patch, _ := strconv.Atoi(matches[3])
-
-	return major, minor, patch
+	newVersion = list[0].Name
+	return list, defaultVersion, oldVersion, newVersion
 }
 
 type Versions struct {
@@ -84,13 +72,10 @@ type Versions struct {
 }
 
 type VersionInfo struct {
-	Name    string   `json:"name"`
-	Version string   `json:"version"`
-	Major   int      `json:"major"`
-	Minor   int      `json:"minor"`
-	Patch   int      `json:"patch"`
-	Repo    string   `json:"repo"`
-	Branch  string   `json:"branch,omitempty"`
-	Commit  string   `json:"commit"`
-	Charts  []string `json:"charts,omitempty"`
+	Name    string          `json:"name"`
+	Version *semver.Version `json:"version"`
+	Repo    string          `json:"repo"`
+	Branch  string          `json:"branch,omitempty"`
+	Commit  string          `json:"commit"`
+	Charts  []string        `json:"charts,omitempty"`
 }

--- a/pkg/test/util/supportedversion/supportedversion_test.go
+++ b/pkg/test/util/supportedversion/supportedversion_test.go
@@ -1,0 +1,78 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package supportedversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	// no need to call init(), since it's called automatically
+	assert.True(t, len(List) > 0, "List should not be empty")
+	assert.True(t, len(Map) > 0, "M should not be empty")
+	assert.True(t, Default != "", "Default should not be empty")
+	assert.True(t, Old != "", "Default should not be empty")
+	assert.True(t, New != "", "Default should not be empty")
+
+	assert.Equal(t, len(List), len(Map), "Map should be same size as List")
+	for _, vi := range List {
+		assert.Equal(t, vi, Map[vi.Name])
+	}
+}
+
+func TestParseVersionsYaml_ValidYaml(t *testing.T) {
+	yamlBytes := []byte(`
+versions:
+  - name: "1.0.0"
+    repo: "repo1"
+    commit: "commit1"
+  - name: "2.0.0"
+    repo: "repo2"
+    commit: "commit2"
+`)
+
+	list, defaultVersion, oldVersion, newVersion := mustParseVersionsYaml(yamlBytes)
+
+	assert.Len(t, list, 2)
+	assert.Equal(t, "1.0.0", defaultVersion)
+	assert.Equal(t, "2.0.0", oldVersion)
+	assert.Equal(t, "1.0.0", newVersion)
+}
+
+func TestParseVersionsYaml_SingleVersion(t *testing.T) {
+	yamlBytes := []byte(`
+versions:
+  - name: "1.0.0"
+    repo: "repo1"
+    commit: "commit1"
+`)
+
+	list, defaultVersion, oldVersion, newVersion := mustParseVersionsYaml(yamlBytes)
+
+	assert.Len(t, list, 1)
+	assert.Equal(t, "1.0.0", defaultVersion)
+	assert.Equal(t, "", oldVersion)
+	assert.Equal(t, "1.0.0", newVersion)
+}
+
+func TestParseVersionsYaml_InvalidYaml(t *testing.T) {
+	yamlBytes := []byte(`invalid yaml`)
+
+	assert.Panics(t, func() {
+		mustParseVersionsYaml(yamlBytes)
+	})
+}

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/istio-ecosystem/sail-operator/api/v1alpha1"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
@@ -253,8 +254,8 @@ spec:
 					It("has sidecars with the correct istio version", func(ctx SpecContext) {
 						for _, pod := range bookinfoPods.Items {
 							sidecarVersion, err := getProxyVersion(pod.Name, bookinfoNamespace)
-							Expect(err).To(Succeed(), "Error getting sidecar version")
-							Expect(sidecarVersion).To(ContainSubstring(version.Version.String()), "Sidecar Istio version does not match the expected version")
+							Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
+							Expect(sidecarVersion).To(Equal(version.Version), "Sidecar Istio version does not match the expected version")
 						}
 						Success("Istio sidecar version matches the expected Istio version")
 					})
@@ -396,14 +397,19 @@ func deployBookinfo(version supportedversion.VersionInfo) error {
 	return nil
 }
 
-func getProxyVersion(podName, namespace string) (string, error) {
-	proxyVersion, err := k.SetNamespace(namespace).Exec(
+func getProxyVersion(podName, namespace string) (*semver.Version, error) {
+	output, err := k.SetNamespace(namespace).Exec(
 		podName,
 		"istio-proxy",
 		`curl -s http://localhost:15000/server_info | grep "ISTIO_VERSION" | awk -F '"' '{print $4}'`)
 	if err != nil {
-		return "", fmt.Errorf("error getting sidecar version: %w", err)
+		return nil, fmt.Errorf("error getting sidecar version: %w", err)
 	}
 
-	return proxyVersion, nil
+	versionStr := strings.TrimSpace(output)
+	version, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return version, fmt.Errorf("error parsing sidecar version %q: %w", versionStr, err)
+	}
+	return version, err
 }

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -211,7 +211,7 @@ spec:
 					It("deploys istiod", func(ctx SpecContext) {
 						Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available; unexpected Condition")
-						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version.String()), "Unexpected istiod version")
+						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
 						Success("Istiod is deployed in the namespace and Running")
 					})
 

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -211,7 +211,7 @@ spec:
 					It("deploys istiod", func(ctx SpecContext) {
 						Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available; unexpected Condition")
-						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
+						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version.String()), "Unexpected istiod version")
 						Success("Istiod is deployed in the namespace and Running")
 					})
 
@@ -254,7 +254,7 @@ spec:
 						for _, pod := range bookinfoPods.Items {
 							sidecarVersion, err := getProxyVersion(pod.Name, bookinfoNamespace)
 							Expect(err).To(Succeed(), "Error getting sidecar version")
-							Expect(sidecarVersion).To(ContainSubstring(version.Version), "Sidecar Istio version does not match the expected version")
+							Expect(sidecarVersion).To(ContainSubstring(version.Version.String()), "Sidecar Istio version does not match the expected version")
 						}
 						Success("Istio sidecar version matches the expected Istio version")
 					})

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -155,7 +155,7 @@ spec:
 					It("deploys istiod", func(ctx SpecContext) {
 						Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available; unexpected Condition")
-						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version.String()), "Unexpected istiod version")
+						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
 						Success("Istiod is deployed in the namespace and Running")
 					})
 

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/istio-ecosystem/sail-operator/api/v1alpha1"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
@@ -76,11 +77,11 @@ var _ = Describe("DualStack configuration ", Ordered, func() {
 			version := version
 
 			// The minimum supported version is 1.23 (and above)
-			if version.Major == 1 && version.Minor < 23 {
+			if version.Version.LessThan(semver.MustParse("1.23.0")) {
 				continue
 			}
 
-			Context("Istio version is: "+version.Version, func() {
+			Context("Istio version is: "+version.Version.String(), func() {
 				BeforeAll(func() {
 					Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
 					Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
@@ -154,7 +155,7 @@ spec:
 					It("deploys istiod", func(ctx SpecContext) {
 						Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available; unexpected Condition")
-						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
+						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version.String()), "Unexpected istiod version")
 						Success("Istiod is deployed in the namespace and Running")
 					})
 

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -133,13 +133,13 @@ spec:
 						Eventually(common.GetObject).
 							WithArguments(ctx, clPrimary, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available on Cluster #1; unexpected Condition")
-						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version.String()), "Unexpected istiod version")
+						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
 						Success("Istiod is deployed in the namespace and Running on Cluster #1")
 
 						Eventually(common.GetObject).
 							WithArguments(ctx, clRemote, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available on Cluster #2; unexpected Condition")
-						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version.String()), "Unexpected istiod version")
+						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
 						Success("Istiod is deployed in the namespace and Running on  Cluster #2")
 					})
 				})

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Multicluster deployment models", Ordered, func() {
 	Describe("Multi-Primary Multi-Network configuration", func() {
 		// Test the Multi-Primary Multi-Network configuration for each supported Istio version
 		for _, version := range supportedversion.List {
-			Context("Istio version is: "+version.Version, func() {
+			Context("Istio version is: "+version.Version.String(), func() {
 				When("Istio resources are created in both clusters with multicluster configuration", func() {
 					BeforeAll(func(ctx SpecContext) {
 						Expect(kubectlClient1.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")
@@ -133,13 +133,13 @@ spec:
 						Eventually(common.GetObject).
 							WithArguments(ctx, clPrimary, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available on Cluster #1; unexpected Condition")
-						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
+						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version.String()), "Unexpected istiod version")
 						Success("Istiod is deployed in the namespace and Running on Cluster #1")
 
 						Eventually(common.GetObject).
 							WithArguments(ctx, clRemote, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available on Cluster #2; unexpected Condition")
-						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
+						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version.String()), "Unexpected istiod version")
 						Success("Istiod is deployed in the namespace and Running on  Cluster #2")
 					})
 				})
@@ -315,7 +315,7 @@ func deploySampleApp(ns string, istioVersion supportedversion.VersionInfo) {
 	Expect(kubectlClient2.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
 		To(Succeed(), "Error patching sample namespace")
 
-	version := istioVersion.Version
+	version := istioVersion.Version.String()
 	// Deploy the sample app from upstream URL in both clusters
 	if istioVersion.Name == "latest" {
 		version = "master"

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/istio-ecosystem/sail-operator/api/v1alpha1"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
@@ -73,11 +74,11 @@ var _ = Describe("Multicluster deployment models", Ordered, func() {
 		// Test the Primary-Remote - Multi-Network configuration for each supported Istio version
 		for _, version := range supportedversion.List {
 			// The Primary-Remote - Multi-Network configuration is only supported in Istio 1.23 and later
-			if version.Major < 1 || (version.Major == 1 && version.Minor < 23) {
+			if version.Version.LessThan(semver.MustParse("1.23.0")) {
 				continue
 			}
 
-			Context("Istio version is: "+version.Version, func() {
+			Context("Istio version is: "+version.Version.String(), func() {
 				When("Istio resources are created in both clusters", func() {
 					BeforeAll(func(ctx SpecContext) {
 						Expect(kubectlClient1.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")
@@ -133,7 +134,7 @@ spec:
 						Eventually(common.GetObject).
 							WithArguments(ctx, clPrimary, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available on Primary; unexpected Condition")
-						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
+						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version.String()), "Unexpected istiod version")
 						Success("Istiod is deployed in the namespace and Running on Primary Cluster")
 					})
 				})

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -134,7 +134,7 @@ spec:
 						Eventually(common.GetObject).
 							WithArguments(ctx, clPrimary, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available on Primary; unexpected Condition")
-						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version.String()), "Unexpected istiod version")
+						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
 						Success("Istiod is deployed in the namespace and Running on Primary Cluster")
 					})
 				})

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -49,8 +49,8 @@ var (
 	// version can have one of the following formats:
 	// - 1.22.2
 	// - 1.23.0-rc.1
-	// - 1.24-alpha
-	istiodVersionRegex = regexp.MustCompile(`Version:"(\d+\.\d+(\.\d+)?(-\w+(\.\d+)?)?)`)
+	// - 1.24-alpha.feabc1234
+	istiodVersionRegex = regexp.MustCompile(`Version:"([^"]*)"`)
 
 	k = kubectl.NewKubectlBuilder()
 )

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	env "github.com/istio-ecosystem/sail-operator/tests/e2e/util/env"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
@@ -201,18 +202,18 @@ func logDebugElement(caption string, info string, err error) {
 	}
 }
 
-func GetVersionFromIstiod() (string, error) {
+func GetVersionFromIstiod() (*semver.Version, error) {
 	k := kubectl.NewKubectlBuilder()
 	output, err := k.SetNamespace(controlPlaneNamespace).Exec("deploy/istiod", "", "pilot-discovery version")
 	if err != nil {
-		return "", fmt.Errorf("error getting version from istiod: %w", err)
+		return nil, fmt.Errorf("error getting version from istiod: %w", err)
 	}
 
 	matches := istiodVersionRegex.FindStringSubmatch(output)
 	if len(matches) > 1 && matches[1] != "" {
-		return matches[1], nil
+		return semver.NewVersion(matches[1])
 	}
-	return "", fmt.Errorf("error getting version from istiod: version not found in output: %s", output)
+	return nil, fmt.Errorf("error getting version from istiod: version not found in output: %s", output)
 }
 
 func CheckPodsReady(ctx SpecContext, cl client.Client, namespace string) (*corev1.PodList, error) {

--- a/versions.yaml
+++ b/versions.yaml
@@ -43,7 +43,7 @@ versions:
       - https://istio-release.storage.googleapis.com/charts/cni-1.21.5.tgz
       - https://istio-release.storage.googleapis.com/charts/ztunnel-1.21.5.tgz
   - name: latest
-    version: 1.24-alpha
+    version: 1.24-alpha.fe2a04689d3b7abf7630dc5646bf825e0c0592fe
     repo: https://github.com/istio/istio
     branch: master
     commit: fe2a04689d3b7abf7630dc5646bf825e0c0592fe


### PR DESCRIPTION
These tests will not just ensure that the functions in supportedversion.go are okay, but also that the versions.yaml file is valid and is parsed successfully.
