### PR TITLE
Delete IstioCNI namespace in dualStack e2e tests

### DIFF
--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -305,9 +305,6 @@ spec:
 			By("Cleaning up the IstioCNI namespace")
 			Expect(k.DeleteNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI Namespace failed to be deleted")
 
-			By("Deleting any left-over Istio and IstioRevision resources")
-			Expect(forceDeleteIstioResources()).To(Succeed())
-			Success("Resources deleted")
 			Success("Cleanup done")
 		})
 	})
@@ -344,27 +341,6 @@ func ImageFromRegistry(regexp string) types.GomegaMatcher {
 func indent(level int, str string) string {
 	indent := strings.Repeat(" ", level)
 	return indent + strings.ReplaceAll(str, "\n", "\n"+indent)
-}
-
-func forceDeleteIstioResources() error {
-	// This is a workaround to delete the Istio CRs that are left in the cluster
-	// This will be improved by splitting the tests into different Nodes with their independent setups and cleanups
-	err := k.ForceDelete("istio", istioName)
-	if err != nil && !strings.Contains(err.Error(), "not found") {
-		return fmt.Errorf("failed to delete %s CR: %w", "istio", err)
-	}
-
-	err = k.ForceDelete("istiorevision", "default")
-	if err != nil && !strings.Contains(err.Error(), "not found") {
-		return fmt.Errorf("failed to delete %s CR: %w", "istiorevision", err)
-	}
-
-	err = k.Delete("istiocni", istioCniName)
-	if err != nil && !strings.Contains(err.Error(), "not found") {
-		return fmt.Errorf("failed to delete %s CR: %w", "istiocni", err)
-	}
-
-	return nil
 }
 
 func getProxyVersion(podName, namespace string) (*semver.Version, error) {

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -279,8 +279,9 @@ spec:
 			By("Cleaning up the Istio namespace")
 			Expect(cl.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: controlPlaneNamespace}})).To(Succeed(), "Istio Namespace failed to be deleted")
 
-			By("Deleting any left-over Istio and IstioRevision resources")
-			Success("Resources deleted")
+			By("Cleaning up the IstioCNI namespace")
+			Expect(k.DeleteNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI Namespace failed to be deleted")
+
 			Success("Cleanup done")
 		})
 	})


### PR DESCRIPTION
Delete IstioCNI namespace in dualStack e2e tests and the API, forceDeleteIstioResources, in control-plane tests.