### PR TITLE
Remove `--default-profile` in favor of automatic platform detection

### DIFF
--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/sail-operator:0.2-latest
-    createdAt: "2024-10-17T09:56:08Z"
+    createdAt: "2024-10-17T16:01:13Z"
     description: Experimental operator for installing Istio service mesh
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -665,7 +665,6 @@ spec:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --zap-log-level=info
-                - --default-profile=openshift
                 command:
                 - /sail-operator
                 image: quay.io/maistra-dev/sail-operator:0.2-latest

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -78,9 +78,6 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --zap-log-level={{ .Values.operatorLogLevel }}
-{{- if eq .Values.platform "openshift" }}
-        - --default-profile=openshift
-{{- end }}
         command:
         - /sail-operator
         image: {{ .Values.image }}

--- a/pkg/config/platform.go
+++ b/pkg/config/platform.go
@@ -17,6 +17,7 @@ package config
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 )
@@ -41,7 +42,9 @@ func DetectPlatform(cfg *rest.Config) (Platform, error) {
 	}
 
 	resources, err := dc.ServerResourcesForGroupVersion(openshiftResourceGroup + "/" + openshiftResourceVersion)
-	if err != nil {
+	if errors.IsNotFound(err) {
+		return PlatformKubernetes, nil
+	} else if err != nil {
 		return "", err
 	}
 

--- a/pkg/config/platform.go
+++ b/pkg/config/platform.go
@@ -1,0 +1,54 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+type Platform string
+
+const (
+	PlatformOpenShift  Platform = "openshift"
+	PlatformKubernetes Platform = "kubernetes"
+)
+
+const (
+	openshiftKind            = "OpenShiftAPIServer"
+	openshiftResourceGroup   = "operator.openshift.io"
+	openshiftResourceVersion = "v1"
+)
+
+func DetectPlatform(cfg *rest.Config) (Platform, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to create discoveryClient: %w", err)
+	}
+
+	resources, err := dc.ServerResourcesForGroupVersion(openshiftResourceGroup + "/" + openshiftResourceVersion)
+	if err != nil {
+		return "", err
+	}
+
+	for _, apiResource := range resources.APIResources {
+		if apiResource.Kind == openshiftKind {
+			return PlatformOpenShift, nil
+		}
+	}
+	return PlatformKubernetes, nil
+}


### PR DESCRIPTION
Fixes #351 

When the operator detects that it's running on OpenShift, it sets the default profile to "openshift".