### PR TITLE
Skip control plane tests for dualStack job

### DIFF
--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -42,13 +42,14 @@ var (
 	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io")
 	bookinfoNamespace     = env.Get("BOOKINFO_NAMESPACE", "bookinfo")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
+	ipFamily              = env.Get("IP_FAMILY", "ipv4")
 
 	k kubectl.Kubectl
 )
 
 func TestInstall(t *testing.T) {
-	if multicluster {
-		t.Skip("Skipping test for multicluster")
+	if ipFamily == "dual" || multicluster {
+		t.Skip("Skipping the control plane tests")
 	}
 	RegisterFailHandler(Fail)
 	setup()


### PR DESCRIPTION
The control plane test suite currently takes around 10 minutes, while the dualStack tests take about 3 minutes. The value of running control plane tests in their current form on a dualStack cluster appears minimal, as these tests do not validate any datapath use cases. Therefore, let's skip the control plane tests for now.