### PR TITLE
Split unit/integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,21 @@
+name: integration-tests
+
+on: [push, pull_request]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Run coverage
+      run: |
+        make test.integration \
+          -e COVERAGE=true
+
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: out/coverage-unit.out,out/coverage-integration.out
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,4 +1,4 @@
-name: Code coverage workflow
+name: unit-tests
 
 on: [push, pull_request]
 
@@ -10,7 +10,7 @@ jobs:
 
     - name: Run coverage
       run: |
-        make test \
+        make test.unit \
           -e COVERAGE=true
 
     - name: Upload to Codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 ignore:
   - "api"
   - "hack"
+  - "tools"
   - "tests"


### PR DESCRIPTION
It turns out reports are merged by codecov (see https://docs.codecov.com/docs/merging-reports), so we can run tests independently without losing results.