### PR TITLE
Improve kubectl utility in e2e tests

### DIFF
--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -43,7 +43,7 @@ var (
 	bookinfoNamespace     = env.Get("BOOKINFO_NAMESPACE", "bookinfo")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 
-	k kubectl.Builder
+	k kubectl.Kubectl
 )
 
 func TestInstall(t *testing.T) {
@@ -62,5 +62,5 @@ func setup() {
 	cl, err = k8sclient.InitK8sClient("")
 	Expect(err).NotTo(HaveOccurred())
 
-	k = kubectl.NewBuilder()
+	k = kubectl.New()
 }

--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -43,7 +43,7 @@ var (
 	bookinfoNamespace     = env.Get("BOOKINFO_NAMESPACE", "bookinfo")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 
-	k *kubectl.KubectlBuilder
+	k *kubectl.Builder
 )
 
 func TestInstall(t *testing.T) {
@@ -62,5 +62,5 @@ func setup() {
 	cl, err = k8sclient.InitK8sClient("")
 	Expect(err).NotTo(HaveOccurred())
 
-	k = kubectl.NewKubectlBuilder()
+	k = kubectl.NewBuilder()
 }

--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -43,7 +43,7 @@ var (
 	bookinfoNamespace     = env.Get("BOOKINFO_NAMESPACE", "bookinfo")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 
-	k *kubectl.Builder
+	k kubectl.Builder
 )
 
 func TestInstall(t *testing.T) {

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -173,7 +173,7 @@ spec:
 					})
 
 					It("doesn't continuously reconcile the IstioCNI CR", func() {
-						Eventually(k.SetNamespace(namespace).Logs).WithArguments("deploy/"+deploymentName, ptr.Of(30*time.Second)).
+						Eventually(k.WithNamespace(namespace).Logs).WithArguments("deploy/"+deploymentName, ptr.Of(30*time.Second)).
 							ShouldNot(ContainSubstring("Reconciliation done"), "IstioCNI is continuously reconciling")
 						Success("IstioCNI stopped reconciling")
 					})
@@ -221,7 +221,7 @@ spec:
 					})
 
 					It("doesn't continuously reconcile the Istio CR", func() {
-						Eventually(k.SetNamespace(namespace).Logs).WithArguments("deploy/"+deploymentName, ptr.Of(30*time.Second)).
+						Eventually(k.WithNamespace(namespace).Logs).WithArguments("deploy/"+deploymentName, ptr.Of(30*time.Second)).
 							ShouldNot(ContainSubstring("Reconciliation done"), "Istio CR is continuously reconciling")
 						Success("Istio CR stopped reconciling")
 					})
@@ -267,7 +267,7 @@ spec:
 
 				When("the Istio CR is deleted", func() {
 					BeforeEach(func() {
-						Expect(k.SetNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
+						Expect(k.WithNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
 						Success("Istio CR deleted")
 					})
 
@@ -281,7 +281,7 @@ spec:
 
 				When("the IstioCNI CR is deleted", func() {
 					BeforeEach(func() {
-						Expect(k.SetNamespace(istioCniNamespace).Delete("istiocni", istioCniName)).To(Succeed(), "IstioCNI CR failed to be deleted")
+						Expect(k.WithNamespace(istioCniNamespace).Delete("istiocni", istioCniName)).To(Succeed(), "IstioCNI CR failed to be deleted")
 						Success("IstioCNI deleted")
 					})
 
@@ -387,7 +387,7 @@ func getBookinfoURL(version supportedversion.VersionInfo) string {
 
 func deployBookinfo(version supportedversion.VersionInfo) error {
 	bookinfoURL := getBookinfoURL(version)
-	err := k.SetNamespace(bookinfoNamespace).Apply(bookinfoURL)
+	err := k.WithNamespace(bookinfoNamespace).Apply(bookinfoURL)
 	if err != nil {
 		return fmt.Errorf("error deploying bookinfo: %w", err)
 	}
@@ -396,7 +396,7 @@ func deployBookinfo(version supportedversion.VersionInfo) error {
 }
 
 func getProxyVersion(podName, namespace string) (*semver.Version, error) {
-	output, err := k.SetNamespace(namespace).Exec(
+	output, err := k.WithNamespace(namespace).Exec(
 		podName,
 		"istio-proxy",
 		`curl -s http://localhost:15000/server_info | grep "ISTIO_VERSION" | awk -F '"' '{print $4}'`)

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -175,7 +175,6 @@ spec:
 					It("doesn't continuously reconcile the IstioCNI CR", func() {
 						Eventually(k.SetNamespace(namespace).Logs).WithArguments("deploy/"+deploymentName, ptr.Of(30*time.Second)).
 							ShouldNot(ContainSubstring("Reconciliation done"), "IstioCNI is continuously reconciling")
-						k.ResetNamespace()
 						Success("IstioCNI stopped reconciling")
 					})
 				})
@@ -224,7 +223,6 @@ spec:
 					It("doesn't continuously reconcile the Istio CR", func() {
 						Eventually(k.SetNamespace(namespace).Logs).WithArguments("deploy/"+deploymentName, ptr.Of(30*time.Second)).
 							ShouldNot(ContainSubstring("Reconciliation done"), "Istio CR is continuously reconciling")
-						k.ResetNamespace()
 						Success("Istio CR stopped reconciling")
 					})
 				})

--- a/tests/e2e/dualstack/dualstack_suite_test.go
+++ b/tests/e2e/dualstack/dualstack_suite_test.go
@@ -43,7 +43,7 @@ var (
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 	ipFamily              = env.Get("IP_FAMILY", "ipv4")
 
-	k *kubectl.Builder
+	k kubectl.Builder
 )
 
 func TestDualStack(t *testing.T) {

--- a/tests/e2e/dualstack/dualstack_suite_test.go
+++ b/tests/e2e/dualstack/dualstack_suite_test.go
@@ -43,7 +43,7 @@ var (
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 	ipFamily              = env.Get("IP_FAMILY", "ipv4")
 
-	k *kubectl.KubectlBuilder
+	k *kubectl.Builder
 )
 
 func TestDualStack(t *testing.T) {
@@ -63,5 +63,5 @@ func setup() {
 	cl, err = k8sclient.InitK8sClient("")
 	Expect(err).NotTo(HaveOccurred())
 
-	k = kubectl.NewKubectlBuilder()
+	k = kubectl.NewBuilder()
 }

--- a/tests/e2e/dualstack/dualstack_suite_test.go
+++ b/tests/e2e/dualstack/dualstack_suite_test.go
@@ -43,7 +43,7 @@ var (
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 	ipFamily              = env.Get("IP_FAMILY", "ipv4")
 
-	k kubectl.Builder
+	k kubectl.Kubectl
 )
 
 func TestDualStack(t *testing.T) {
@@ -63,5 +63,5 @@ func setup() {
 	cl, err = k8sclient.InitK8sClient("")
 	Expect(err).NotTo(HaveOccurred())
 
-	k = kubectl.NewBuilder()
+	k = kubectl.New()
 }

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -81,7 +81,7 @@ var _ = Describe("DualStack configuration ", Ordered, func() {
 				continue
 			}
 
-			Context("Istio version is: "+version.Version.String(), func() {
+			Context(fmt.Sprintf("Istio version %s", version.Version), func() {
 				BeforeAll(func() {
 					Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
 					Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -205,10 +205,10 @@ spec:
 						Expect(k.Patch("namespace", SleepNamespace, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
 							To(Succeed(), "Error patching sleep namespace")
 
-						Expect(k.SetNamespace(DualStackNamespace).Apply(getYAMLPodURL(version, DualStackNamespace))).To(Succeed(), "error deploying tcpDualStack pod")
-						Expect(k.SetNamespace(IPv4Namespace).Apply(getYAMLPodURL(version, IPv4Namespace))).To(Succeed(), "error deploying ipv4 pod")
-						Expect(k.SetNamespace(IPv6Namespace).Apply(getYAMLPodURL(version, IPv6Namespace))).To(Succeed(), "error deploying ipv6 pod")
-						Expect(k.SetNamespace(SleepNamespace).Apply(getYAMLPodURL(version, SleepNamespace))).To(Succeed(), "error deploying sleep pod")
+						Expect(k.WithNamespace(DualStackNamespace).Apply(getYAMLPodURL(version, DualStackNamespace))).To(Succeed(), "error deploying tcpDualStack pod")
+						Expect(k.WithNamespace(IPv4Namespace).Apply(getYAMLPodURL(version, IPv4Namespace))).To(Succeed(), "error deploying ipv4 pod")
+						Expect(k.WithNamespace(IPv6Namespace).Apply(getYAMLPodURL(version, IPv6Namespace))).To(Succeed(), "error deploying ipv6 pod")
+						Expect(k.WithNamespace(SleepNamespace).Apply(getYAMLPodURL(version, SleepNamespace))).To(Succeed(), "error deploying sleep pod")
 
 						Success("dualStack validation pods deployed")
 					})
@@ -254,7 +254,7 @@ spec:
 
 				When("the Istio CR is deleted", func() {
 					BeforeEach(func() {
-						Expect(k.SetNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
+						Expect(k.WithNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
 						Success("Istio CR deleted")
 					})
 
@@ -268,7 +268,7 @@ spec:
 
 				When("the IstioCNI CR is deleted", func() {
 					BeforeEach(func() {
-						Expect(k.SetNamespace(istioCniNamespace).Delete("istiocni", istioCniName)).To(Succeed(), "IstioCNI CR failed to be deleted")
+						Expect(k.WithNamespace(istioCniNamespace).Delete("istiocni", istioCniName)).To(Succeed(), "IstioCNI CR failed to be deleted")
 						Success("IstioCNI deleted")
 					})
 
@@ -356,7 +356,7 @@ func getYAMLPodURL(version supportedversion.VersionInfo, namespace string) strin
 
 func checkPodConnectivity(podName, namespace, echoStr string) {
 	command := fmt.Sprintf(`sh -c 'echo %s | nc tcp-echo.%s 9000'`, echoStr, echoStr)
-	response, err := k.SetNamespace(namespace).Exec(podName, "sleep", command)
+	response, err := k.WithNamespace(namespace).Exec(podName, "sleep", command)
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error connecting to the %q pod", podName))
 	Expect(response).To(ContainSubstring(fmt.Sprintf("hello %s", echoStr)), fmt.Sprintf("Unexpected response from %s pod", podName))
 }

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -333,7 +333,7 @@ func deploySampleApp(ns string, istioVersion supportedversion.VersionInfo) {
 }
 
 // getListCurlResponses runs the curl command 10 times from the sleep pod in the given cluster and get response list
-func getListCurlResponses(k *kubectl.KubectlBuilder, podName string) []string {
+func getListCurlResponses(k *kubectl.Builder, podName string) []string {
 	var responses []string
 	for i := 0; i < 10; i++ {
 		response, err := k.SetNamespace("sample").Exec(podName, "sleep", "curl -sS helloworld.sample:5000/hello")

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -333,7 +333,7 @@ func deploySampleApp(ns string, istioVersion supportedversion.VersionInfo) {
 }
 
 // getListCurlResponses runs the curl command 10 times from the sleep pod in the given cluster and get response list
-func getListCurlResponses(k *kubectl.Builder, podName string) []string {
+func getListCurlResponses(k kubectl.Builder, podName string) []string {
 	var responses []string
 	for i := 0; i < 10; i++ {
 		response, err := k.SetNamespace("sample").Exec(podName, "sleep", "curl -sS helloworld.sample:5000/hello")

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -146,13 +146,13 @@ spec:
 
 				When("Gateway is created in both clusters", func() {
 					BeforeAll(func(ctx SpecContext) {
-						Expect(kubectlClient1.SetNamespace(controlPlaneNamespace).Apply(eastGatewayYAML)).To(Succeed(), "Gateway creation failed on Cluster #1")
+						Expect(kubectlClient1.WithNamespace(controlPlaneNamespace).Apply(eastGatewayYAML)).To(Succeed(), "Gateway creation failed on Cluster #1")
 
-						Expect(kubectlClient2.SetNamespace(controlPlaneNamespace).Apply(westGatewayYAML)).To(Succeed(), "Gateway creation failed on  Cluster #2")
+						Expect(kubectlClient2.WithNamespace(controlPlaneNamespace).Apply(westGatewayYAML)).To(Succeed(), "Gateway creation failed on  Cluster #2")
 
 						// Expose the Gateway service in both clusters
-						Expect(kubectlClient1.SetNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on Cluster #1")
-						Expect(kubectlClient2.SetNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on  Cluster #2")
+						Expect(kubectlClient1.WithNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on Cluster #1")
+						Expect(kubectlClient2.WithNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on  Cluster #2")
 					})
 
 					It("updates both Gateway status to Available", func(ctx SpecContext) {
@@ -257,8 +257,8 @@ spec:
 				When("istio CR is deleted in both clusters", func() {
 					BeforeEach(func() {
 						// Delete the Istio CR in both clusters
-						Expect(kubectlClient1.SetNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
-						Expect(kubectlClient2.SetNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
+						Expect(kubectlClient1.WithNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
+						Expect(kubectlClient2.WithNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
 						Success("Istio CR is deleted in both clusters")
 					})
 
@@ -321,22 +321,22 @@ func deploySampleApp(ns string, istioVersion supportedversion.VersionInfo) {
 		version = "master"
 	}
 	helloWorldURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/helloworld/helloworld.yaml", version)
-	Expect(kubectlClient1.SetNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on Cluster #1")
-	Expect(kubectlClient2.SetNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on  Cluster #2")
+	Expect(kubectlClient1.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on Cluster #1")
+	Expect(kubectlClient2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on  Cluster #2")
 
-	Expect(kubectlClient1.SetNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v1")).To(Succeed(), "Sample service deploy failed on Cluster #1")
-	Expect(kubectlClient2.SetNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v2")).To(Succeed(), "Sample service deploy failed on  Cluster #2")
+	Expect(kubectlClient1.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v1")).To(Succeed(), "Sample service deploy failed on Cluster #1")
+	Expect(kubectlClient2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v2")).To(Succeed(), "Sample service deploy failed on  Cluster #2")
 
 	sleepURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/sleep/sleep.yaml", version)
-	Expect(kubectlClient1.SetNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on Cluster #1")
-	Expect(kubectlClient2.SetNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on  Cluster #2")
+	Expect(kubectlClient1.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on Cluster #1")
+	Expect(kubectlClient2.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on  Cluster #2")
 }
 
 // getListCurlResponses runs the curl command 10 times from the sleep pod in the given cluster and get response list
 func getListCurlResponses(k kubectl.Builder, podName string) []string {
 	var responses []string
 	for i := 0; i < 10; i++ {
-		response, err := k.SetNamespace("sample").Exec(podName, "sleep", "curl -sS helloworld.sample:5000/hello")
+		response, err := k.WithNamespace("sample").Exec(podName, "sleep", "curl -sS helloworld.sample:5000/hello")
 		Expect(err).NotTo(HaveOccurred())
 		responses = append(responses, response)
 	}

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -49,8 +49,8 @@ var _ = Describe("Multicluster deployment models", Ordered, func() {
 	BeforeAll(func(ctx SpecContext) {
 		if !skipDeploy {
 			// Deploy the Sail Operator on both clusters
-			Expect(kubectlClient1.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Cluster #1")
-			Expect(kubectlClient2.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on  Cluster #2")
+			Expect(k1.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Cluster #1")
+			Expect(k2.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on  Cluster #2")
 
 			Expect(helm.Install("sail-operator", filepath.Join(project.RootDir, "chart"), "--namespace "+namespace, "--set=image="+image, "--kubeconfig "+kubeconfig)).
 				To(Succeed(), "Operator failed to be deployed in Cluster #1")
@@ -76,8 +76,8 @@ var _ = Describe("Multicluster deployment models", Ordered, func() {
 			Context("Istio version is: "+version.Version.String(), func() {
 				When("Istio resources are created in both clusters with multicluster configuration", func() {
 					BeforeAll(func(ctx SpecContext) {
-						Expect(kubectlClient1.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")
-						Expect(kubectlClient2.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")
+						Expect(k1.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")
+						Expect(k2.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")
 
 						// Push the intermediate CA to both clusters
 						Expect(certs.PushIntermediateCA(controlPlaneNamespace, kubeconfig, "east", "network1", artifacts, clPrimary)).To(Succeed())
@@ -110,11 +110,11 @@ spec:
       network: %s`
 						multiclusterCluster1YAML := fmt.Sprintf(multiclusterYAML, version.Name, controlPlaneNamespace, "mesh1", "cluster1", "network1")
 						Log("Istio CR Cluster #1: ", multiclusterCluster1YAML)
-						Expect(kubectlClient1.CreateFromString(multiclusterCluster1YAML)).To(Succeed(), "Istio Resource creation failed on Cluster #1")
+						Expect(k1.CreateFromString(multiclusterCluster1YAML)).To(Succeed(), "Istio Resource creation failed on Cluster #1")
 
 						multiclusterCluster2YAML := fmt.Sprintf(multiclusterYAML, version.Name, controlPlaneNamespace, "mesh1", "cluster2", "network2")
 						Log("Istio CR Cluster #2: ", multiclusterCluster2YAML)
-						Expect(kubectlClient2.CreateFromString(multiclusterCluster2YAML)).To(Succeed(), "Istio Resource creation failed on  Cluster #2")
+						Expect(k2.CreateFromString(multiclusterCluster2YAML)).To(Succeed(), "Istio Resource creation failed on  Cluster #2")
 					})
 
 					It("updates both Istio CR status to Ready", func(ctx SpecContext) {
@@ -146,13 +146,13 @@ spec:
 
 				When("Gateway is created in both clusters", func() {
 					BeforeAll(func(ctx SpecContext) {
-						Expect(kubectlClient1.WithNamespace(controlPlaneNamespace).Apply(eastGatewayYAML)).To(Succeed(), "Gateway creation failed on Cluster #1")
+						Expect(k1.WithNamespace(controlPlaneNamespace).Apply(eastGatewayYAML)).To(Succeed(), "Gateway creation failed on Cluster #1")
 
-						Expect(kubectlClient2.WithNamespace(controlPlaneNamespace).Apply(westGatewayYAML)).To(Succeed(), "Gateway creation failed on  Cluster #2")
+						Expect(k2.WithNamespace(controlPlaneNamespace).Apply(westGatewayYAML)).To(Succeed(), "Gateway creation failed on  Cluster #2")
 
 						// Expose the Gateway service in both clusters
-						Expect(kubectlClient1.WithNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on Cluster #1")
-						Expect(kubectlClient2.WithNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on  Cluster #2")
+						Expect(k1.WithNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on Cluster #1")
+						Expect(k2.WithNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on  Cluster #2")
 					})
 
 					It("updates both Gateway status to Available", func(ctx SpecContext) {
@@ -170,23 +170,23 @@ spec:
 				When("are installed remote secrets on each cluster", func() {
 					BeforeAll(func(ctx SpecContext) {
 						// Get the internal IP of the control plane node in both clusters
-						internalIPCluster1, err := kubectlClient1.GetInternalIP("node-role.kubernetes.io/control-plane")
+						internalIPCluster1, err := k1.GetInternalIP("node-role.kubernetes.io/control-plane")
 						Expect(err).NotTo(HaveOccurred())
 						Expect(internalIPCluster1).NotTo(BeEmpty(), "Internal IP is empty for Cluster #1")
 
-						internalIPCluster2, err := kubectlClient2.GetInternalIP("node-role.kubernetes.io/control-plane")
+						internalIPCluster2, err := k2.GetInternalIP("node-role.kubernetes.io/control-plane")
 						Expect(internalIPCluster2).NotTo(BeEmpty(), "Internal IP is empty for  Cluster #2")
 						Expect(err).NotTo(HaveOccurred())
 
 						// Install a remote secret in Cluster #1 that provides access to the  Cluster #2 API server.
 						secret, err := istioctl.CreateRemoteSecret(kubeconfig2, "cluster2", internalIPCluster2)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(kubectlClient1.ApplyString(secret)).To(Succeed(), "Remote secret creation failed on Cluster #1")
+						Expect(k1.ApplyString(secret)).To(Succeed(), "Remote secret creation failed on Cluster #1")
 
 						// Install a remote secret in  Cluster #2 that provides access to the Cluster #1 API server.
 						secret, err = istioctl.CreateRemoteSecret(kubeconfig, "cluster1", internalIPCluster1)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(kubectlClient2.ApplyString(secret)).To(Succeed(), "Remote secret creation failed on Cluster #1")
+						Expect(k2.ApplyString(secret)).To(Succeed(), "Remote secret creation failed on Cluster #1")
 					})
 
 					It("remote secrets are created", func(ctx SpecContext) {
@@ -242,12 +242,12 @@ spec:
 						Expect(err).NotTo(HaveOccurred(), "Error getting sleep pod name on  Cluster #2")
 
 						// Run the curl command from the sleep pod in the  Cluster #2 and get response list to validate that we get responses from both clusters
-						Cluster2Responses := strings.Join(getListCurlResponses(kubectlClient2, sleepPodNameCluster2), "\n")
+						Cluster2Responses := strings.Join(getListCurlResponses(k2, sleepPodNameCluster2), "\n")
 						Expect(Cluster2Responses).To(ContainSubstring("Hello version: v1"), "Responses from  Cluster #2 are not the expected")
 						Expect(Cluster2Responses).To(ContainSubstring("Hello version: v2"), "Responses from  Cluster #2 are not the expected")
 
 						// Run the curl command from the sleep pod in the Cluster #1 and get response list to validate that we get responses from both clusters
-						Cluster1Responses := strings.Join(getListCurlResponses(kubectlClient1, sleepPodNameCluster1), "\n")
+						Cluster1Responses := strings.Join(getListCurlResponses(k1, sleepPodNameCluster1), "\n")
 						Expect(Cluster1Responses).To(ContainSubstring("Hello version: v1"), "Responses from Cluster #1 are not the expected")
 						Expect(Cluster1Responses).To(ContainSubstring("Hello version: v2"), "Responses from Cluster #1 are not the expected")
 						Success("Sample app is accessible from both clusters")
@@ -257,8 +257,8 @@ spec:
 				When("istio CR is deleted in both clusters", func() {
 					BeforeEach(func() {
 						// Delete the Istio CR in both clusters
-						Expect(kubectlClient1.WithNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
-						Expect(kubectlClient2.WithNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
+						Expect(k1.WithNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
+						Expect(k2.WithNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
 						Success("Istio CR is deleted in both clusters")
 					})
 
@@ -273,16 +273,16 @@ spec:
 
 				AfterAll(func(ctx SpecContext) {
 					// Delete namespace to ensure clean up for new tests iteration
-					Expect(kubectlClient1.DeleteNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-					Expect(kubectlClient2.DeleteNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #2")
+					Expect(k1.DeleteNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
+					Expect(k2.DeleteNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #2")
 
 					common.CheckNamespaceEmpty(ctx, clPrimary, controlPlaneNamespace)
 					common.CheckNamespaceEmpty(ctx, clRemote, controlPlaneNamespace)
 					Success("ControlPlane Namespaces are empty")
 
 					// Delete the entire sample namespace in both clusters
-					Expect(kubectlClient1.DeleteNamespace("sample")).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-					Expect(kubectlClient2.DeleteNamespace("sample")).To(Succeed(), "Namespace failed to be deleted on  Cluster #2")
+					Expect(k1.DeleteNamespace("sample")).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
+					Expect(k2.DeleteNamespace("sample")).To(Succeed(), "Namespace failed to be deleted on  Cluster #2")
 
 					common.CheckNamespaceEmpty(ctx, clPrimary, "sample")
 					common.CheckNamespaceEmpty(ctx, clRemote, "sample")
@@ -294,8 +294,8 @@ spec:
 
 	AfterAll(func(ctx SpecContext) {
 		// Delete the Sail Operator from both clusters
-		Expect(kubectlClient1.DeleteNamespace(namespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-		Expect(kubectlClient2.DeleteNamespace(namespace)).To(Succeed(), "Namespace failed to be deleted on  Cluster #2")
+		Expect(k1.DeleteNamespace(namespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
+		Expect(k2.DeleteNamespace(namespace)).To(Succeed(), "Namespace failed to be deleted on  Cluster #2")
 
 		// Delete the intermediate CA from both clusters
 		common.CheckNamespaceEmpty(ctx, clPrimary, namespace)
@@ -306,13 +306,13 @@ spec:
 // deploySampleApp deploys the sample app in the given cluster
 func deploySampleApp(ns string, istioVersion supportedversion.VersionInfo) {
 	// Create the namespace
-	Expect(kubectlClient1.CreateNamespace(ns)).To(Succeed(), "Namespace failed to be created")
-	Expect(kubectlClient2.CreateNamespace(ns)).To(Succeed(), "Namespace failed to be created")
+	Expect(k1.CreateNamespace(ns)).To(Succeed(), "Namespace failed to be created")
+	Expect(k2.CreateNamespace(ns)).To(Succeed(), "Namespace failed to be created")
 
 	// Label the namespace
-	Expect(kubectlClient1.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
+	Expect(k1.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
 		To(Succeed(), "Error patching sample namespace")
-	Expect(kubectlClient2.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
+	Expect(k2.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
 		To(Succeed(), "Error patching sample namespace")
 
 	version := istioVersion.Version.String()
@@ -321,15 +321,15 @@ func deploySampleApp(ns string, istioVersion supportedversion.VersionInfo) {
 		version = "master"
 	}
 	helloWorldURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/helloworld/helloworld.yaml", version)
-	Expect(kubectlClient1.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on Cluster #1")
-	Expect(kubectlClient2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on  Cluster #2")
+	Expect(k1.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on Cluster #1")
+	Expect(k2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on  Cluster #2")
 
-	Expect(kubectlClient1.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v1")).To(Succeed(), "Sample service deploy failed on Cluster #1")
-	Expect(kubectlClient2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v2")).To(Succeed(), "Sample service deploy failed on  Cluster #2")
+	Expect(k1.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v1")).To(Succeed(), "Sample service deploy failed on Cluster #1")
+	Expect(k2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v2")).To(Succeed(), "Sample service deploy failed on  Cluster #2")
 
 	sleepURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/sleep/sleep.yaml", version)
-	Expect(kubectlClient1.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on Cluster #1")
-	Expect(kubectlClient2.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on  Cluster #2")
+	Expect(k1.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on Cluster #1")
+	Expect(k2.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on  Cluster #2")
 }
 
 // getListCurlResponses runs the curl command 10 times from the sleep pod in the given cluster and get response list

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -80,8 +80,8 @@ var _ = Describe("Multicluster deployment models", Ordered, func() {
 						Expect(k2.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")
 
 						// Push the intermediate CA to both clusters
-						Expect(certs.PushIntermediateCA(controlPlaneNamespace, kubeconfig, "east", "network1", artifacts, clPrimary)).To(Succeed())
-						Expect(certs.PushIntermediateCA(controlPlaneNamespace, kubeconfig2, "west", "network2", artifacts, clRemote)).To(Succeed())
+						Expect(certs.PushIntermediateCA(k1, controlPlaneNamespace, "east", "network1", artifacts, clPrimary)).To(Succeed())
+						Expect(certs.PushIntermediateCA(k2, controlPlaneNamespace, "west", "network2", artifacts, clRemote)).To(Succeed())
 
 						// Wait for the secret to be created in both clusters
 						Eventually(func() error {

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Multicluster deployment models", Ordered, func() {
 		if !skipDeploy {
 			// Deploy the Sail Operator on both clusters
 			Expect(k1.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Cluster #1")
-			Expect(k2.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on  Cluster #2")
+			Expect(k2.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Cluster #2")
 
 			Expect(helm.Install("sail-operator", filepath.Join(project.RootDir, "chart"), "--namespace "+namespace, "--set=image="+image, "--kubeconfig "+kubeconfig)).
 				To(Succeed(), "Operator failed to be deployed in Cluster #1")
@@ -114,7 +114,7 @@ spec:
 
 						multiclusterCluster2YAML := fmt.Sprintf(multiclusterYAML, version.Name, controlPlaneNamespace, "mesh1", "cluster2", "network2")
 						Log("Istio CR Cluster #2: ", multiclusterCluster2YAML)
-						Expect(k2.CreateFromString(multiclusterCluster2YAML)).To(Succeed(), "Istio Resource creation failed on  Cluster #2")
+						Expect(k2.CreateFromString(multiclusterCluster2YAML)).To(Succeed(), "Istio Resource creation failed on Cluster #2")
 					})
 
 					It("updates both Istio CR status to Ready", func(ctx SpecContext) {
@@ -140,19 +140,18 @@ spec:
 							WithArguments(ctx, clRemote, kube.Key("istiod", controlPlaneNamespace), &appsv1.Deployment{}).
 							Should(HaveCondition(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Istiod is not Available on Cluster #2; unexpected Condition")
 						Expect(common.GetVersionFromIstiod()).To(Equal(version.Version), "Unexpected istiod version")
-						Success("Istiod is deployed in the namespace and Running on  Cluster #2")
+						Success("Istiod is deployed in the namespace and Running on Cluster #2")
 					})
 				})
 
 				When("Gateway is created in both clusters", func() {
 					BeforeAll(func(ctx SpecContext) {
 						Expect(k1.WithNamespace(controlPlaneNamespace).Apply(eastGatewayYAML)).To(Succeed(), "Gateway creation failed on Cluster #1")
-
-						Expect(k2.WithNamespace(controlPlaneNamespace).Apply(westGatewayYAML)).To(Succeed(), "Gateway creation failed on  Cluster #2")
+						Expect(k2.WithNamespace(controlPlaneNamespace).Apply(westGatewayYAML)).To(Succeed(), "Gateway creation failed on Cluster #2")
 
 						// Expose the Gateway service in both clusters
 						Expect(k1.WithNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on Cluster #1")
-						Expect(k2.WithNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on  Cluster #2")
+						Expect(k2.WithNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on Cluster #2")
 					})
 
 					It("updates both Gateway status to Available", func(ctx SpecContext) {
@@ -196,7 +195,7 @@ spec:
 
 						secret, err = common.GetObject(ctx, clRemote, kube.Key("istio-remote-secret-cluster1", controlPlaneNamespace), &corev1.Secret{})
 						Expect(err).NotTo(HaveOccurred())
-						Expect(secret).NotTo(BeNil(), "Secret is not created on  Cluster #2")
+						Expect(secret).NotTo(BeNil(), "Secret is not created on Cluster #2")
 						Success("Remote secrets are created in both clusters")
 					})
 				})
@@ -238,8 +237,8 @@ spec:
 						Expect(err).NotTo(HaveOccurred(), "Error getting sleep pod name on Cluster #1")
 
 						sleepPodNameCluster2, err := common.GetPodNameByLabel(ctx, clRemote, "sample", "app", "sleep")
-						Expect(sleepPodNameCluster2).NotTo(BeEmpty(), "Sleep pod not found on  Cluster #2")
-						Expect(err).NotTo(HaveOccurred(), "Error getting sleep pod name on  Cluster #2")
+						Expect(sleepPodNameCluster2).NotTo(BeEmpty(), "Sleep pod not found on Cluster #2")
+						Expect(err).NotTo(HaveOccurred(), "Error getting sleep pod name on Cluster #2")
 
 						// Run the curl command from the sleep pod in the  Cluster #2 and get response list to validate that we get responses from both clusters
 						Cluster2Responses := strings.Join(getListCurlResponses(k2, sleepPodNameCluster2), "\n")
@@ -282,7 +281,7 @@ spec:
 
 					// Delete the entire sample namespace in both clusters
 					Expect(k1.DeleteNamespace("sample")).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-					Expect(k2.DeleteNamespace("sample")).To(Succeed(), "Namespace failed to be deleted on  Cluster #2")
+					Expect(k2.DeleteNamespace("sample")).To(Succeed(), "Namespace failed to be deleted on Cluster #2")
 
 					common.CheckNamespaceEmpty(ctx, clPrimary, "sample")
 					common.CheckNamespaceEmpty(ctx, clRemote, "sample")
@@ -295,7 +294,7 @@ spec:
 	AfterAll(func(ctx SpecContext) {
 		// Delete the Sail Operator from both clusters
 		Expect(k1.DeleteNamespace(namespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-		Expect(k2.DeleteNamespace(namespace)).To(Succeed(), "Namespace failed to be deleted on  Cluster #2")
+		Expect(k2.DeleteNamespace(namespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #2")
 
 		// Delete the intermediate CA from both clusters
 		common.CheckNamespaceEmpty(ctx, clPrimary, namespace)
@@ -322,14 +321,14 @@ func deploySampleApp(ns string, istioVersion supportedversion.VersionInfo) {
 	}
 	helloWorldURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/helloworld/helloworld.yaml", version)
 	Expect(k1.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on Cluster #1")
-	Expect(k2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on  Cluster #2")
+	Expect(k2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on Cluster #2")
 
 	Expect(k1.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v1")).To(Succeed(), "Sample service deploy failed on Cluster #1")
-	Expect(k2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v2")).To(Succeed(), "Sample service deploy failed on  Cluster #2")
+	Expect(k2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v2")).To(Succeed(), "Sample service deploy failed on Cluster #2")
 
 	sleepURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/sleep/sleep.yaml", version)
 	Expect(k1.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on Cluster #1")
-	Expect(k2.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on  Cluster #2")
+	Expect(k2.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on Cluster #2")
 }
 
 // getListCurlResponses runs the curl command 10 times from the sleep pod in the given cluster and get response list

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -333,7 +333,7 @@ func deploySampleApp(ns string, istioVersion supportedversion.VersionInfo) {
 }
 
 // getListCurlResponses runs the curl command 10 times from the sleep pod in the given cluster and get response list
-func getListCurlResponses(k kubectl.Builder, podName string) []string {
+func getListCurlResponses(k kubectl.Kubectl, podName string) []string {
 	var responses []string
 	for i := 0; i < 10; i++ {
 		response, err := k.WithNamespace("sample").Exec(podName, "sleep", "curl -sS helloworld.sample:5000/hello")

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -73,8 +73,8 @@ var _ = Describe("Multicluster deployment models", Ordered, func() {
 	Describe("Multi-Primary Multi-Network configuration", func() {
 		// Test the Multi-Primary Multi-Network configuration for each supported Istio version
 		for _, version := range supportedversion.List {
-			Context("Istio version is: "+version.Version.String(), func() {
-				When("Istio resources are created in both clusters with multicluster configuration", func() {
+			Context(fmt.Sprintf("Istio version %s", version.Version), func() {
+				When("Istio resources are created in both clusters", func() {
 					BeforeAll(func(ctx SpecContext) {
 						Expect(k1.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")
 						Expect(k2.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Multicluster deployment models", Ordered, func() {
 				continue
 			}
 
-			Context("Istio version is: "+version.Version.String(), func() {
+			Context(fmt.Sprintf("Istio version %s", version.Version), func() {
 				When("Istio resources are created in both clusters", func() {
 					BeforeAll(func(ctx SpecContext) {
 						Expect(k1.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -212,7 +212,7 @@ spec:
 						By("Creating Remote Secret on Primary Cluster")
 						secret, err := istioctl.CreateRemoteSecret(kubeconfig2, "remote", internalIPRemote)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(k1.ApplyString(secret)).To(Succeed(), "Remote secret creation failed on Primary Cluster")
+						Expect(k1.WithNamespace(controlPlaneNamespace).ApplyString(secret)).To(Succeed(), "Remote secret creation failed on Primary Cluster")
 					})
 
 					It("secret is created", func(ctx SpecContext) {

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -85,9 +85,9 @@ var _ = Describe("Multicluster deployment models", Ordered, func() {
 						Expect(k2.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be created")
 
 						// Push the intermediate CA to both clusters
-						Expect(certs.PushIntermediateCA(controlPlaneNamespace, kubeconfig, "east", "network1", artifacts, clPrimary)).
+						Expect(certs.PushIntermediateCA(k1, controlPlaneNamespace, "east", "network1", artifacts, clPrimary)).
 							To(Succeed(), "Error pushing intermediate CA to Primary Cluster")
-						Expect(certs.PushIntermediateCA(controlPlaneNamespace, kubeconfig2, "west", "network2", artifacts, clRemote)).
+						Expect(certs.PushIntermediateCA(k2, controlPlaneNamespace, "west", "network2", artifacts, clRemote)).
 							To(Succeed(), "Error pushing intermediate CA to Remote Cluster")
 
 						// Wait for the secret to be created in both clusters

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -141,13 +141,13 @@ spec:
 
 				When("Gateway is created on Primary cluster ", func() {
 					BeforeAll(func(ctx SpecContext) {
-						Expect(kubectlClient1.SetNamespace(controlPlaneNamespace).Apply(eastGatewayYAML)).To(Succeed(), "Gateway creation failed on Primary Cluster")
+						Expect(kubectlClient1.WithNamespace(controlPlaneNamespace).Apply(eastGatewayYAML)).To(Succeed(), "Gateway creation failed on Primary Cluster")
 
 						// Expose istiod service in Primary cluster
-						Expect(kubectlClient1.SetNamespace(controlPlaneNamespace).Apply(exposeIstiodYAML)).To(Succeed(), "Expose Istiod creation failed on Primary Cluster")
+						Expect(kubectlClient1.WithNamespace(controlPlaneNamespace).Apply(exposeIstiodYAML)).To(Succeed(), "Expose Istiod creation failed on Primary Cluster")
 
 						// Expose the Gateway service in both clusters
-						Expect(kubectlClient1.SetNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on Primary Cluster")
+						Expect(kubectlClient1.WithNamespace(controlPlaneNamespace).Apply(exposeServiceYAML)).To(Succeed(), "Expose Service creation failed on Primary Cluster")
 					})
 
 					It("updates Gateway status to Available", func(ctx SpecContext) {
@@ -232,7 +232,7 @@ spec:
 
 				When("gateway is created in Remote cluster", func() {
 					BeforeAll(func(ctx SpecContext) {
-						Expect(kubectlClient2.SetNamespace(controlPlaneNamespace).Apply(westGatewayYAML)).To(Succeed(), "Gateway creation failed on Remote Cluster")
+						Expect(kubectlClient2.WithNamespace(controlPlaneNamespace).Apply(westGatewayYAML)).To(Succeed(), "Gateway creation failed on Remote Cluster")
 						Success("Gateway is created in Remote cluster")
 					})
 
@@ -299,8 +299,8 @@ spec:
 
 				When("Istio CR and RemoteIstio CR are deleted in both clusters", func() {
 					BeforeEach(func() {
-						Expect(kubectlClient1.SetNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
-						Expect(kubectlClient2.SetNamespace(controlPlaneNamespace).Delete("remoteistio", istioName)).To(Succeed(), "RemoteIstio CR failed to be deleted")
+						Expect(kubectlClient1.WithNamespace(controlPlaneNamespace).Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
+						Expect(kubectlClient2.WithNamespace(controlPlaneNamespace).Delete("remoteistio", istioName)).To(Succeed(), "RemoteIstio CR failed to be deleted")
 						Success("Istio and RemoteIstio are deleted")
 					})
 

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -52,8 +52,8 @@ var (
 	exposeServiceYAML string
 	exposeIstiodYAML  string
 
-	kubectlClient1 *kubectl.KubectlBuilder
-	kubectlClient2 *kubectl.KubectlBuilder
+	kubectlClient1 *kubectl.Builder
+	kubectlClient2 *kubectl.Builder
 )
 
 func TestInstall(t *testing.T) {
@@ -99,6 +99,6 @@ func setup(t *testing.T) {
 	exposeIstiodYAML = fmt.Sprintf("%s/docs/multicluster/expose-istiod.yaml", baseRepoDir)
 
 	// Initialize kubectl utilities, one for each cluster
-	kubectlClient1 = kubectl.NewKubectlBuilder().SetKubeconfig(kubeconfig)
-	kubectlClient2 = kubectl.NewKubectlBuilder().SetKubeconfig(kubeconfig2)
+	kubectlClient1 = kubectl.NewBuilder().SetKubeconfig(kubeconfig)
+	kubectlClient2 = kubectl.NewBuilder().SetKubeconfig(kubeconfig2)
 }

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -52,8 +52,8 @@ var (
 	exposeServiceYAML string
 	exposeIstiodYAML  string
 
-	kubectlClient1 kubectl.Kubectl
-	kubectlClient2 kubectl.Kubectl
+	k1 kubectl.Kubectl
+	k2 kubectl.Kubectl
 )
 
 func TestInstall(t *testing.T) {
@@ -99,6 +99,6 @@ func setup(t *testing.T) {
 	exposeIstiodYAML = fmt.Sprintf("%s/docs/multicluster/expose-istiod.yaml", baseRepoDir)
 
 	// Initialize kubectl utilities, one for each cluster
-	kubectlClient1 = kubectl.New().WithKubeconfig(kubeconfig)
-	kubectlClient2 = kubectl.New().WithKubeconfig(kubeconfig2)
+	k1 = kubectl.New().WithKubeconfig(kubeconfig)
+	k2 = kubectl.New().WithKubeconfig(kubeconfig2)
 }

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -52,8 +52,8 @@ var (
 	exposeServiceYAML string
 	exposeIstiodYAML  string
 
-	kubectlClient1 *kubectl.Builder
-	kubectlClient2 *kubectl.Builder
+	kubectlClient1 kubectl.Builder
+	kubectlClient2 kubectl.Builder
 )
 
 func TestInstall(t *testing.T) {

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -99,6 +99,6 @@ func setup(t *testing.T) {
 	exposeIstiodYAML = fmt.Sprintf("%s/docs/multicluster/expose-istiod.yaml", baseRepoDir)
 
 	// Initialize kubectl utilities, one for each cluster
-	kubectlClient1 = kubectl.NewBuilder().SetKubeconfig(kubeconfig)
-	kubectlClient2 = kubectl.NewBuilder().SetKubeconfig(kubeconfig2)
+	kubectlClient1 = kubectl.NewBuilder().WithKubeconfig(kubeconfig)
+	kubectlClient2 = kubectl.NewBuilder().WithKubeconfig(kubeconfig2)
 }

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -52,8 +52,8 @@ var (
 	exposeServiceYAML string
 	exposeIstiodYAML  string
 
-	kubectlClient1 kubectl.Builder
-	kubectlClient2 kubectl.Builder
+	kubectlClient1 kubectl.Kubectl
+	kubectlClient2 kubectl.Kubectl
 )
 
 func TestInstall(t *testing.T) {
@@ -99,6 +99,6 @@ func setup(t *testing.T) {
 	exposeIstiodYAML = fmt.Sprintf("%s/docs/multicluster/expose-istiod.yaml", baseRepoDir)
 
 	// Initialize kubectl utilities, one for each cluster
-	kubectlClient1 = kubectl.NewBuilder().WithKubeconfig(kubeconfig)
-	kubectlClient2 = kubectl.NewBuilder().WithKubeconfig(kubeconfig2)
+	kubectlClient1 = kubectl.New().WithKubeconfig(kubeconfig)
+	kubectlClient2 = kubectl.New().WithKubeconfig(kubeconfig2)
 }

--- a/tests/e2e/operator/operator_suite_test.go
+++ b/tests/e2e/operator/operator_suite_test.go
@@ -36,7 +36,7 @@ var (
 	deploymentName = env.Get("DEPLOYMENT_NAME", "sail-operator")
 	multicluster   = env.GetBool("MULTICLUSTER", false)
 
-	k kubectl.Builder
+	k kubectl.Kubectl
 )
 
 func TestInstall(t *testing.T) {
@@ -62,5 +62,5 @@ func setup() {
 		GinkgoWriter.Println("Running on Kubernetes")
 	}
 
-	k = kubectl.NewBuilder()
+	k = kubectl.New()
 }

--- a/tests/e2e/operator/operator_suite_test.go
+++ b/tests/e2e/operator/operator_suite_test.go
@@ -36,7 +36,7 @@ var (
 	deploymentName = env.Get("DEPLOYMENT_NAME", "sail-operator")
 	multicluster   = env.GetBool("MULTICLUSTER", false)
 
-	k *kubectl.Builder
+	k kubectl.Builder
 )
 
 func TestInstall(t *testing.T) {

--- a/tests/e2e/operator/operator_suite_test.go
+++ b/tests/e2e/operator/operator_suite_test.go
@@ -36,7 +36,7 @@ var (
 	deploymentName = env.Get("DEPLOYMENT_NAME", "sail-operator")
 	multicluster   = env.GetBool("MULTICLUSTER", false)
 
-	k *kubectl.KubectlBuilder
+	k *kubectl.Builder
 )
 
 func TestInstall(t *testing.T) {
@@ -62,5 +62,5 @@ func setup() {
 		GinkgoWriter.Println("Running on Kubernetes")
 	}
 
-	k = kubectl.NewKubectlBuilder()
+	k = kubectl.NewBuilder()
 }

--- a/tests/e2e/util/certs/certs.go
+++ b/tests/e2e/util/certs/certs.go
@@ -228,7 +228,7 @@ func PushIntermediateCA(ns, kubeconfig, zone, network, basePath string, cl clien
 	if err != nil {
 		// Label the namespace with the network
 		k := kubectl.NewBuilder()
-		k.SetKubeconfig(kubeconfig)
+		k.WithKubeconfig(kubeconfig)
 		err = k.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"topology.istio.io/network":"`+network+`"}}}`)
 		if err != nil {
 			return fmt.Errorf("failed to label namespace: %w", err)

--- a/tests/e2e/util/certs/certs.go
+++ b/tests/e2e/util/certs/certs.go
@@ -227,7 +227,7 @@ func PushIntermediateCA(ns, kubeconfig, zone, network, basePath string, cl clien
 	_, err := common.GetObject(context.Background(), cl, kube.Key("cacerts", ns), &corev1.Secret{})
 	if err != nil {
 		// Label the namespace with the network
-		k := kubectl.NewBuilder()
+		k := kubectl.New()
 		k.WithKubeconfig(kubeconfig)
 		err = k.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"topology.istio.io/network":"`+network+`"}}}`)
 		if err != nil {

--- a/tests/e2e/util/certs/certs.go
+++ b/tests/e2e/util/certs/certs.go
@@ -219,7 +219,7 @@ func writeFile(confPath string, confContent string) error {
 }
 
 // PushIntermediateCA pushes the intermediate CA to the cluster
-func PushIntermediateCA(ns, kubeconfig, zone, network, basePath string, cl client.Client) error {
+func PushIntermediateCA(k kubectl.Kubectl, ns, zone, network, basePath string, cl client.Client) error {
 	// Set cert dir
 	certDir := filepath.Join(basePath, "certs")
 
@@ -227,8 +227,6 @@ func PushIntermediateCA(ns, kubeconfig, zone, network, basePath string, cl clien
 	_, err := common.GetObject(context.Background(), cl, kube.Key("cacerts", ns), &corev1.Secret{})
 	if err != nil {
 		// Label the namespace with the network
-		k := kubectl.New()
-		k.WithKubeconfig(kubeconfig)
 		err = k.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"topology.istio.io/network":"`+network+`"}}}`)
 		if err != nil {
 			return fmt.Errorf("failed to label namespace: %w", err)

--- a/tests/e2e/util/certs/certs.go
+++ b/tests/e2e/util/certs/certs.go
@@ -227,7 +227,7 @@ func PushIntermediateCA(ns, kubeconfig, zone, network, basePath string, cl clien
 	_, err := common.GetObject(context.Background(), cl, kube.Key("cacerts", ns), &corev1.Secret{})
 	if err != nil {
 		// Label the namespace with the network
-		k := kubectl.NewKubectlBuilder()
+		k := kubectl.NewBuilder()
 		k.SetKubeconfig(kubeconfig)
 		err = k.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"topology.istio.io/network":"`+network+`"}}}`)
 		if err != nil {

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -141,20 +141,20 @@ func LogDebugInfo() {
 }
 
 func logOperatorDebugInfo() {
-	operator, err := k.SetNamespace(namespace).GetYAML("deployment", deploymentName)
+	operator, err := k.WithNamespace(namespace).GetYAML("deployment", deploymentName)
 	logDebugElement("Operator Deployment YAML", operator, err)
 
-	logs, err := k.SetNamespace(namespace).Logs("deploy/"+deploymentName, ptr.Of(120*time.Second))
+	logs, err := k.WithNamespace(namespace).Logs("deploy/"+deploymentName, ptr.Of(120*time.Second))
 	logDebugElement("Operator logs", logs, err)
 
-	events, err := k.SetNamespace(namespace).GetEvents()
+	events, err := k.WithNamespace(namespace).GetEvents()
 	logDebugElement("Events in "+namespace, events, err)
 
 	// Temporary information to gather more details about failure
-	pods, err := k.SetNamespace(namespace).GetPods("", "-o wide")
+	pods, err := k.WithNamespace(namespace).GetPods("", "-o wide")
 	logDebugElement("Pods in "+namespace, pods, err)
 
-	describe, err := k.SetNamespace(namespace).Describe("deployment", deploymentName)
+	describe, err := k.WithNamespace(namespace).Describe("deployment", deploymentName)
 	logDebugElement("Operator Deployment describe", describe, err)
 }
 
@@ -162,13 +162,13 @@ func logIstioDebugInfo() {
 	resource, err := k.GetYAML("istio", istioName)
 	logDebugElement("Istio YAML", resource, err)
 
-	output, err := k.SetNamespace(controlPlaneNamespace).GetPods("", "-o wide")
+	output, err := k.WithNamespace(controlPlaneNamespace).GetPods("", "-o wide")
 	logDebugElement("Pods in "+controlPlaneNamespace, output, err)
 
-	logs, err := k.SetNamespace(controlPlaneNamespace).Logs("deploy/istiod", ptr.Of(120*time.Second))
+	logs, err := k.WithNamespace(controlPlaneNamespace).Logs("deploy/istiod", ptr.Of(120*time.Second))
 	logDebugElement("Istiod logs", logs, err)
 
-	events, err := k.SetNamespace(controlPlaneNamespace).GetEvents()
+	events, err := k.WithNamespace(controlPlaneNamespace).GetEvents()
 	logDebugElement("Events in "+controlPlaneNamespace, events, err)
 }
 
@@ -176,20 +176,20 @@ func logCNIDebugInfo() {
 	resource, err := k.GetYAML("istiocni", istioCniName)
 	logDebugElement("IstioCNI YAML", resource, err)
 
-	ds, err := k.SetNamespace(istioCniNamespace).GetYAML("daemonset", "istio-cni-node")
+	ds, err := k.WithNamespace(istioCniNamespace).GetYAML("daemonset", "istio-cni-node")
 	logDebugElement("Istio CNI DaemonSet YAML", ds, err)
 
-	events, err := k.SetNamespace(istioCniNamespace).GetEvents()
+	events, err := k.WithNamespace(istioCniNamespace).GetEvents()
 	logDebugElement("Events in "+istioCniNamespace, events, err)
 
 	// Temporary information to gather more details about failure
-	pods, err := k.SetNamespace(istioCniNamespace).GetPods("", "-o wide")
+	pods, err := k.WithNamespace(istioCniNamespace).GetPods("", "-o wide")
 	logDebugElement("Pods in "+istioCniNamespace, pods, err)
 
-	describe, err := k.SetNamespace(istioCniNamespace).Describe("daemonset", "istio-cni-node")
+	describe, err := k.WithNamespace(istioCniNamespace).Describe("daemonset", "istio-cni-node")
 	logDebugElement("Istio CNI DaemonSet describe", describe, err)
 
-	logs, err := k.SetNamespace(istioCniNamespace).Logs("daemonset/istio-cni-node", ptr.Of(120*time.Second))
+	logs, err := k.WithNamespace(istioCniNamespace).Logs("daemonset/istio-cni-node", ptr.Of(120*time.Second))
 	logDebugElement("Istio CNI logs", logs, err)
 }
 
@@ -205,7 +205,7 @@ func logDebugElement(caption string, info string, err error) {
 
 func GetVersionFromIstiod() (*semver.Version, error) {
 	k := kubectl.NewBuilder()
-	output, err := k.SetNamespace(controlPlaneNamespace).Exec("deploy/istiod", "", "pilot-discovery version")
+	output, err := k.WithNamespace(controlPlaneNamespace).Exec("deploy/istiod", "", "pilot-discovery version")
 	if err != nil {
 		return nil, fmt.Errorf("error getting version from istiod: %w", err)
 	}

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -52,7 +52,7 @@ var (
 	// - 1.24-alpha.feabc1234
 	istiodVersionRegex = regexp.MustCompile(`Version:"([^"]*)"`)
 
-	k = kubectl.NewBuilder()
+	k = kubectl.New()
 )
 
 // GetObject returns the object with the given key
@@ -204,7 +204,7 @@ func logDebugElement(caption string, info string, err error) {
 }
 
 func GetVersionFromIstiod() (*semver.Version, error) {
-	k := kubectl.NewBuilder()
+	k := kubectl.New()
 	output, err := k.WithNamespace(controlPlaneNamespace).Exec("deploy/istiod", "", "pilot-discovery version")
 	if err != nil {
 		return nil, fmt.Errorf("error getting version from istiod: %w", err)

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -145,7 +145,6 @@ func logOperatorDebugInfo() {
 	logDebugElement("Operator Deployment YAML", operator, err)
 
 	logs, err := k.SetNamespace(namespace).Logs("deploy/"+deploymentName, ptr.Of(120*time.Second))
-	k.ResetNamespace()
 	logDebugElement("Operator logs", logs, err)
 
 	events, err := k.SetNamespace(namespace).GetEvents()
@@ -167,7 +166,6 @@ func logIstioDebugInfo() {
 	logDebugElement("Pods in "+controlPlaneNamespace, output, err)
 
 	logs, err := k.SetNamespace(controlPlaneNamespace).Logs("deploy/istiod", ptr.Of(120*time.Second))
-	k.ResetNamespace()
 	logDebugElement("Istiod logs", logs, err)
 
 	events, err := k.SetNamespace(controlPlaneNamespace).GetEvents()

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -52,7 +52,7 @@ var (
 	// - 1.24-alpha.feabc1234
 	istiodVersionRegex = regexp.MustCompile(`Version:"([^"]*)"`)
 
-	k = kubectl.NewKubectlBuilder()
+	k = kubectl.NewBuilder()
 )
 
 // GetObject returns the object with the given key
@@ -206,7 +206,7 @@ func logDebugElement(caption string, info string, err error) {
 }
 
 func GetVersionFromIstiod() (*semver.Version, error) {
-	k := kubectl.NewKubectlBuilder()
+	k := kubectl.NewBuilder()
 	output, err := k.SetNamespace(controlPlaneNamespace).Exec("deploy/istiod", "", "pilot-discovery version")
 	if err != nil {
 		return nil, fmt.Errorf("error getting version from istiod: %w", err)

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -238,7 +238,7 @@ func (k Kubectl) GetInternalIP(label string) (string, error) {
 
 // Exec executes a command in the pod or specific container
 func (k Kubectl) Exec(pod, container, command string) (string, error) {
-	cmd := k.build(fmt.Sprintf(" exec %s %s -- %s", pod, containerflag(container), command))
+	cmd := k.build(fmt.Sprintf(" exec %s %s -- %s", pod, containerFlag(container), command))
 	output, err := k.executeCommand(cmd)
 	if err != nil {
 		return "", err
@@ -297,7 +297,7 @@ func labelFlag(label string) string {
 	return "-l " + label
 }
 
-func containerflag(container string) string {
+func containerFlag(container string) string {
 	if container == "" {
 		return ""
 	}

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -34,17 +34,12 @@ const DefaultBinary = "kubectl"
 // NewBuilder creates a new kubectl.Builder
 func NewBuilder() *Builder {
 	k := &Builder{}
-	k.setBinary()
-	return k
-}
-
-func (k *Builder) setBinary() {
-	binary := DefaultBinary
 	if cmd := os.Getenv("COMMAND"); cmd != "" {
-		binary = cmd
+		k.binary = cmd
+	} else {
+		k.binary = DefaultBinary
 	}
-
-	k.binary = binary
+	return k
 }
 
 func (k *Builder) build(cmd string) string {

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -31,8 +31,11 @@ type Builder struct {
 
 const DefaultBinary = "kubectl"
 
-func newBuilder() *Builder {
-	return &Builder{}
+// NewBuilder creates a new kubectl.Builder
+func NewBuilder() *Builder {
+	k := &Builder{}
+	k.setBinary()
+	return k
 }
 
 func (k *Builder) setBinary() {
@@ -61,13 +64,6 @@ func (k *Builder) build(cmd string) string {
 
 	// Join all the arguments with a space
 	return strings.Join(args, " ")
-}
-
-// NewBuilder creates a new kubectl.Builder
-func NewBuilder() *Builder {
-	k := newBuilder()
-	k.setBinary()
-	return k
 }
 
 // SetNamespace sets the namespace

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -29,8 +29,6 @@ type Kubectl struct {
 	kubeconfig string
 }
 
-const DefaultBinary = "kubectl"
-
 // New creates a new kubectl.Kubectl
 func New() Kubectl {
 	return Kubectl{}.WithBinary(os.Getenv("COMMAND"))
@@ -55,10 +53,10 @@ func (k Kubectl) build(cmd string) string {
 	return strings.Join(args, " ")
 }
 
-// WithBinary returns a new Kubectl with the binary set to the given value; if the value is "", DefaultBinary is used.
+// WithBinary returns a new Kubectl with the binary set to the given value; if the value is "", the binary is set to "kubectl"
 func (k Kubectl) WithBinary(binary string) Kubectl {
 	if binary == "" {
-		k.binary = DefaultBinary
+		k.binary = "kubectl"
 	} else {
 		k.binary = binary
 	}

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -32,17 +32,11 @@ type Builder struct {
 const DefaultBinary = "kubectl"
 
 // NewBuilder creates a new kubectl.Builder
-func NewBuilder() *Builder {
-	k := &Builder{}
-	if cmd := os.Getenv("COMMAND"); cmd != "" {
-		k.binary = cmd
-	} else {
-		k.binary = DefaultBinary
-	}
-	return k
+func NewBuilder() Builder {
+	return Builder{}.SetBinary(os.Getenv("COMMAND"))
 }
 
-func (k *Builder) build(cmd string) string {
+func (k Builder) build(cmd string) string {
 	args := []string{k.binary}
 
 	// Only append namespace if it's set
@@ -61,8 +55,18 @@ func (k *Builder) build(cmd string) string {
 	return strings.Join(args, " ")
 }
 
-// SetNamespace sets the namespace
-func (k *Builder) SetNamespace(ns string) *Builder {
+// SetBinary returns a new Builder with the binary set to the given value; if the value is "", DefaultBinary is used.
+func (k Builder) SetBinary(binary string) Builder {
+	if binary == "" {
+		k.binary = DefaultBinary
+	} else {
+		k.binary = binary
+	}
+	return k
+}
+
+// SetNamespace returns a new Builder with the namespace set to the given value
+func (k Builder) SetNamespace(ns string) Builder {
 	if ns == "" {
 		k.namespace = "--all-namespaces"
 	} else {
@@ -71,9 +75,11 @@ func (k *Builder) SetNamespace(ns string) *Builder {
 	return k
 }
 
-// SetKubeconfig sets the kubeconfig
-func (k *Builder) SetKubeconfig(kubeconfig string) *Builder {
-	if kubeconfig != "" {
+// SetKubeconfig returns a new Builder with kubeconfig set to the given value
+func (k Builder) SetKubeconfig(kubeconfig string) Builder {
+	if kubeconfig == "" {
+		k.kubeconfig = ""
+	} else {
 		k.kubeconfig = fmt.Sprintf("--kubeconfig %s", kubeconfig)
 	}
 	return k
@@ -81,7 +87,7 @@ func (k *Builder) SetKubeconfig(kubeconfig string) *Builder {
 
 // CreateNamespace creates a namespace
 // If the namespace already exists, it will return nil
-func (k *Builder) CreateNamespace(ns string) error {
+func (k Builder) CreateNamespace(ns string) error {
 	cmd := k.build(" create namespace " + ns)
 	output, err := k.executeCommand(cmd)
 	if err != nil {
@@ -96,10 +102,9 @@ func (k *Builder) CreateNamespace(ns string) error {
 }
 
 // CreateFromString creates a resource from the given yaml string
-func (k *Builder) CreateFromString(yamlString string) error {
+func (k Builder) CreateFromString(yamlString string) error {
 	cmd := k.build(" create -f -")
 	_, err := shell.ExecuteCommandWithInput(cmd, yamlString)
-	k.ResetNamespace()
 	if err != nil {
 		return fmt.Errorf("error creating resource from yaml: %w", err)
 	}
@@ -107,22 +112,20 @@ func (k *Builder) CreateFromString(yamlString string) error {
 }
 
 // DeleteCRDs deletes the CRDs by given list of crds names
-func (k *Builder) DeleteCRDs(crds []string) error {
+func (k Builder) DeleteCRDs(crds []string) error {
 	for _, crd := range crds {
 		cmd := k.build(" delete crd " + crd)
 		_, err := shell.ExecuteCommand(cmd)
 		if err != nil {
-			k.ResetNamespace()
 			return fmt.Errorf("error deleting crd %s: %w", crd, err)
 		}
 	}
 
-	k.ResetNamespace()
 	return nil
 }
 
 // DeleteNamespace deletes a namespace
-func (k *Builder) DeleteNamespace(ns string) error {
+func (k Builder) DeleteNamespace(ns string) error {
 	cmd := k.build(" delete namespace " + ns)
 	_, err := k.executeCommand(cmd)
 	if err != nil {
@@ -133,10 +136,9 @@ func (k *Builder) DeleteNamespace(ns string) error {
 }
 
 // ApplyString applies the given yaml string to the cluster
-func (k *Builder) ApplyString(yamlString string) error {
+func (k Builder) ApplyString(yamlString string) error {
 	cmd := k.build(" apply --server-side -f -")
 	_, err := shell.ExecuteCommandWithInput(cmd, yamlString)
-	k.ResetNamespace()
 	if err != nil {
 		return fmt.Errorf("error applying yaml: %w", err)
 	}
@@ -145,13 +147,13 @@ func (k *Builder) ApplyString(yamlString string) error {
 }
 
 // Apply applies the given yaml file to the cluster
-func (k *Builder) Apply(yamlFile string) error {
+func (k Builder) Apply(yamlFile string) error {
 	err := k.ApplyWithLabels(yamlFile, "")
 	return err
 }
 
 // ApplyWithLabels applies the given yaml file to the cluster with the given labels
-func (k *Builder) ApplyWithLabels(yamlFile, label string) error {
+func (k Builder) ApplyWithLabels(yamlFile, label string) error {
 	cmd := k.build(" apply " + labelFlag(label) + " -f " + yamlFile)
 	_, err := k.executeCommand(cmd)
 	if err != nil {
@@ -162,7 +164,7 @@ func (k *Builder) ApplyWithLabels(yamlFile, label string) error {
 }
 
 // DeleteFromFile deletes a resource from the given yaml file
-func (k *Builder) DeleteFromFile(yamlFile string) error {
+func (k Builder) DeleteFromFile(yamlFile string) error {
 	cmd := k.build(" delete -f " + yamlFile)
 	_, err := k.executeCommand(cmd)
 	if err != nil {
@@ -173,7 +175,7 @@ func (k *Builder) DeleteFromFile(yamlFile string) error {
 }
 
 // Delete deletes a resource based on the namespace, kind and the name
-func (k *Builder) Delete(kind, name string) error {
+func (k Builder) Delete(kind, name string) error {
 	cmd := k.build(" delete " + kind + " " + name)
 	_, err := k.executeCommand(cmd)
 	if err != nil {
@@ -184,7 +186,7 @@ func (k *Builder) Delete(kind, name string) error {
 }
 
 // Patch patches a resource
-func (k *Builder) Patch(kind, name, patchType, patch string) error {
+func (k Builder) Patch(kind, name, patchType, patch string) error {
 	cmd := k.build(fmt.Sprintf(" patch %s %s --type=%s -p=%q", kind, name, patchType, patch))
 	_, err := k.executeCommand(cmd)
 	if err != nil {
@@ -194,7 +196,7 @@ func (k *Builder) Patch(kind, name, patchType, patch string) error {
 }
 
 // ForceDelete deletes a resource by removing its finalizers
-func (k *Builder) ForceDelete(kind, name string) error {
+func (k Builder) ForceDelete(kind, name string) error {
 	// Not all resources have finalizers, trying to remove them returns an error here.
 	// We explicitly ignore the error and attempt to delete the resource anyway.
 	_ = k.Patch(kind, name, "json", `[{"op": "remove", "path": "/metadata/finalizers"}]`)
@@ -202,7 +204,7 @@ func (k *Builder) ForceDelete(kind, name string) error {
 }
 
 // GetYAML returns the yaml of a resource
-func (k *Builder) GetYAML(kind, name string) (string, error) {
+func (k Builder) GetYAML(kind, name string) (string, error) {
 	cmd := k.build(fmt.Sprintf(" get %s %s -o yaml", kind, name))
 	output, err := k.executeCommand(cmd)
 	if err != nil {
@@ -213,7 +215,7 @@ func (k *Builder) GetYAML(kind, name string) (string, error) {
 }
 
 // GetPods returns the pods of a namespace
-func (k *Builder) GetPods(args ...string) (string, error) {
+func (k Builder) GetPods(args ...string) (string, error) {
 	cmd := k.build(fmt.Sprintf(" get pods %s", strings.Join(args, " ")))
 	output, err := k.executeCommand(cmd)
 	if err != nil {
@@ -224,7 +226,7 @@ func (k *Builder) GetPods(args ...string) (string, error) {
 }
 
 // GetInternalIP returns the internal IP of a node
-func (k *Builder) GetInternalIP(label string) (string, error) {
+func (k Builder) GetInternalIP(label string) (string, error) {
 	cmd := k.build(fmt.Sprintf(" get nodes -l %s -o jsonpath='{.items[0].status.addresses[?(@.type==\"InternalIP\")].address}'", label))
 	output, err := k.executeCommand(cmd)
 	if err != nil {
@@ -235,7 +237,7 @@ func (k *Builder) GetInternalIP(label string) (string, error) {
 }
 
 // Exec executes a command in the pod or specific container
-func (k *Builder) Exec(pod, container, command string) (string, error) {
+func (k Builder) Exec(pod, container, command string) (string, error) {
 	cmd := k.build(fmt.Sprintf(" exec %s %s -- %s", pod, containerflag(container), command))
 	output, err := k.executeCommand(cmd)
 	if err != nil {
@@ -245,7 +247,7 @@ func (k *Builder) Exec(pod, container, command string) (string, error) {
 }
 
 // GetEvents returns the events of a namespace
-func (k *Builder) GetEvents() (string, error) {
+func (k Builder) GetEvents() (string, error) {
 	cmd := k.build(" get events")
 	output, err := k.executeCommand(cmd)
 	if err != nil {
@@ -256,7 +258,7 @@ func (k *Builder) GetEvents() (string, error) {
 }
 
 // Describe returns the description of a resource
-func (k *Builder) Describe(kind, name string) (string, error) {
+func (k Builder) Describe(kind, name string) (string, error) {
 	cmd := k.build(fmt.Sprintf(" describe %s %s", kind, name))
 	output, err := k.executeCommand(cmd)
 	if err != nil {
@@ -267,7 +269,7 @@ func (k *Builder) Describe(kind, name string) (string, error) {
 }
 
 // Logs returns the logs of a deployment
-func (k *Builder) Logs(pod string, since *time.Duration) (string, error) {
+func (k Builder) Logs(pod string, since *time.Duration) (string, error) {
 	cmd := k.build(fmt.Sprintf(" logs %s %s", pod, sinceFlag(since)))
 	output, err := shell.ExecuteCommand(cmd)
 	if err != nil {
@@ -277,15 +279,8 @@ func (k *Builder) Logs(pod string, since *time.Duration) (string, error) {
 }
 
 // executeCommand handles running the command and then resets the namespace automatically
-func (k *Builder) executeCommand(cmd string) (string, error) {
-	result, err := shell.ExecuteCommand(cmd)
-	k.ResetNamespace()
-	return result, err
-}
-
-// ResetNamespace resets the namespace
-func (k *Builder) ResetNamespace() {
-	k.namespace = ""
+func (k Builder) executeCommand(cmd string) (string, error) {
+	return shell.ExecuteCommand(cmd)
 }
 
 func sinceFlag(since *time.Duration) string {

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -33,7 +33,7 @@ const DefaultBinary = "kubectl"
 
 // NewBuilder creates a new kubectl.Builder
 func NewBuilder() Builder {
-	return Builder{}.SetBinary(os.Getenv("COMMAND"))
+	return Builder{}.WithBinary(os.Getenv("COMMAND"))
 }
 
 func (k Builder) build(cmd string) string {
@@ -55,8 +55,8 @@ func (k Builder) build(cmd string) string {
 	return strings.Join(args, " ")
 }
 
-// SetBinary returns a new Builder with the binary set to the given value; if the value is "", DefaultBinary is used.
-func (k Builder) SetBinary(binary string) Builder {
+// WithBinary returns a new Builder with the binary set to the given value; if the value is "", DefaultBinary is used.
+func (k Builder) WithBinary(binary string) Builder {
 	if binary == "" {
 		k.binary = DefaultBinary
 	} else {
@@ -65,8 +65,8 @@ func (k Builder) SetBinary(binary string) Builder {
 	return k
 }
 
-// SetNamespace returns a new Builder with the namespace set to the given value
-func (k Builder) SetNamespace(ns string) Builder {
+// WithNamespace returns a new Builder with the namespace set to the given value
+func (k Builder) WithNamespace(ns string) Builder {
 	if ns == "" {
 		k.namespace = "--all-namespaces"
 	} else {
@@ -75,8 +75,8 @@ func (k Builder) SetNamespace(ns string) Builder {
 	return k
 }
 
-// SetKubeconfig returns a new Builder with kubeconfig set to the given value
-func (k Builder) SetKubeconfig(kubeconfig string) Builder {
+// WithKubeconfig returns a new Builder with kubeconfig set to the given value
+func (k Builder) WithKubeconfig(kubeconfig string) Builder {
 	if kubeconfig == "" {
 		k.kubeconfig = ""
 	} else {


### PR DESCRIPTION
The main purpose of these changes is to prevent bugs when kubectl.Builder (now called kubectl.Kubectl) is used in multiple places. Previously, if you called `SetNamespace()`, you had to also call `ResetNamespace()` afterwards so that the next invocation of the tool defaults back to no namespace. This also means that the tool wasn't thread-safe.