### PR TITLE
Create GH Action for update-deps

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -1,0 +1,43 @@
+name: Update-deps workflow
+
+on:
+  schedule: 
+    - cron: "0 5 * * *" # everyday at 5AM UTC
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to update"
+        default: "main"
+        required: true
+
+run-name: update-deps
+
+env:
+  GIT_USER: ${{ secrets.GIT_USER }}
+  GH_TOKEN: ${{ secrets.GIT_TOKEN }}
+  AUTOMATOR_ORG: istio-ecosystem
+  AUTOMATOR_REPO: sail-operator
+  AUTOMATOR_BRANCH:  ${{ inputs.branch || 'main' }}
+
+jobs:
+  update-deps:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: istio/test-infra
+        ref: master
+
+    - name: Run Automator
+      run: |
+        ./tools/automator/automator.sh \
+          --org=$AUTOMATOR_ORG \
+          --repo=sail-operator \
+          --branch=$AUTOMATOR_BRANCH \
+          '--title=Automator: Update dependencies in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH' \
+          --labels=auto-merge \
+          --modifier=update_deps \
+          --token-env \
+          --cmd=./tools/update_deps.sh \
+          --signoff


### PR DESCRIPTION
With this GitHub Action, we can now also run the job manually on specific branches. Comes in handy when dealing with release branches. I also adjusted the cron timer to trigger every day at 5AM instead of just weekdays :shrug:

This won't work until https://github.com/istio-ecosystem/sail-operator/pull/386 is merged, which is why I'm adding a hold.

Fixes #390 