### PR TITLE
Helm: Remove redundant platform-specific cmd during installation

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -46,16 +46,8 @@ Default configuration values can be changed using one or more `--set <parameter>
 
 2. Install the Sail Operator base charts which will manage all the Custom Resource Definitions(CRDs) to be able to deploy the Istio control plane:
 
-* Kubernetes
-
     ```sh
     $ helm install sail-operator sail-operator/sail-operator --namespace sail-operator
-    ```
-
-* OpenShift
-
-    ```sh
-    $ helm install sail-operator sail-operator/sail-operator --namespace sail-operator --set platform=openshift
     ```
 
 3. Validate the CRD installation with the `helm ls` command:


### PR DESCRIPTION
Sail Operator automatically detects the platform, so you don’t have to use separate commands for Kubernetes and OpenShift.
