### PR TITLE
Remove duplicate newline at EOF of values_types

### DIFF
--- a/api/v1alpha1/values_types.gen.go
+++ b/api/v1alpha1/values_types.gen.go
@@ -3784,4 +3784,3 @@ type HTTPRetry struct {
 	// See the [retry plugin configuration](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_connection_management#retry-plugin-configuration) for more details.
 	RetryRemoteLocalities *bool `json:"retryRemoteLocalities,omitempty"`
 }
-

--- a/hack/api_transformer/main.go
+++ b/hack/api_transformer/main.go
@@ -761,12 +761,14 @@ func removeLeadingEmptyLinesFromStructs(str string) string {
 
 	lines := strings.Split(str, "\n")
 	var prevTrimmedLine string
-	for _, line := range lines {
+	for index, line := range lines {
 		trimmedLine := strings.TrimSpace(line)
 		skipLine := trimmedLine == "" && strings.HasSuffix(prevTrimmedLine, "struct {")
 		if !skipLine {
 			sb.WriteString(line)
-			sb.WriteString("\n")
+			if index < len(lines)-1 {
+				sb.WriteString("\n")
+			}
 		}
 		prevTrimmedLine = trimmedLine
 	}


### PR DESCRIPTION
There's a bug in golangci-lint that causes a panic on double empty lines at EOF. Patching the golangci-lint version in another PR.