### PR TITLE
Use logAsJson instead of logAsJSON in ZTunnel APIs

### DIFF
--- a/api/v1/values_types_extra.go
+++ b/api/v1/values_types_extra.go
@@ -93,7 +93,7 @@ type ZTunnelConfig struct {
 	// Same as `global.logging.level`, but will override it if set
 	Logging *GlobalLoggingConfig `json:"logging,omitempty"`
 	// Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.
-	LogAsJSON *bool `json:"logAsJSON,omitempty"`
+	LogAsJson *bool `json:"logAsJson,omitempty"` //nolint
 }
 
 // ZTunnelGlobalConfig is a subset of the Global Configuration used in the Istio ztunnel chart.
@@ -118,7 +118,7 @@ type ZTunnelGlobalConfig struct { // Default k8s resources settings for all Isti
 	ImagePullSecrets []string `json:"imagePullSecrets,omitempty"`
 
 	// Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.
-	LogAsJSON *bool `json:"logAsJSON,omitempty"`
+	LogAsJson *bool `json:"logAsJson,omitempty"` //nolint
 	// Specifies the global logging level settings for the Istio control plane components.
 	Logging *GlobalLoggingConfig `json:"logging,omitempty"`
 

--- a/api/v1/values_types_extra.go
+++ b/api/v1/values_types_extra.go
@@ -93,7 +93,7 @@ type ZTunnelConfig struct {
 	// Same as `global.logging.level`, but will override it if set
 	Logging *GlobalLoggingConfig `json:"logging,omitempty"`
 	// Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.
-	LogAsJson *bool `json:"logAsJson,omitempty"` //nolint
+	LogAsJSON *bool `json:"logAsJson,omitempty"`
 }
 
 // ZTunnelGlobalConfig is a subset of the Global Configuration used in the Istio ztunnel chart.
@@ -118,7 +118,7 @@ type ZTunnelGlobalConfig struct { // Default k8s resources settings for all Isti
 	ImagePullSecrets []string `json:"imagePullSecrets,omitempty"`
 
 	// Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.
-	LogAsJson *bool `json:"logAsJson,omitempty"` //nolint
+	LogAsJSON *bool `json:"logAsJson,omitempty"`
 	// Specifies the global logging level settings for the Istio control plane components.
 	Logging *GlobalLoggingConfig `json:"logging,omitempty"`
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -5369,8 +5369,8 @@ func (in *ZTunnelConfig) DeepCopyInto(out *ZTunnelConfig) {
 		*out = new(GlobalLoggingConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.LogAsJson != nil {
-		in, out := &in.LogAsJson, &out.LogAsJson
+	if in.LogAsJSON != nil {
+		in, out := &in.LogAsJSON, &out.LogAsJSON
 		*out = new(bool)
 		**out = **in
 	}
@@ -5409,8 +5409,8 @@ func (in *ZTunnelGlobalConfig) DeepCopyInto(out *ZTunnelGlobalConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.LogAsJson != nil {
-		in, out := &in.LogAsJson, &out.LogAsJson
+	if in.LogAsJSON != nil {
+		in, out := &in.LogAsJSON, &out.LogAsJSON
 		*out = new(bool)
 		**out = **in
 	}

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -5369,8 +5369,8 @@ func (in *ZTunnelConfig) DeepCopyInto(out *ZTunnelConfig) {
 		*out = new(GlobalLoggingConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.LogAsJSON != nil {
-		in, out := &in.LogAsJSON, &out.LogAsJSON
+	if in.LogAsJson != nil {
+		in, out := &in.LogAsJson, &out.LogAsJson
 		*out = new(bool)
 		**out = **in
 	}
@@ -5409,8 +5409,8 @@ func (in *ZTunnelGlobalConfig) DeepCopyInto(out *ZTunnelGlobalConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.LogAsJSON != nil {
-		in, out := &in.LogAsJSON, &out.LogAsJSON
+	if in.LogAsJson != nil {
+		in, out := &in.LogAsJson, &out.LogAsJson
 		*out = new(bool)
 		**out = **in
 	}

--- a/bundle/manifests/sailoperator.io_ztunnels.yaml
+++ b/bundle/manifests/sailoperator.io_ztunnels.yaml
@@ -177,7 +177,7 @@ spec:
                         items:
                           type: string
                         type: array
-                      logAsJSON:
+                      logAsJson:
                         description: Specifies whether istio components should output
                           logs in json format by adding --log_as_json argument to
                           each container.
@@ -262,7 +262,7 @@ spec:
                         description: Specifies the default namespace for the Istio
                           control plane components.
                         type: string
-                      logAsJSON:
+                      logAsJson:
                         description: Specifies whether istio components should output
                           logs in json format by adding --log_as_json argument to
                           each container.

--- a/chart/crds/sailoperator.io_ztunnels.yaml
+++ b/chart/crds/sailoperator.io_ztunnels.yaml
@@ -177,7 +177,7 @@ spec:
                         items:
                           type: string
                         type: array
-                      logAsJSON:
+                      logAsJson:
                         description: Specifies whether istio components should output
                           logs in json format by adding --log_as_json argument to
                           each container.
@@ -262,7 +262,7 @@ spec:
                         description: Specifies the default namespace for the Istio
                           control plane components.
                         type: string
-                      logAsJSON:
+                      logAsJson:
                         description: Specifies whether istio components should output
                           logs in json format by adding --log_as_json argument to
                           each container.


### PR DESCRIPTION
The Ztunnel charts (as well as other Istio resources) use logAsJson and not logAsJSON.
