### PR TITLE
Add workflow to detect broken links in doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/broken-link.md
+++ b/.github/ISSUE_TEMPLATE/broken-link.md
@@ -1,0 +1,1 @@
+Broken link detected. Please see the [job results](https://github.com/istio-ecosystem/sail-operator/actions/workflows/brokenlinks.yml) for details.

--- a/.github/workflows/brokenlinks.yml
+++ b/.github/workflows/brokenlinks.yml
@@ -1,0 +1,35 @@
+---
+name: Check broken links
+
+on:
+  schedule:
+    # Run this job every sunday at midnight
+    - cron: "0 0 * * 0"
+
+permissions: {}
+
+jobs:
+  markdown-link-check-periodic:
+    name: Markdown Links (all files)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      # Checks the status of hyperlinks in .md files
+      - name: Check links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-verbose-mode: 'yes'
+          config-file: ".mdlinkcheck.json"
+          folder-path: "docs/common, docs/multicluster"
+
+      - name: Raise an Issue to report broken links
+        if: ${{ failure() }}
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Broken link detected by CI
+          content-filepath: .github/ISSUE_TEMPLATE/broken-link.md
+          labels: automated, broken link

--- a/.mdlinkcheck.json
+++ b/.mdlinkcheck.json
@@ -1,0 +1,16 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://docs.github.com"
+    },
+    {
+      "pattern": "^https://github.com/\\S+/\\S+/(issues|pull)/[0-9]+"
+    },
+    {
+      "pattern": "^https://github.com/pulls"
+    },
+    {
+      "pattern": "^https://opensource.org/licenses/Apache-2.0$"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a GitHub workflow that validates any broken links in the Sail Operator docs. It is scheduled to run every Sunday at midnight.
