### PR TITLE
Update version in sample yamls

### DIFF
--- a/chart/samples/ambient/istio-sample.yaml
+++ b/chart/samples/ambient/istio-sample.yaml
@@ -3,7 +3,7 @@ kind: Istio
 metadata:
   name: default
 spec:
-  version: v1.24.0
+  version: v1.24.2
   namespace: istio-system
   profile: ambient
   updateStrategy:

--- a/chart/samples/ambient/istiocni-sample.yaml
+++ b/chart/samples/ambient/istiocni-sample.yaml
@@ -3,6 +3,6 @@ kind: IstioCNI
 metadata:
   name: default
 spec:
-  version: v1.24.0
+  version: v1.24.2
   profile: ambient
   namespace: istio-cni

--- a/chart/samples/ambient/istioztunnel-sample.yaml
+++ b/chart/samples/ambient/istioztunnel-sample.yaml
@@ -3,6 +3,6 @@ kind: ZTunnel
 metadata:
   name: default
 spec:
-  version: v1.24.0
+  version: v1.24.2
   namespace: ztunnel
   profile: ambient

--- a/chart/samples/istio-sample-gw-api.yaml
+++ b/chart/samples/istio-sample-gw-api.yaml
@@ -3,7 +3,7 @@ kind: Istio
 metadata:
   name: gateway-controller
 spec:
-  version: v1.23.0
+  version: v1.24.2
   namespace: gateway-controller
   updateStrategy:
     type: InPlace

--- a/chart/samples/istio-sample-revisionbased.yaml
+++ b/chart/samples/istio-sample-revisionbased.yaml
@@ -3,7 +3,7 @@ kind: Istio
 metadata:
   name: default
 spec:
-  version: v1.23.2
+  version: v1.24.2
   namespace: istio-system
   updateStrategy:
     type: RevisionBased

--- a/hack/update-version-list.sh
+++ b/hack/update-version-list.sh
@@ -88,7 +88,9 @@ function updateVersionInSamples() {
 
     sed -i -E \
       -e "s/version: .*/version: $defaultVersion/g" \
-      chart/samples/istio-sample.yaml chart/samples/istiocni-sample.yaml
+      chart/samples/istio-sample.yaml chart/samples/istiocni-sample.yaml chart/samples/istio-sample-gw-api.yaml \
+      chart/samples/istio-sample-revisionbased.yaml chart/samples/ambient/istiocni-sample.yaml \
+      chart/samples/ambient/istio-sample.yaml  chart/samples/ambient/istioztunnel-sample.yaml
 }
 
 updateVersionsInIstioTypeComment


### PR DESCRIPTION
Currently, update-version-list.sh is only updating few of the sample yamls. This PR modifies it to update the missing files along with the ambient sample yamls.
