### PR TITLE
Ignore istio version suffix used in the downstream builds

### DIFF
--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -55,7 +55,8 @@ var (
 	// - 1.22.2
 	// - 1.23.0-rc.1
 	// - 1.24-alpha.feabc1234
-	istiodVersionRegex = regexp.MustCompile(`Version:"([^"]*)"`)
+	// matching only the version before first '_' which is used in the downstream builds, e.g. "1.23.2_ossm_tp.2"
+	istiodVersionRegex = regexp.MustCompile(`Version:"([^"_]*)[^"]*"`)
 
 	k = kubectl.New()
 )


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
The test is expecting to see the same version parsed from versions.yaml and a version string returned by `pilot-discovery version`. This is not the same in downstream builds as we use the `_ossm` suffix.

