### PR TITLE
Disable imageDigest support in ztunnel controller

### DIFF
--- a/controllers/ztunnel/ztunnel_controller.go
+++ b/controllers/ztunnel/ztunnel_controller.go
@@ -143,11 +143,11 @@ func (r *Reconciler) installHelmChart(ctx context.Context, ztunnel *v1alpha1.ZTu
 	// userValues = applyImageDigests(ztunnel, userValues, config.Config)
 
 	if userValues == nil {
-		userValues = &v1alpha1.ZTunnelValues{}
+		userValues = &v1.ZTunnelValues{}
 	}
 
 	if userValues.ZTunnel == nil {
-		userValues.ZTunnel = &v1alpha1.ZTunnelConfig{}
+		userValues.ZTunnel = &v1.ZTunnelConfig{}
 	}
 
 	// apply userValues on top of defaultValues from profiles

--- a/controllers/ztunnel/ztunnel_controller.go
+++ b/controllers/ztunnel/ztunnel_controller.go
@@ -139,7 +139,16 @@ func (r *Reconciler) installHelmChart(ctx context.Context, ztunnel *v1alpha1.ZTu
 	userValues := ztunnel.Spec.Values
 
 	// apply image digests from configuration, if not already set by user
-	userValues = applyImageDigests(ztunnel, userValues, config.Config)
+	// TODO: Revisit once we support ImageOverrides for ztunnel
+	// userValues = applyImageDigests(ztunnel, userValues, config.Config)
+
+	if userValues == nil {
+		userValues = &v1alpha1.ZTunnelValues{}
+	}
+
+	if userValues.ZTunnel == nil {
+		userValues.ZTunnel = &v1alpha1.ZTunnelConfig{}
+	}
 
 	// apply userValues on top of defaultValues from profiles
 	mergedHelmValues, err := istiovalues.ApplyProfilesAndPlatform(

--- a/controllers/ztunnel/ztunnel_controller_test.go
+++ b/controllers/ztunnel/ztunnel_controller_test.go
@@ -338,7 +338,9 @@ func TestDetermineReadyCondition(t *testing.T) {
 	}
 }
 
-func PTestApplyImageDigests(t *testing.T) {
+func TestApplyImageDigests(t *testing.T) {
+	t.Skip("https://github.com/istio-ecosystem/sail-operator/issues/581")
+
 	testCases := []struct {
 		name         string
 		config       config.OperatorConfig

--- a/controllers/ztunnel/ztunnel_controller_test.go
+++ b/controllers/ztunnel/ztunnel_controller_test.go
@@ -338,7 +338,7 @@ func TestDetermineReadyCondition(t *testing.T) {
 	}
 }
 
-func TestApplyImageDigests(t *testing.T) {
+func PTestApplyImageDigests(t *testing.T) {
 	testCases := []struct {
 		name         string
 		config       config.OperatorConfig


### PR DESCRIPTION
Currently, we have some pending work with the ztunnel images that are used as imageDigests. Because of this, when deploying Ambient profile using the OSSM operator, the ztunnel pod fails to come up. This PR temporarily disables this functionality until proper support is implemented.

Alternatives:
1. Default Image: If image details are not provided in the ZTunnel CR, the operator will use the default image from the helm chart.
2. Explicitly specify image details: Following a recent fix in the ztunnel controller ([PR#568](https://github.com/istio-ecosystem/sail-operator/pull/568)), users can specify image details within the ztunnel CR itself in one of the following ways. 
    2.1: ztunnel.spec.values.ztunnel.image
    2.2: ztunnel.spec.values.global.hub/tag

Note: This change impacts on the Ztunnel image when using the Ambient profile and will not have any affect on other images.

Fixes: https://github.com/istio-ecosystem/sail-operator/issues/581