### PR TITLE
Minor updates to Gateway docs

### DIFF
--- a/docs/common/create-and-configure-gateways.md
+++ b/docs/common/create-and-configure-gateways.md
@@ -13,7 +13,7 @@ You can deploy gateways using either the Gateway API or Gateway Injection method
 Gateway Injection uses the same mechanisms as Istio sidecar injection to create 
 a gateway from a `Deployment` resource that is paired with a `Service` resource 
 that can be made accessible from outside the cluster. For more information, see 
-[Installing Gateways](https://preliminary.istio.io/latest/docs/setup/additional-setup/gateway/#deploying-a-gateway).
+[Installing Gateways](https://istio.io/latest/docs/setup/additional-setup/gateway/#deploying-a-gateway).
 
 To configure gateway injection with the `bookinfo` application, we have provided 
 a [sample gateway configuration](../../chart/samples/ingress-gateway.yaml?raw=1) that should be applied in the namespace 
@@ -22,7 +22,7 @@ where the application is installed:
 1. Create the `istio-ingressgateway` deployment and service:
 
     ```sh
-    $ oc apply -f -n <app-namespace> ingress-gateway.yaml
+    $ oc apply -f ingress-gateway.yaml
     ```
 
 2. Configure the `bookinfo` application with the new gateway:


### PR DESCRIPTION
This PR makes the following updates:
1. Updates the link to the gateway deployment to use istio.io instead of preliminary.istio.io
2. Removes the namespace reference to align with the recommendation that the gateway should be deployed in the same namespace as the application.

