### PR TITLE
Use upstream builder image in update-deps workflow

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -22,12 +22,18 @@ env:
 jobs:
   update-deps:
     runs-on: ubuntu-latest
+    container:
+      image: gcr.io/istio-testing/build-tools:master-8eb42e9551b9a67c330aeef783f2498647d91289
+      options: --entrypoint ''
 
     steps:
     - uses: actions/checkout@v4
       with:
         repository: istio/test-infra
         ref: master
+
+    # this is a workaround for a permissions issue when using the istio build container
+    - run: git config --system --add safe.directory /__w/sail-operator/sail-operator
 
     - name: Run Automator
       run: |
@@ -37,7 +43,8 @@ jobs:
           --branch=$AUTOMATOR_BRANCH \
           '--title=Automator: Update dependencies in $AUTOMATOR_ORG/$AUTOMATOR_REPO@$AUTOMATOR_BRANCH' \
           --labels=auto-merge \
+          --email=openshiftservicemeshbot@gmail.com \
           --modifier=update_deps \
           --token-env \
-          --cmd=./tools/update_deps.sh \
+          --cmd='BUILD_WITH_CONTAINER=0 ./tools/update_deps.sh' \
           --signoff

--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -31,6 +31,10 @@ function getLatestVersion() {
 # Update common files
 make update-common
 
+# update build container used in github actions
+NEW_IMAGE_MASTER=$(grep IMAGE_VERSION= < common/scripts/setup_env.sh | cut -d= -f2)
+sed -i -e "s|\(gcr.io/istio-testing/build-tools\):master.*|\1:$NEW_IMAGE_MASTER|" .github/workflows/update-deps.yaml
+
 # Update go dependencies
 export GO111MODULE=on
 go get -u "istio.io/istio@${UPDATE_BRANCH}"


### PR DESCRIPTION
Turns out we need the upstream image in order for the pr-creator tool to be present.

Sorry about this one. This time I tested end-to-end on my fork.

Fixes #390
