### PR TITLE
Switch to sail-dev quay org

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -56,7 +56,7 @@ LD_EXTRAFLAGS += -X ${GO_MODULE}/pkg/version.buildStatus=${GIT_STATUS}
 LD_FLAGS = -extldflags -static ${LD_EXTRAFLAGS} -s -w
 
 # Image hub to use
-HUB ?= quay.io/maistra-dev
+HUB ?= quay.io/sail-dev
 # Image tag to use
 TAG ?= ${MINOR_VERSION}-latest
 # Image base to use

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -33,8 +33,8 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
-    containerImage: quay.io/maistra-dev/sail-operator:0.3-latest
-    createdAt: "2024-12-19T05:05:23Z"
+    containerImage: quay.io/sail-dev/sail-operator:0.3-latest
+    createdAt: "2025-01-17T09:17:31Z"
     description: Experimental operator for installing Istio service mesh
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -743,7 +743,7 @@ spec:
                 - --zap-log-level=info
                 command:
                 - /sail-operator
-                image: quay.io/maistra-dev/sail-operator:0.3-latest
+                image: quay.io/sail-dev/sail-operator:0.3-latest
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/chart/README.md
+++ b/chart/README.md
@@ -86,7 +86,7 @@ Default configuration values can be changed using one or more `--set <parameter>
     $ kubectl -n sail-operator get deployment --output wide
 
     NAME            READY   UP-TO-DATE   AVAILABLE   AGE    CONTAINERS                IMAGES                                                                                    SELECTOR
-    sail-operator   1/1     1            1           107s   kube-rbac-proxy,sail-operator  gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0,quay.io/maistra-dev/sail-operator:0.1-latest   app.kubernetes.io/created-by=sailoperator,app.kubernetes.io/part-of=sailoperator,control-plane=sail-operator
+    sail-operator   1/1     1            1           107s   kube-rbac-proxy,sail-operator  gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0,quay.io/sail-dev/sail-operator:0.1-latest   app.kubernetes.io/created-by=sailoperator,app.kubernetes.io/part-of=sailoperator,control-plane=sail-operator
 
     $ kubectl -n sail-operator get pods -o wide
 

--- a/chart/samples/gwControllerMode.yaml
+++ b/chart/samples/gwControllerMode.yaml
@@ -7,7 +7,7 @@ spec:
   namespace: istio-gw
   values:
     global:
-      hub: quay.io/maistra-dev
+      hub: quay.io/sail-dev
       tag: gwAPIControllerMode
     pilot:
       env:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -51,7 +51,7 @@ csv:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
-image: quay.io/maistra-dev/sail-operator:0.3-latest
+image: quay.io/sail-dev/sail-operator:0.3-latest
 # We're commenting out the imagePullPolicy to use k8s defaults
 # imagePullPolicy: Always
 proxy:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -207,7 +207,7 @@ $ make BUILD_WITH_CONTAINER=0 test.e2e.ocp
 The following environment variables define the behavior of the test run:
 
 * SKIP_BUILD=false - If set to true, the test will skip the build process and an existing operator image will be used to deploy the operator and run the test. The operator image that is going to be used is defined by the `IMAGE` variable.
-* IMAGE=quay.io/maistra-dev/sail-operator:latest - The operator image to be used to deploy the operator and run the test. This is useful when you want to test a specific operator image.
+* IMAGE=quay.io/sail-dev/sail-operator:latest - The operator image to be used to deploy the operator and run the test. This is useful when you want to test a specific operator image.
 * SKIP_DEPLOY=false - If set to true, the test will skip the deployment of the operator. This is useful when the operator is already deployed in the cluster, and you want to run the test only.
 * OCP=false - If set to true, the test will be configured to run on an OCP cluster and use the `oc` command to interact with it. If set to false, the test will run in a KinD cluster and use `kubectl`.
 * OLM=false - If set to true, the test will use the OLM (Operator Lifecycle Manager) to install the operator. If set to false, the test will use Helm to install the operator.

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -44,7 +44,7 @@ import (
 )
 
 var (
-	OperatorImage     = env.Get("IMAGE", "quay.io/maistra-dev/sail-operator:latest")
+	OperatorImage     = env.Get("IMAGE", "quay.io/sail-dev/sail-operator:latest")
 	OperatorNamespace = env.Get("NAMESPACE", "sail-operator")
 
 	deploymentName        = env.Get("DEPLOYMENT_NAME", "sail-operator")


### PR DESCRIPTION
Moving off of the old `maistra-dev` org on quay.io. I also created a `sail-operator` org on quay which we might want to use for GA releases later on.

Fixes #347.