### PR TITLE
Avoid specifying platform in the e2e tests

### DIFF
--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -31,7 +31,6 @@ import (
 var (
 	cl                    client.Client
 	err                   error
-	ocp                   = env.GetBool("OCP", false)
 	namespace             = common.OperatorNamespace
 	deploymentName        = env.Get("DEPLOYMENT_NAME", "sail-operator")
 	controlPlaneNamespace = env.Get("CONTROL_PLANE_NS", "istio-system")

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -47,15 +47,10 @@ var _ = Describe("Control Plane Installation", Ordered, func() {
 	BeforeAll(func(ctx SpecContext) {
 		Expect(k.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created")
 
-		extraArg := ""
-		if ocp {
-			extraArg = "--set=platform=openshift"
-		}
-
 		if skipDeploy {
 			Success("Skipping operator installation because it was deployed externally")
 		} else {
-			Expect(common.InstallOperatorViaHelm(extraArg)).
+			Expect(common.InstallOperatorViaHelm()).
 				To(Succeed(), "Operator failed to be deployed")
 		}
 
@@ -333,10 +328,6 @@ spec:
 			To(Succeed(), "Operator failed to be deleted")
 		GinkgoWriter.Println("Operator uninstalled")
 
-		if ocp {
-			Success("Skipping deletion of operator namespace to avoid removal of operator container image from internal registry")
-			return
-		}
 		Expect(k.DeleteNamespace(namespace)).To(Succeed(), "Namespace failed to be deleted")
 		Success("Namespace deleted")
 	})

--- a/tests/e2e/dualstack/dualstack_suite_test.go
+++ b/tests/e2e/dualstack/dualstack_suite_test.go
@@ -31,7 +31,6 @@ import (
 var (
 	cl                    client.Client
 	err                   error
-	ocp                   = env.GetBool("OCP", false)
 	namespace             = common.OperatorNamespace
 	deploymentName        = env.Get("DEPLOYMENT_NAME", "sail-operator")
 	controlPlaneNamespace = env.Get("CONTROL_PLANE_NS", "istio-system")

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -51,15 +51,10 @@ var _ = Describe("DualStack configuration ", Ordered, func() {
 	BeforeAll(func(ctx SpecContext) {
 		Expect(k.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created")
 
-		extraArg := ""
-		if ocp {
-			extraArg = "--set=platform=openshift"
-		}
-
 		if skipDeploy {
 			Success("Skipping operator installation because it was deployed externally")
 		} else {
-			Expect(common.InstallOperatorViaHelm(extraArg)).
+			Expect(common.InstallOperatorViaHelm()).
 				To(Succeed(), "Operator failed to be deployed")
 		}
 

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -58,15 +58,10 @@ var _ = Describe("Operator", Ordered, func() {
 		BeforeAll(func() {
 			Expect(k.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created")
 
-			extraArg := ""
-			if ocp {
-				extraArg = "--set=platform=openshift"
-			}
-
 			if skipDeploy {
 				Success("Skipping operator installation because it was deployed externally")
 			} else {
-				Expect(common.InstallOperatorViaHelm(extraArg)).
+				Expect(common.InstallOperatorViaHelm()).
 					To(Succeed(), "Operator failed to be deployed")
 			}
 		})

--- a/tests/e2e/operator/operator_suite_test.go
+++ b/tests/e2e/operator/operator_suite_test.go
@@ -30,7 +30,6 @@ import (
 
 var (
 	cl             client.Client
-	ocp            = env.GetBool("OCP", false)
 	skipDeploy     = env.GetBool("SKIP_DEPLOY", false)
 	namespace      = common.OperatorNamespace
 	deploymentName = env.Get("DEPLOYMENT_NAME", "sail-operator")
@@ -55,12 +54,6 @@ func setup() {
 	var err error
 	cl, err = k8sclient.InitK8sClient("")
 	Expect(err).NotTo(HaveOccurred())
-
-	if ocp {
-		GinkgoWriter.Println("Running on OCP cluster")
-	} else {
-		GinkgoWriter.Println("Running on Kubernetes")
-	}
 
 	k = kubectl.New("clOperator")
 }


### PR DESCRIPTION
Sail Operator can automatically discovery the platform (i.e., ocp or k8s) and there is no need to explicitly specify the platform while running the e2e tests.
