### PR TITLE
Allow overriding Ambient params in IstioCNI

### DIFF
--- a/api/v1alpha1/values_types.gen.go
+++ b/api/v1alpha1/values_types.gen.go
@@ -132,7 +132,8 @@ type CNIConfig struct {
 	//
 	// See: https://kubernetes.io/docs/tutorials/security/seccomp/
 	SeccompProfile *k8sv1.SeccompProfile `json:"seccompProfile,omitempty"`
-
+	// Configuration for Istio Ambient.
+	Ambient *CNIAmbientConfig `json:"ambient,omitempty"`
 	// Specifies the CNI provider. Can be either "default" or "multus". When set to "multus", an additional
 	// NetworkAttachmentDefinition resource is deployed to the cluster to allow the istio-cni plugin to be
 	// invoked in a cluster using the Multus CNI plugin.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -232,6 +232,11 @@ func (in *CNIConfig) DeepCopyInto(out *CNIConfig) {
 		*out = new(v1.SeccompProfile)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Ambient != nil {
+		in, out := &in.Ambient, &out.Ambient
+		*out = new(CNIAmbientConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Provider != nil {
 		in, out := &in.Provider, &out.Provider
 		*out = new(string)

--- a/bundle/manifests/sailoperator.io_istiocnis.yaml
+++ b/bundle/manifests/sailoperator.io_istiocnis.yaml
@@ -1024,6 +1024,25 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                         type: object
+                      ambient:
+                        description: Configuration for Istio Ambient.
+                        properties:
+                          configDir:
+                            description: The directory path containing the configuration
+                              files for Ambient. Defaults to /etc/ambient-config.
+                            type: string
+                          dnsCapture:
+                            description: If enabled, and ambient is enabled, DNS redirection
+                              will be enabled.
+                            type: boolean
+                          enabled:
+                            description: Controls whether ambient redirection is enabled
+                            type: boolean
+                          ipv6:
+                            description: 'UNSTABLE: If enabled, and ambient is enabled,
+                              enables ipv6 support'
+                            type: boolean
+                        type: object
                       chained:
                         description: |-
                           Configure the plugin as a chained CNI plugin. When true, the configuration is added to the CNI chain; when false,

--- a/chart/crds/sailoperator.io_istiocnis.yaml
+++ b/chart/crds/sailoperator.io_istiocnis.yaml
@@ -1024,6 +1024,25 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                         type: object
+                      ambient:
+                        description: Configuration for Istio Ambient.
+                        properties:
+                          configDir:
+                            description: The directory path containing the configuration
+                              files for Ambient. Defaults to /etc/ambient-config.
+                            type: string
+                          dnsCapture:
+                            description: If enabled, and ambient is enabled, DNS redirection
+                              will be enabled.
+                            type: boolean
+                          enabled:
+                            description: Controls whether ambient redirection is enabled
+                            type: boolean
+                          ipv6:
+                            description: 'UNSTABLE: If enabled, and ambient is enabled,
+                              enables ipv6 support'
+                            type: boolean
+                        type: object
                       chained:
                         description: |-
                           Configure the plugin as a chained CNI plugin. When true, the configuration is added to the CNI chain; when false,

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -81,6 +81,23 @@ _Appears in:_
 | `validationCABundle` _string_ | validation webhook CA bundle |  |  |
 
 
+#### CNIAmbientConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [CNIConfig](#cniconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Controls whether ambient redirection is enabled |  |  |
+| `configDir` _string_ | The directory path containing the configuration files for Ambient. Defaults to /etc/ambient-config. |  |  |
+| `dnsCapture` _boolean_ | If enabled, and ambient is enabled, DNS redirection will be enabled. |  |  |
+| `ipv6` _boolean_ | UNSTABLE: If enabled, and ambient is enabled, enables ipv6 support |  |  |
 
 
 #### CNIConfig
@@ -116,6 +133,7 @@ _Appears in:_
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core)_ | The k8s resource requests and limits for the istio-cni Pods. |  |  |
 | `privileged` _boolean_ | No longer used for CNI. See: https://github.com/istio/istio/issues/49004  Deprecated: Marked as deprecated in pkg/apis/values_types.proto. |  |  |
 | `seccompProfile` _[SeccompProfile](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#seccompprofile-v1-core)_ | The Container seccompProfile  See: https://kubernetes.io/docs/tutorials/security/seccomp/ |  |  |
+| `ambient` _[CNIAmbientConfig](#cniambientconfig)_ | Configuration for Istio Ambient. |  |  |
 | `provider` _string_ | Specifies the CNI provider. Can be either "default" or "multus". When set to "multus", an additional NetworkAttachmentDefinition resource is deployed to the cluster to allow the istio-cni plugin to be invoked in a cluster using the Multus CNI plugin. |  |  |
 | `rollingMaxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#intorstring-intstr-util)_ | The number of pods that can be unavailable during a rolling update of the CNI DaemonSet (see `updateStrategy.rollingUpdate.maxUnavailable` here: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec). May be specified as a number of pods or as a percent of the total number of pods at the start of the update. |  | XIntOrString: \{\}   |
 

--- a/hack/api_transformer/transform.yaml
+++ b/hack/api_transformer/transform.yaml
@@ -73,7 +73,6 @@ inputFiles:
     - SidecarInjectorConfig.ObjectSelector # appears to be unused
     - CNIConfig.Enabled                    # CNI is enabled by the mere presence of the IstioCNI resource
     - CNIConfig.LogLevel                   # deprecated and replaced with CNIConfig.logging.level
-    - CNIConfig.Ambient                    # we don't support Ambient yet
     - CNIUsageConfig.Chained               # deprecated and unused in upstream
     - BaseConfig.EnableCRDTemplates        # not used, because the operator doesn't deploy CRDs
     - BaseConfig.EnableIstioConfigCRDs     # present in values.yaml, but not used in any chart


### PR DESCRIPTION
Even though we can install Ambient using the Sail Operator, we're unable to override some of the Ambient parameters in the IstioCNI chart because the CNIAmbientConfig is missing from the CNIConfig struct. This PR fixes it.

Related to: https://github.com/istio-ecosystem/sail-operator/issues/500
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>