### PR TITLE
Centralize the way the sample apps yaml are being set to be deployed

### DIFF
--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -40,7 +40,7 @@ var (
 	istioCniName          = env.Get("ISTIOCNI_NAME", "default")
 	skipDeploy            = env.GetBool("SKIP_DEPLOY", false)
 	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io")
-	bookinfoNamespace     = env.Get("BOOKINFO_NAMESPACE", "bookinfo")
+	sampleNamespace       = env.Get("SAMPLE_NAMESPACE", "sample")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 	ipFamily              = env.Get("IP_FAMILY", "ipv4")
 

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -227,7 +227,7 @@ spec:
 						Expect(k.Patch("namespace", sampleNamespace, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
 							To(Succeed(), "Error patching sample namespace")
 						Expect(k.WithNamespace(sampleNamespace).
-							ApplyWithLabels(common.GetYAMLPodURL(version, sampleNamespace), "version=v1")).
+							ApplyWithLabels(common.GetSampleYAML(version, sampleNamespace), "version=v1")).
 							To(Succeed(), "Error deploying sample")
 						Success("sample deployed")
 					})

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -221,31 +221,39 @@ spec:
 					})
 				})
 
-				When("bookinfo is deployed", func() {
+				When("sample pod is deployed", func() {
 					BeforeAll(func() {
-						Expect(k.CreateNamespace(bookinfoNamespace)).To(Succeed(), "Bookinfo namespace failed to be created")
-						Expect(k.Patch("namespace", bookinfoNamespace, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
-							To(Succeed(), "Error patching bookinfo namespace")
-						Expect(deployBookinfo(version)).To(Succeed(), "Error deploying bookinfo")
-						Success("Bookinfo deployed")
+						Expect(k.CreateNamespace(sampleNamespace)).To(Succeed(), "Sample namespace failed to be created")
+						Expect(k.Patch("namespace", sampleNamespace, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
+							To(Succeed(), "Error patching sample namespace")
+						Expect(k.WithNamespace(sampleNamespace).
+							ApplyWithLabels(common.GetYAMLPodURL(version, sampleNamespace), "version=v1")).
+							To(Succeed(), "Error deploying sample")
+						Success("sample deployed")
 					})
 
-					bookinfoPods := &corev1.PodList{}
+					samplePods := &corev1.PodList{}
 
 					It("updates the pods status to Running", func(ctx SpecContext) {
-						Expect(cl.List(ctx, bookinfoPods, client.InNamespace(bookinfoNamespace))).To(Succeed())
-						Expect(bookinfoPods.Items).ToNot(BeEmpty(), "No pods found in bookinfo namespace")
+						Eventually(func() bool {
+							// Wait until the sample pod exists. Is wraped inside a function to avoid failure on the first iteration
+							Expect(cl.List(ctx, samplePods, client.InNamespace(sampleNamespace))).To(Succeed())
+							return len(samplePods.Items) > 0
+						}).Should(BeTrue(), "No sample pods found")
 
-						for _, pod := range bookinfoPods.Items {
-							Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(pod.Name, bookinfoNamespace), &corev1.Pod{}).
+						Expect(cl.List(ctx, samplePods, client.InNamespace(sampleNamespace))).To(Succeed())
+						Expect(samplePods.Items).ToNot(BeEmpty(), "No pods found in sample namespace")
+
+						for _, pod := range samplePods.Items {
+							Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(pod.Name, sampleNamespace), &corev1.Pod{}).
 								Should(HaveCondition(corev1.PodReady, metav1.ConditionTrue), "Pod is not Ready")
 						}
-						Success("Bookinfo pods are ready")
+						Success("sample pods are ready")
 					})
 
 					It("has sidecars with the correct istio version", func(ctx SpecContext) {
-						for _, pod := range bookinfoPods.Items {
-							sidecarVersion, err := getProxyVersion(pod.Name, bookinfoNamespace)
+						for _, pod := range samplePods.Items {
+							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
 							Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
 							Expect(sidecarVersion).To(Equal(version.Version), "Sidecar Istio version does not match the expected version")
 						}
@@ -253,9 +261,9 @@ spec:
 					})
 
 					AfterAll(func(ctx SpecContext) {
-						By("Deleting bookinfo")
-						Expect(k.DeleteNamespace(bookinfoNamespace)).To(Succeed(), "Bookinfo namespace failed to be deleted")
-						Success("Bookinfo deleted")
+						By("Deleting sample")
+						Expect(k.DeleteNamespace(sampleNamespace)).To(Succeed(), "sample namespace failed to be deleted")
+						Success("sample deleted")
 					})
 				})
 
@@ -363,27 +371,6 @@ func forceDeleteIstioResources() error {
 	err = k.Delete("istiocni", istioCniName)
 	if err != nil && !strings.Contains(err.Error(), "not found") {
 		return fmt.Errorf("failed to delete %s CR: %w", "istiocni", err)
-	}
-
-	return nil
-}
-
-func getBookinfoURL(version supportedversion.VersionInfo) string {
-	// Bookinfo YAML for the current version can be found from istio/istio repository
-	// If the version is latest, we need to get the latest version from the master branch
-	bookinfoURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/bookinfo/platform/kube/bookinfo.yaml", version.Version)
-	if version.Name == "latest" {
-		bookinfoURL = "https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/platform/kube/bookinfo.yaml"
-	}
-
-	return bookinfoURL
-}
-
-func deployBookinfo(version supportedversion.VersionInfo) error {
-	bookinfoURL := getBookinfoURL(version)
-	err := k.WithNamespace(bookinfoNamespace).Apply(bookinfoURL)
-	if err != nil {
-		return fmt.Errorf("error deploying bookinfo: %w", err)
 	}
 
 	return nil

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -199,10 +199,10 @@ spec:
 						Expect(k.Patch("namespace", SleepNamespace, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
 							To(Succeed(), "Error patching sleep namespace")
 
-						Expect(k.WithNamespace(DualStackNamespace).Apply(common.GetYAMLPodURL(version, "tcp-echo-dual-stack"))).To(Succeed(), "error deploying tcpDualStack pod")
-						Expect(k.WithNamespace(IPv4Namespace).Apply(common.GetYAMLPodURL(version, "tcp-echo-ipv4"))).To(Succeed(), "error deploying ipv4 pod")
-						Expect(k.WithNamespace(IPv6Namespace).Apply(common.GetYAMLPodURL(version, "tcp-echo-ipv6"))).To(Succeed(), "error deploying ipv6 pod")
-						Expect(k.WithNamespace(SleepNamespace).Apply(common.GetYAMLPodURL(version, "sleep"))).To(Succeed(), "error deploying sleep pod")
+						Expect(k.WithNamespace(DualStackNamespace).Apply(common.GetSampleYAML(version, "tcp-echo-dual-stack"))).To(Succeed(), "error deploying tcpDualStack pod")
+						Expect(k.WithNamespace(IPv4Namespace).Apply(common.GetSampleYAML(version, "tcp-echo-ipv4"))).To(Succeed(), "error deploying ipv4 pod")
+						Expect(k.WithNamespace(IPv6Namespace).Apply(common.GetSampleYAML(version, "tcp-echo-ipv6"))).To(Succeed(), "error deploying ipv6 pod")
+						Expect(k.WithNamespace(SleepNamespace).Apply(common.GetSampleYAML(version, "sleep"))).To(Succeed(), "error deploying sleep pod")
 
 						Success("dualStack validation pods deployed")
 					})

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -199,10 +199,10 @@ spec:
 						Expect(k.Patch("namespace", SleepNamespace, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
 							To(Succeed(), "Error patching sleep namespace")
 
-						Expect(k.WithNamespace(DualStackNamespace).Apply(getYAMLPodURL(version, DualStackNamespace))).To(Succeed(), "error deploying tcpDualStack pod")
-						Expect(k.WithNamespace(IPv4Namespace).Apply(getYAMLPodURL(version, IPv4Namespace))).To(Succeed(), "error deploying ipv4 pod")
-						Expect(k.WithNamespace(IPv6Namespace).Apply(getYAMLPodURL(version, IPv6Namespace))).To(Succeed(), "error deploying ipv6 pod")
-						Expect(k.WithNamespace(SleepNamespace).Apply(getYAMLPodURL(version, SleepNamespace))).To(Succeed(), "error deploying sleep pod")
+						Expect(k.WithNamespace(DualStackNamespace).Apply(common.GetYAMLPodURL(version, "tcp-echo-dual-stack"))).To(Succeed(), "error deploying tcpDualStack pod")
+						Expect(k.WithNamespace(IPv4Namespace).Apply(common.GetYAMLPodURL(version, "tcp-echo-ipv4"))).To(Succeed(), "error deploying ipv4 pod")
+						Expect(k.WithNamespace(IPv6Namespace).Apply(common.GetYAMLPodURL(version, "tcp-echo-ipv6"))).To(Succeed(), "error deploying ipv6 pod")
+						Expect(k.WithNamespace(SleepNamespace).Apply(common.GetYAMLPodURL(version, "sleep"))).To(Succeed(), "error deploying sleep pod")
 
 						Success("dualStack validation pods deployed")
 					})
@@ -321,29 +321,6 @@ func ImageFromRegistry(regexp string) types.GomegaMatcher {
 
 func getEnvVars(container corev1.Container) []corev1.EnvVar {
 	return container.Env
-}
-
-func getYAMLPodURL(version supportedversion.VersionInfo, namespace string) string {
-	var url string
-
-	switch namespace {
-	case DualStackNamespace:
-		url = "samples/tcp-echo/tcp-echo-dual-stack.yaml"
-	case IPv4Namespace:
-		url = "samples/tcp-echo/tcp-echo-ipv4.yaml"
-	case IPv6Namespace:
-		url = "samples/tcp-echo/tcp-echo-ipv6.yaml"
-	case SleepNamespace:
-		url = "samples/sleep/sleep.yaml"
-	default:
-		return ""
-	}
-
-	if version.Name == "latest" {
-		return fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/master/%s", url)
-	}
-
-	return fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/%s", version.Version, url)
 }
 
 func checkPodConnectivity(podName, namespace, echoStr string) {

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -209,8 +209,8 @@ spec:
 							To(Succeed(), "Error patching sample namespace")
 
 						// Deploy the sample app in both clusters
-						helloWorldURL := common.GetYAMLPodURL(version, "helloworld")
-						sleepURL := common.GetYAMLPodURL(version, "sleep")
+						helloWorldURL := common.GetSampleYAML(version, "helloworld")
+						sleepURL := common.GetSampleYAML(version, "sleep")
 
 						// On Cluster 0, create a service for the helloworld app v1
 						Expect(k1.WithNamespace("sample").ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Failed to deploy helloworld service")

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -198,8 +198,29 @@ spec:
 
 				When("sample apps are deployed in both clusters", func() {
 					BeforeAll(func(ctx SpecContext) {
+						// Create the namespace
+						Expect(k1.CreateNamespace("sample")).To(Succeed(), "Namespace failed to be created")
+						Expect(k2.CreateNamespace("sample")).To(Succeed(), "Namespace failed to be created")
+
+						// Label the sample namespace
+						Expect(k1.Patch("namespace", "sample", "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
+							To(Succeed(), "Error patching sample namespace")
+						Expect(k2.Patch("namespace", "sample", "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
+							To(Succeed(), "Error patching sample namespace")
+
 						// Deploy the sample app in both clusters
-						deploySampleApp("sample", version)
+						helloWorldURL := common.GetYAMLPodURL(version, "helloworld")
+						sleepURL := common.GetYAMLPodURL(version, "sleep")
+
+						// On Cluster 0, create a service for the helloworld app v1
+						Expect(k1.WithNamespace("sample").ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Failed to deploy helloworld service")
+						Expect(k1.WithNamespace("sample").ApplyWithLabels(helloWorldURL, "version=v1")).To(Succeed(), "Failed to deploy helloworld service")
+						Expect(k1.WithNamespace("sample").Apply(sleepURL)).To(Succeed(), "Failed to deploy sleep service")
+
+						// On Cluster 1, create a service for the helloworld app v2
+						Expect(k2.WithNamespace("sample").ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Failed to deploy helloworld service")
+						Expect(k2.WithNamespace("sample").ApplyWithLabels(helloWorldURL, "version=v2")).To(Succeed(), "Failed to deploy helloworld service")
+						Expect(k2.WithNamespace("sample").Apply(sleepURL)).To(Succeed(), "Failed to deploy sleep service")
 						Success("Sample app is deployed in both clusters")
 					})
 
@@ -207,7 +228,7 @@ spec:
 						samplePodsCluster1 := &corev1.PodList{}
 
 						Expect(clPrimary.List(ctx, samplePodsCluster1, client.InNamespace("sample"))).To(Succeed())
-						Expect(samplePodsCluster1.Items).ToNot(BeEmpty(), "No pods found in bookinfo namespace")
+						Expect(samplePodsCluster1.Items).ToNot(BeEmpty(), "No pods found in sample namespace")
 
 						for _, pod := range samplePodsCluster1.Items {
 							Eventually(common.GetObject).
@@ -217,7 +238,7 @@ spec:
 
 						samplePodsCluster2 := &corev1.PodList{}
 						Expect(clRemote.List(ctx, samplePodsCluster2, client.InNamespace("sample"))).To(Succeed())
-						Expect(samplePodsCluster2.Items).ToNot(BeEmpty(), "No pods found in bookinfo namespace")
+						Expect(samplePodsCluster2.Items).ToNot(BeEmpty(), "No pods found in sample namespace")
 
 						for _, pod := range samplePodsCluster2.Items {
 							Eventually(common.GetObject).
@@ -290,32 +311,3 @@ spec:
 		Expect(k2.WaitNamespaceDeleted(namespace)).To(Succeed())
 	})
 })
-
-// deploySampleApp deploys the sample app in the given cluster
-func deploySampleApp(ns string, istioVersion supportedversion.VersionInfo) {
-	// Create the namespace
-	Expect(k1.CreateNamespace(ns)).To(Succeed(), "Namespace failed to be created")
-	Expect(k2.CreateNamespace(ns)).To(Succeed(), "Namespace failed to be created")
-
-	// Label the namespace
-	Expect(k1.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
-		To(Succeed(), "Error patching sample namespace")
-	Expect(k2.Patch("namespace", ns, "merge", `{"metadata":{"labels":{"istio-injection":"enabled"}}}`)).
-		To(Succeed(), "Error patching sample namespace")
-
-	version := istioVersion.Version.String()
-	// Deploy the sample app from upstream URL in both clusters
-	if istioVersion.Name == "latest" {
-		version = "master"
-	}
-	helloWorldURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/helloworld/helloworld.yaml", version)
-	Expect(k1.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on Cluster #1")
-	Expect(k2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Sample service deploy failed on Cluster #2")
-
-	Expect(k1.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v1")).To(Succeed(), "Sample service deploy failed on Cluster #1")
-	Expect(k2.WithNamespace(ns).ApplyWithLabels(helloWorldURL, "version=v2")).To(Succeed(), "Sample service deploy failed on Cluster #2")
-
-	sleepURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/sleep/sleep.yaml", version)
-	Expect(k1.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on Cluster #1")
-	Expect(k2.WithNamespace(ns).Apply(sleepURL)).To(Succeed(), "Sample sleep deploy failed on Cluster #2")
-}

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -256,8 +256,8 @@ spec:
 							To(Succeed(), "Error patching sample namespace")
 
 						// Deploy the sample app in both clusters
-						helloWorldURL := common.GetYAMLPodURL(v, "helloworld")
-						sleepURL := common.GetYAMLPodURL(v, "sleep")
+						helloWorldURL := common.GetSampleYAML(v, "helloworld")
+						sleepURL := common.GetSampleYAML(v, "sleep")
 
 						// On Cluster 0, create a service for the helloworld app v1
 						Expect(k1.WithNamespace("sample").ApplyWithLabels(helloWorldURL, "service=helloworld")).To(Succeed(), "Failed to deploy helloworld service")

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -278,15 +278,13 @@ func GetYAMLPodURL(version supportedversion.VersionInfo, appName string) string 
 	switch appName {
 	case "tcp-echo-dual-stack":
 		url = "samples/tcp-echo/tcp-echo-dual-stack.yaml"
-	case "tcp-echo-ipv4":
-	case "tcp-echo":
+	case "tcp-echo-ipv4", "tcp-echo":
 		url = "samples/tcp-echo/tcp-echo-ipv4.yaml"
 	case "tcp-echo-ipv6":
 		url = "samples/tcp-echo/tcp-echo-ipv6.yaml"
 	case "sleep":
 		url = "samples/sleep/sleep.yaml"
-	case "helloworld":
-	case "sample":
+	case "helloworld", "sample":
 		url = "samples/helloworld/helloworld.yaml"
 	default:
 		return ""

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -264,11 +264,11 @@ func UninstallOperator() error {
 	return helm.Uninstall("sail-operator", "--namespace", OperatorNamespace)
 }
 
-// GetYAMLPodURL returns the URL of the yaml file for the testing app.
+// GetSampleYAML returns the URL of the yaml file for the testing app.
 // args:
 // version: the version of the Istio to get the yaml file from.
 // appName: the name of the testing app. Example: helloworld, sleep, tcp-echo.
-func GetYAMLPodURL(version supportedversion.VersionInfo, appName string) string {
+func GetSampleYAML(version supportedversion.VersionInfo, appName string) string {
 	// This func will be used to get URLs for the yaml files of the testing apps. Example: helloworld, sleep, tcp-echo.
 	// Default values points to upstream Istio sample yaml files. Custom paths can be provided using environment variables.
 
@@ -309,7 +309,7 @@ func GetYAMLPodURL(version supportedversion.VersionInfo, appName string) string 
 	}
 
 	// Base URL logic
-	baseURL := os.Getenv("POD_SAMPLE_YAML_BASE_URL")
+	baseURL := os.Getenv("SAMPLE_YAML_BASE_URL")
 	if baseURL == "" {
 		baseURL = "https://raw.githubusercontent.com/istio/istio"
 	}


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [X] Enhancement / New Feature
- [ ] Bug Fix
- [X] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
This PR addresses these needs:
* Centralize the way that the pod yaml URL is being used across all the e2e tests to simplify the deployment of the sample application
* Stop using bookinfo app to validate sidecar injection
* Adding POD_SAMPLE_YAML_BASE_URL to enable a way to set custom yaml string that will allow user to use their own yaml with custom images

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #467 

#### Additional information:
