### PR TITLE
Fix gitleaks by scanning only files

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -665,7 +665,7 @@ lint-watches: ## Checks if the operator watches all resource kinds present in He
 	@hack/lint-watches.sh
 
 lint-secrets: gitleaks ## Checks whether any secrets are present in the repository.
-	@${GITLEAKS} detect --redact -v
+	@${GITLEAKS} detect --no-git --redact -v
 
 .PHONY: lint
 lint: lint-scripts lint-copyright-banner lint-go lint-yaml lint-helm lint-bundle lint-watches lint-secrets ## Run all linters.


### PR DESCRIPTION
When gitleaks attempts to scan the git history in a shallow clone, it can trigger the bug https://github.com/gitleaks/gitleaks/issues/1168. By disabling git scanning, we should be able to avoid it.