### PR TITLE
Support metrics on dualStack clusters

### DIFF
--- a/bundle/manifests/sail-operator-metrics-service_v1_service.yaml
+++ b/bundle/manifests/sail-operator-metrics-service_v1_service.yaml
@@ -12,6 +12,7 @@ metadata:
     control-plane: sail-operator
   name: sail-operator-metrics-service
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - name: https
     port: 8443

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/sail-operator:0.2-latest
-    createdAt: "2024-10-17T05:05:02Z"
+    createdAt: "2024-10-17T09:56:08Z"
     description: Experimental operator for installing Istio service mesh
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -639,7 +639,7 @@ spec:
                         - linux
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
+                - --secure-listen-address=:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0

--- a/chart/templates/auth_proxy_service.yaml
+++ b/chart/templates/auth_proxy_service.yaml
@@ -12,6 +12,7 @@ metadata:
   name: {{ .Values.deployment.name }}-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - name: https
     port: 8443

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
                 - linux
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
+        - --secure-listen-address=:8443
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0


### PR DESCRIPTION
Sail Operator uses `kube-rbac-proxy` to serve metrics securely.
It is configured to listen on `secure-listen-address` with an
`upstream` that points to the actual metrics server in the Sail
Operator listening on the loopback interface. Currently, the 
`secure-listen-address` is configured with "0.0.0.0:8443" and this
PR updates it to ":8443" so that it can listen on both IPv4 and 
IPv6 interfaces.

This PR also modifies the spec.ipFamilyPolicy of                                                                                                                                              
sail-operator-metrics-service to PreferDualStack, so that it can 
support all types of clusters.

Related to: https://github.com/istio-ecosystem/sail-operator/issues/372
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

Notes:
----------
Accessing the Sail Operator metrics using the metrics service (with the right RBAC) over IPv4 address.
```
~ $ curl -4 -s -k -H "Authorization: Bearer `cat /var/run/secrets/kubernetes.io/serviceaccount/token`" https://sail-operator-metrics-service.sail-operator.svc.cluster.local:8443/metrics
# HELP certwatcher_read_certificate_errors_total Total number of certificate read errors
# TYPE certwatcher_read_certificate_errors_total counter
certwatcher_read_certificate_errors_total 0
# HELP certwatcher_read_certificate_total Total number of certificate reads
...
```

Similarly, via IPv6 address
```
~ $ curl -6 -s -k -H "Authorization: Bearer `cat /var/run/secrets/kubernetes.io/serviceaccount/token`" https://sail-operator-metrics-service.sail-operator.svc.cluster.local:8443/metrics
# HELP certwatcher_read_certificate_errors_total Total number of certificate read errors
# TYPE certwatcher_read_certificate_errors_total counter
certwatcher_read_certificate_errors_total 0
# HELP certwatcher_read_certificate_total Total number of certificate reads
...
```
