### PR TITLE
Fix failures due to IP_FAMILIES change

### DIFF
--- a/tests/e2e/integ-suite-kind.sh
+++ b/tests/e2e/integ-suite-kind.sh
@@ -28,6 +28,9 @@ export KIND_REGISTRY_PORT="5000"
 export KIND_REGISTRY="localhost:${KIND_REGISTRY_PORT}"
 export DEFAULT_CLUSTER_YAML="${SCRIPTPATH}/config/default.yaml"
 export IP_FAMILY="${IP_FAMILY:-ipv4}"
+
+# See https://github.com/istio-ecosystem/sail-operator/issues/558
+export KIND_IP_FAMILY="${IP_FAMILY}"
 export ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"
 export MULTICLUSTER="${MULTICLUSTER:-false}"
 # Set variable to exclude kind clusters from kubectl annotations. 


### PR DESCRIPTION
This PR sets KIND_IP_FAMILY to align with the IP_FAMILY used in Sail Operator scripts. Since the order of IP families is not relevant for Sail Operator e2e tests, we do not require the IP_FAMILIES variable used upstream.

Fixes: https://github.com/istio-ecosystem/sail-operator/issues/558