### PR TITLE
Consolidate reconciler config fields into ReconcilerConfig

### DIFF
--- a/controllers/istio/istio_controller.go
+++ b/controllers/istio/istio_controller.go
@@ -46,20 +46,16 @@ import (
 
 // Reconciler reconciles an Istio object
 type Reconciler struct {
-	ResourceDirectory string
-	Platform          config.Platform
-	DefaultProfile    string
+	Config config.ReconcilerConfig
 	client.Client
 	Scheme *runtime.Scheme
 }
 
-func NewReconciler(client client.Client, scheme *runtime.Scheme, resourceDir string, platform config.Platform, defaultProfile string) *Reconciler {
+func NewReconciler(cfg config.ReconcilerConfig, client client.Client, scheme *runtime.Scheme) *Reconciler {
 	return &Reconciler{
-		ResourceDirectory: resourceDir,
-		Platform:          platform,
-		DefaultProfile:    defaultProfile,
-		Client:            client,
-		Scheme:            scheme,
+		Config: cfg,
+		Client: client,
+		Scheme: scheme,
 	}
 }
 
@@ -111,8 +107,8 @@ func validate(istio *v1alpha1.Istio) error {
 func (r *Reconciler) reconcileActiveRevision(ctx context.Context, istio *v1alpha1.Istio) error {
 	values, err := revision.ComputeValues(
 		istio.Spec.Values, istio.Spec.Namespace, istio.Spec.Version,
-		r.Platform, r.DefaultProfile, istio.Spec.Profile,
-		r.ResourceDirectory, getActiveRevisionName(istio))
+		r.Config.Platform, r.Config.DefaultProfile, istio.Spec.Profile,
+		r.Config.ResourceDirectory, getActiveRevisionName(istio))
 	if err != nil {
 		return err
 	}

--- a/controllers/istiorevision/istiorevision_controller.go
+++ b/controllers/istiorevision/istiorevision_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/istio-ecosystem/sail-operator/api/v1alpha1"
+	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/constants"
 	"github.com/istio-ecosystem/sail-operator/pkg/enqueuelogger"
 	"github.com/istio-ecosystem/sail-operator/pkg/errlist"
@@ -67,17 +68,17 @@ const (
 // Reconciler reconciles an IstioRevision object
 type Reconciler struct {
 	client.Client
-	Scheme            *runtime.Scheme
-	ResourceDirectory string
-	ChartManager      *helm.ChartManager
+	Config       config.ReconcilerConfig
+	Scheme       *runtime.Scheme
+	ChartManager *helm.ChartManager
 }
 
-func NewReconciler(client client.Client, scheme *runtime.Scheme, resourceDir string, chartManager *helm.ChartManager) *Reconciler {
+func NewReconciler(cfg config.ReconcilerConfig, client client.Client, scheme *runtime.Scheme, chartManager *helm.ChartManager) *Reconciler {
 	return &Reconciler{
-		Client:            client,
-		Scheme:            scheme,
-		ResourceDirectory: resourceDir,
-		ChartManager:      chartManager,
+		Config:       cfg,
+		Client:       client,
+		Scheme:       scheme,
+		ChartManager: chartManager,
 	}
 }
 
@@ -181,7 +182,7 @@ func getReleaseName(rev *v1alpha1.IstioRevision) string {
 }
 
 func (r *Reconciler) getChartDir(rev *v1alpha1.IstioRevision) string {
-	return path.Join(r.ResourceDirectory, rev.Spec.Version, "charts", getChartName(rev))
+	return path.Join(r.Config.ResourceDirectory, rev.Spec.Version, "charts", getChartName(rev))
 }
 
 func getChartName(rev *v1alpha1.IstioRevision) string {

--- a/controllers/remoteistio/remoteistio_controller.go
+++ b/controllers/remoteistio/remoteistio_controller.go
@@ -44,20 +44,16 @@ import (
 
 // Reconciler reconciles a RemoteIstio object
 type Reconciler struct {
-	ResourceDirectory string
-	Platform          config.Platform
-	DefaultProfile    string
+	Config config.ReconcilerConfig
 	client.Client
 	Scheme *runtime.Scheme
 }
 
-func NewReconciler(client client.Client, scheme *runtime.Scheme, resourceDir string, platform config.Platform, defaultProfile string) *Reconciler {
+func NewReconciler(cfg config.ReconcilerConfig, client client.Client, scheme *runtime.Scheme) *Reconciler {
 	return &Reconciler{
-		ResourceDirectory: resourceDir,
-		Platform:          platform,
-		DefaultProfile:    defaultProfile,
-		Client:            client,
-		Scheme:            scheme,
+		Config: cfg,
+		Client: client,
+		Scheme: scheme,
 	}
 }
 
@@ -109,8 +105,8 @@ func validate(istio *v1alpha1.RemoteIstio) error {
 func (r *Reconciler) reconcileActiveRevision(ctx context.Context, istio *v1alpha1.RemoteIstio) error {
 	values, err := revision.ComputeValues(
 		istio.Spec.Values, istio.Spec.Namespace, istio.Spec.Version,
-		r.Platform, r.DefaultProfile, istio.Spec.Profile,
-		r.ResourceDirectory, getActiveRevisionName(istio))
+		r.Config.Platform, r.Config.DefaultProfile, istio.Spec.Profile,
+		r.Config.ResourceDirectory, getActiveRevisionName(istio))
 	if err != nil {
 		return err
 	}

--- a/controllers/remoteistio/remoteistio_controller_test.go
+++ b/controllers/remoteistio/remoteistio_controller_test.go
@@ -51,7 +51,7 @@ var (
 )
 
 func TestReconcile(t *testing.T) {
-	resourceDir := t.TempDir()
+	cfg := newReconcilerTestConfig(t)
 
 	t.Run("returns error when Istio version not set", func(t *testing.T) {
 		istio := &v1alpha1.RemoteIstio{
@@ -61,7 +61,7 @@ func TestReconcile(t *testing.T) {
 		cl := newFakeClientBuilder().
 			WithObjects(istio).
 			Build()
-		reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, config.PlatformKubernetes, "")
+		reconciler := NewReconciler(cfg, cl, scheme.Scheme)
 
 		_, err := reconciler.Reconcile(ctx, istio)
 		if err == nil {
@@ -97,7 +97,9 @@ func TestReconcile(t *testing.T) {
 			WithStatusSubresource(&v1alpha1.RemoteIstio{}).
 			WithObjects(istio).
 			Build()
-		reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, config.PlatformKubernetes, "invalid-profile")
+		cfg := newReconcilerTestConfig(t)
+		cfg.DefaultProfile = "invalid-profile"
+		reconciler := NewReconciler(cfg, cl, scheme.Scheme)
 
 		_, err := reconciler.Reconcile(ctx, istio)
 		if err == nil {
@@ -137,7 +139,7 @@ func TestReconcile(t *testing.T) {
 				},
 			}).
 			Build()
-		reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, config.PlatformKubernetes, "")
+		reconciler := NewReconciler(cfg, cl, scheme.Scheme)
 
 		_, err := reconciler.Reconcile(ctx, istio)
 		if err == nil {
@@ -222,7 +224,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestDetermineStatus(t *testing.T) {
-	resourceDir := t.TempDir()
+	cfg := newReconcilerTestConfig(t)
 
 	generation := int64(100)
 
@@ -533,7 +535,7 @@ func TestDetermineStatus(t *testing.T) {
 				WithObjects(initObjs...).
 				WithInterceptorFuncs(interceptorFuncs).
 				Build()
-			reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, config.PlatformKubernetes, "")
+			reconciler := NewReconciler(cfg, cl, scheme.Scheme)
 
 			status, err := reconciler.determineStatus(ctx, istio, tc.reconciliationErr)
 			if (err != nil) != tc.wantErr {
@@ -548,7 +550,7 @@ func TestDetermineStatus(t *testing.T) {
 }
 
 func TestUpdateStatus(t *testing.T) {
-	resourceDir := t.TempDir()
+	cfg := newReconcilerTestConfig(t)
 
 	generation := int64(100)
 	oneMinuteAgo := testtime.OneMinuteAgo()
@@ -734,7 +736,7 @@ func TestUpdateStatus(t *testing.T) {
 				WithObjects(initObjs...).
 				WithInterceptorFuncs(interceptorFuncs).
 				Build()
-			reconciler := NewReconciler(cl, scheme.Scheme, resourceDir, config.PlatformKubernetes, "")
+			reconciler := NewReconciler(cfg, cl, scheme.Scheme)
 
 			err := reconciler.updateStatus(ctx, istio, tc.reconciliationErr)
 			if (err != nil) != tc.wantErr {
@@ -913,5 +915,13 @@ func noWrites(t *testing.T) interceptor.Funcs {
 			t.Fatalf("unexpected call to SubResourcePatch with the object %+v: %v", obj, string(debug.Stack()))
 			return nil
 		},
+	}
+}
+
+func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
+	return config.ReconcilerConfig{
+		ResourceDirectory: t.TempDir(),
+		Platform:          config.PlatformKubernetes,
+		DefaultProfile:    "",
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,12 @@ type IstioImageConfig struct {
 	ZTunnelImage string `properties:"ztunnel"`
 }
 
+type ReconcilerConfig struct {
+	ResourceDirectory string
+	Platform          Platform
+	DefaultProfile    string
+}
+
 func Read(configFile string) error {
 	p, err := properties.LoadFile(configFile, properties.UTF8)
 	if err != nil {

--- a/tests/integration/api/suite_test.go
+++ b/tests/integration/api/suite_test.go
@@ -73,19 +73,19 @@ var _ = BeforeSuite(func() {
 	}
 
 	chartManager := helm.NewChartManager(mgr.GetConfig(), "")
-	resourceDir := path.Join(project.RootDir, "resources")
 
-	Expect(istio.NewReconciler(mgr.GetClient(), mgr.GetScheme(), resourceDir, config.PlatformKubernetes, "").
-		SetupWithManager(mgr)).To(Succeed())
+	cfg := config.ReconcilerConfig{
+		ResourceDirectory: path.Join(project.RootDir, "resources"),
+		Platform:          config.PlatformKubernetes,
+		DefaultProfile:    "",
+	}
 
-	Expect(remoteistio.NewReconciler(mgr.GetClient(), mgr.GetScheme(), resourceDir, config.PlatformKubernetes, "").
-		SetupWithManager(mgr)).To(Succeed())
-
-	Expect(istiorevision.NewReconciler(mgr.GetClient(), mgr.GetScheme(), resourceDir, chartManager).
-		SetupWithManager(mgr)).To(Succeed())
-
-	Expect(istiocni.NewReconciler(mgr.GetClient(), mgr.GetScheme(), resourceDir, chartManager, config.PlatformKubernetes, "").
-		SetupWithManager(mgr)).To(Succeed())
+	cl := mgr.GetClient()
+	scheme := mgr.GetScheme()
+	Expect(istio.NewReconciler(cfg, cl, scheme).SetupWithManager(mgr)).To(Succeed())
+	Expect(remoteistio.NewReconciler(cfg, cl, scheme).SetupWithManager(mgr)).To(Succeed())
+	Expect(istiorevision.NewReconciler(cfg, cl, scheme, chartManager).SetupWithManager(mgr)).To(Succeed())
+	Expect(istiocni.NewReconciler(cfg, cl, scheme, chartManager).SetupWithManager(mgr)).To(Succeed())
 
 	// create new cancellable context
 	var ctx context.Context


### PR DESCRIPTION
Most reconcilers need the same three config fields: `ResourceDirectory`, `Platform`, and `DefaultProfile`. Instead of passing these fields separately, we now pass them via a `ReconcilerConfig` struct.