### PR TITLE
Generate asciidoc API reference

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -395,7 +395,8 @@ gen-check: gen restore-manifest-dates check-clean-repo ## Verify that changes in
 CRD_PATH := ./api
 OUTPUT_DOCS_PATH := ./docs/api-reference
 CONFIG_API_DOCS_GEN_PATH := ./hack/api-docs/config.yaml
-TEMPLATES_DIR := ./hack/api-docs/templates/markdown
+DOCS_RENDERER := markdown
+TEMPLATES_DIR := ./hack/api-docs/templates/$(DOCS_RENDERER)
 
 gen-api-docs: ## Generate API documentation. Known issues: go fmt does not properly handle tabs and add new line empty. Workaround is applied to the generated markdown files. The crd-ref-docs tool add br tags to the generated markdown files. Workaround is applied to the generated markdown files.
 	@echo "Generating API documentation..."
@@ -405,12 +406,12 @@ gen-api-docs: ## Generate API documentation. Known issues: go fmt does not prope
 		--source-path=$(CRD_PATH) \
 		--templates-dir=$(TEMPLATES_DIR) \
 		--config=$(CONFIG_API_DOCS_GEN_PATH) \
-		--renderer=markdown \
+		--renderer=$(DOCS_RENDERER) \
 		--output-path=$(OUTPUT_DOCS_PATH) \
 		--output-mode=group
 	@find $(OUTPUT_DOCS_PATH) -type f -name "*.md" -exec sed -i 's/<br \/>/ /g' {} \;
 	@find $(OUTPUT_DOCS_PATH) -type f -name "*.md" -exec sed -i 's/\t/  /g' {} \;
-	@find $(OUTPUT_DOCS_PATH) -type f -name "*.md" -exec sed -i '/^```/,/^```/ {/./!d;}' {} \;
+	@find $(OUTPUT_DOCS_PATH) -type f \( -name "*.md" -o -name "*.asciidoc" \) -exec sed -i '/^```/,/^```/ {/./!d;}' {} \;
 	@echo "API reference documentation generated at $(OUTPUT_DOCS_PATH)"
 
 .PHONY: restore-manifest-dates

--- a/hack/api-docs/templates/asciidoctor/gv_details.tpl
+++ b/hack/api-docs/templates/asciidoctor/gv_details.tpl
@@ -1,0 +1,19 @@
+{{- define "gvDetails" -}}
+{{- $gv := . -}}
+[id="{{ asciidocGroupVersionID $gv | asciidocRenderAnchorID }}"]
+=== {{ $gv.GroupVersionString }}
+
+{{ $gv.Doc }}
+
+{{- if $gv.Kinds  }}
+.Resource Types
+{{- range $gv.SortedKinds }}
+- {{ $gv.TypeForKind . | asciidocRenderTypeLink }}
+{{- end }}
+{{ end }}
+
+{{ range $gv.SortedTypes }}
+{{ template "type" . }}
+{{ end }}
+
+{{- end -}}

--- a/hack/api-docs/templates/asciidoctor/gv_list.tpl
+++ b/hack/api-docs/templates/asciidoctor/gv_list.tpl
@@ -1,0 +1,16 @@
+{{- define "gvList" -}}
+{{- $groupVersions := . -}}
+
+[id="{p}-api-reference"]
+== API Reference
+
+.Packages
+{{- range $groupVersions }}
+- {{ asciidocRenderGVLink . }}
+{{- end }}
+
+{{ range $groupVersions }}
+{{ template "gvDetails" . }}
+{{ end }}
+
+{{- end -}}

--- a/hack/api-docs/templates/asciidoctor/type.tpl
+++ b/hack/api-docs/templates/asciidoctor/type.tpl
@@ -1,0 +1,58 @@
+{{- define "type" -}}
+{{- $type := . -}}
+{{- if asciidocShouldRenderType $type -}}
+{{- if not $type.Markers.hidefromdoc -}}
+
+[id="{{ asciidocTypeID $type | asciidocRenderAnchorID }}"]
+==== {{ $type.Name  }}
+
+{{ if $type.IsAlias }}_Underlying type:_ _{{ asciidocRenderTypeLink $type.UnderlyingType  }}_{{ end }}
+
+{{ $type.Doc }}
+
+{{ if $type.Validation -}}
+.Validation:
+{{- range $type.Validation }}
+- {{ . }}
+{{- end }}
+{{- end }}
+
+{{ if $type.References -}}
+.Appears In:
+****
+{{- range $type.SortedReferences }}
+- {{ asciidocRenderTypeLink . }}
+{{- end }}
+****
+{{- end }}
+
+{{ if $type.Members -}}
+[cols="20a,50a,15a,15a", options="header"]
+|===
+| Field | Description | Default | Validation
+{{ if $type.GVK -}}
+| *`apiVersion`* __string__ | `{{ $type.GVK.Group }}/{{ $type.GVK.Version }}` | |
+| *`kind`* __string__ | `{{ $type.GVK.Kind }}` | |
+{{ end -}}
+
+{{ range $type.Members -}}
+{{ with .Markers.hidefromdoc -}}
+{{ else -}}
+| *`{{ .Name  }}`* __{{ asciidocRenderType .Type }}__ | {{ template "type_members" . }} | {{ .Default }} | {{ range .Validation -}} {{ asciidocRenderValidation . }} +{{ end }}
+{{ end }}
+{{ end -}}
+|===
+{{ end -}}
+
+{{ if $type.EnumValues -}} 
+|===
+| Field | Description |
+{{ range $type.EnumValues -}}
+| `{{ .Name }}` | {{ asciidocRenderFieldDoc .Doc }} +
+{{ end -}}
+|===
+{{ end -}}
+
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/hack/api-docs/templates/asciidoctor/type_members.tpl
+++ b/hack/api-docs/templates/asciidoctor/type_members.tpl
@@ -1,0 +1,8 @@
+{{- define "type_members" -}}
+{{- $field := . -}}
+{{- if eq $field.Name "metadata" -}}
+Refer to Kubernetes API documentation for fields of `metadata`.
+{{ else -}}
+{{ asciidocRenderFieldDoc $field.Doc }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Add the possibility to generate API reference in asciidoc format (example of generated [sailoperator.io.asciidoc](https://gist.github.com/bmangoen/f744019fd12cad940d37b1b6be2bd377#file-sailoperato-io-asciidoc) file)

Related Issue [OSSM-6856](https://issues.redhat.com/browse/OSSM-6856)