### PR TITLE
Fix ztunnel controller to apply values.ztunnel config

### DIFF
--- a/controllers/ztunnel/ztunnel_controller.go
+++ b/controllers/ztunnel/ztunnel_controller.go
@@ -147,7 +147,16 @@ func (r *Reconciler) installHelmChart(ctx context.Context, ztunnel *v1alpha1.ZTu
 		return fmt.Errorf("failed to apply profile: %w", err)
 	}
 
-	_, err = r.ChartManager.UpgradeOrInstallChart(ctx, r.getChartDir(ztunnel), mergedHelmValues, ztunnel.Spec.Namespace, ztunnelChart, ownerReference)
+	// Apply any user Overrides configured as part of values.ztunnel
+	// This step was not required for the IstioCNI resource because the Helm templates[*] automatically override values.cni
+	// [*]https://github.com/istio/istio/blob/0200fd0d4c3963a72f36987c2e8c2887df172abf/manifests/charts/istio-cni/templates/zzy_descope_legacy.yaml#L3
+	// However, ztunnel charts do not have such a file, hence we are manually applying the mergeOperation here.
+	finalHelmValues, err := istiovalues.ApplyUserValues(helm.FromValues(mergedHelmValues), helm.FromValues(userValues.ZTunnel))
+	if err != nil {
+		return fmt.Errorf("failed to apply user overrides: %w", err)
+	}
+
+	_, err = r.ChartManager.UpgradeOrInstallChart(ctx, r.getChartDir(ztunnel), finalHelmValues, ztunnel.Spec.Namespace, ztunnelChart, ownerReference)
 	if err != nil {
 		return fmt.Errorf("failed to install/update Helm chart %q: %w", ztunnelChart, err)
 	}

--- a/pkg/istiovalues/profiles.go
+++ b/pkg/istiovalues/profiles.go
@@ -46,6 +46,12 @@ func ApplyProfilesAndPlatform(
 	return values, nil
 }
 
+func ApplyUserValues(mergedValues, userValues helm.Values,
+) (helm.Values, error) {
+	values := helm.Values(mergeOverwrite(mergedValues, userValues))
+	return values, nil
+}
+
 func resolve(defaultProfile, userProfile string) []string {
 	switch {
 	case userProfile != "" && userProfile != "default":

--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -177,7 +177,11 @@ metadata:
 spec:
   profile: ambient
   version: %s
-  namespace: %s`
+  namespace: %s
+  values:
+    ztunnel:
+      env:
+        CUSTOM_ENV_VAR: "true"`
 						ztunnelYaml = fmt.Sprintf(ztunnelYaml, version.Name, ztunnelNamespace)
 						Log("ZTunnel YAML:", ztunnelYaml)
 						Expect(k.CreateFromString(ztunnelYaml)).To(Succeed(), "ZTunnel creation failed")
@@ -210,6 +214,10 @@ spec:
 						Expect(ztunnelObj).To(HaveContainersThat(ContainElement(WithTransform(getEnvVars,
 							ContainElement(corev1.EnvVar{Name: "ISTIO_META_ENABLE_HBONE", Value: "true"})))),
 							"Expected ISTIO_META_ENABLE_HBONE to be set to true, but not found")
+
+						Expect(ztunnelObj).To(HaveContainersThat(ContainElement(WithTransform(getEnvVars,
+							ContainElement(corev1.EnvVar{Name: "CUSTOM_ENV_VAR", Value: "true"})))),
+							"Expected CUSTOM_ENV_VAR to be set to true, but not found")
 					})
 				})
 


### PR DESCRIPTION
In the Sail Operator, any config specified under values.ztunnel in the ZTunnel resource was being ignored. This fix ensures that the ztunnel controller correctly applies these values.

Fixes: https://github.com/istio-ecosystem/sail-operator/issues/567
