### PR TITLE
Remove redundant variable copying in for loops

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -18,7 +18,7 @@ linters:
   disable-all: true
   enable:
     - errcheck
-    - exportloopref
+    - copyloopvar
     - depguard
     - gocritic
     - gofumpt

--- a/controllers/istio/istio_controller_test.go
+++ b/controllers/istio/istio_controller_test.go
@@ -527,7 +527,6 @@ func TestDetermineStatus(t *testing.T) {
 
 			initObjs := []client.Object{istio}
 			for _, rev := range tc.revisions {
-				rev := rev
 				initObjs = append(initObjs, &rev)
 			}
 
@@ -728,7 +727,6 @@ func TestUpdateStatus(t *testing.T) {
 
 			initObjs := []client.Object{istio}
 			for _, rev := range tc.revisions {
-				rev := rev
 				initObjs = append(initObjs, &rev)
 			}
 

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -117,9 +117,6 @@ metadata:
 
 	Describe("given Istio version", func() {
 		for _, version := range supportedversion.List {
-			// Note: This var version is needed to avoid the closure of the loop
-			version := version
-
 			Context(version.Name, func() {
 				BeforeAll(func() {
 					Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -70,9 +70,6 @@ var _ = Describe("DualStack configuration ", Ordered, func() {
 
 	Describe("for supported versions", func() {
 		for _, version := range supportedversion.List {
-			// Note: This var version is needed to avoid the closure of the loop
-			version := version
-
 			// The minimum supported version is 1.23 (and above)
 			if version.Version.LessThan(semver.MustParse("1.23.0")) {
 				continue

--- a/tests/integration/api/istio_test.go
+++ b/tests/integration/api/istio_test.go
@@ -222,8 +222,6 @@ var _ = Describe("Istio resource", Ordered, func() {
 		})
 
 		for _, withWorkloads := range []bool{true, false} {
-			withWorkloads := withWorkloads
-
 			Context(generateContextName(withWorkloads), func() {
 				if withWorkloads {
 					BeforeAll(func() {


### PR DESCRIPTION
With the release of Go 1.22, it's no longer necessary to manually copy loop variables inside for loops.