### PR TITLE
Include integration tests in code coverage calculation

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,12 +10,12 @@ jobs:
 
     - name: Run coverage
       run: |
-        make test.unit \
+        make test \
           -e COVERAGE=true
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v4
       with:
-        file: out/coverage.out
+        files: out/coverage-unit.out,out/coverage-integration.out
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -71,8 +71,8 @@ ENVTEST_K8S_VERSION ?= 1.29.0
 # Set DOCKER_BUILD_FLAGS to specify flags to pass to 'docker build', default to empty. Example: --platform=linux/arm64
 DOCKER_BUILD_FLAGS ?= "--platform=$(TARGET_OS)/$(TARGET_ARCH)"
 
-GOTEST_FLAGS := $(if $(VERBOSE),-v) $(if $(COVERAGE),-coverprofile=$(REPO_ROOT)/out/coverage.out)
-GINKGO_FLAGS := $(if $(VERBOSE),-v) $(if $(CI),--no-color)
+GOTEST_FLAGS := $(if $(VERBOSE),-v) $(if $(COVERAGE),-coverprofile=$(REPO_ROOT)/out/coverage-unit.out)
+GINKGO_FLAGS := $(if $(VERBOSE),-v) $(if $(CI),--no-color) $(if $(COVERAGE),-coverprofile=coverage-integration.out -coverpkg=./... --output-dir=out)
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")


### PR DESCRIPTION
This makes sure we're also measuring code coverage for our integration tests. I hope codecov is smart enough to merge the files.