### PR TITLE
Allow setting vendor-specific defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This document aims to provide an overview of the project and some information fo
     - [Writing Tests](#writing-tests)
     - [Integration Tests](#integration-tests)
     - [End-to-End Tests](#end-to-end-tests)
+    - [Vendor-specific changes](#vendor-specific-changes)
 - [Community Support and Contributing](#community-support-and-contributing)
 - [Sail Enhancement Proposal](#sail-enhancement-proposal)
 - [Issue management](#issue-management)
@@ -210,6 +211,18 @@ or
 ```sh
 make test.e2e.ocp
 ```
+
+### Vendor-specific changes
+
+As you might know, the Sail Operator project serves as the community upstream for the Red Hat OpenShift Service Mesh 3 operator. To accomodate any vendor-specific changes, we have a few places in the code base that allow for vendors to make downstream changes to the project with minimal conflicts. As a rule, these vendor-specific modifications should not include code changes, and they should be vendor-agnostic, ie if any other vendor wants to use them, they should be flexible enough to allow for doing that.
+
+#### versions.yaml
+
+The name of the versions.yaml file can be overwritten using the VERSIONS_YAML_FILE environment variable. This way, downstream vendors can point to a custom list of supported versions.
+
+#### vendor_defaults.yaml
+
+By modifying `pkg/istiovalues/vendor_defaults.yaml`, vendors can change some defaults for the helm values. Note that these are defaults, not overrides, so user input will always take precendence.
 
 ## Community Support and Contributing
 Please refer to the [CONTRIBUTING-SAIL-PROJECT.md](https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md) file for more information on how to contribute to the Sail Operator project. This file contains all the information you need to get started with contributing to the project.

--- a/pkg/istiovalues/vendor_defaults.go
+++ b/pkg/istiovalues/vendor_defaults.go
@@ -1,0 +1,50 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istiovalues
+
+import (
+	_ "embed"
+
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/helm"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	//go:embed vendor_defaults.yaml
+	vendorDefaultsYAML []byte
+	vendorDefaults     map[string]map[string]any
+)
+
+func init() {
+	vendorDefaults = MustParseVendorDefaultsYAML(vendorDefaultsYAML)
+}
+
+func MustParseVendorDefaultsYAML(defaultsYAML []byte) map[string]map[string]any {
+	var parsedDefaults map[string]map[string]any
+	err := yaml.Unmarshal(defaultsYAML, &parsedDefaults)
+	if err != nil {
+		panic("failed to read vendor_defaults.yaml: " + err.Error())
+	}
+	return parsedDefaults
+}
+
+func ApplyVendorDefaults(version string, values *v1.Values) (*v1.Values, error) {
+	if len(vendorDefaults) == 0 {
+		return values, nil
+	}
+	mergedValues := helm.Values(mergeOverwrite(helm.FromValues(values), vendorDefaults[version]))
+	return helm.ToValues(mergedValues, &v1.Values{})
+}

--- a/pkg/istiovalues/vendor_defaults.yaml
+++ b/pkg/istiovalues/vendor_defaults.yaml
@@ -1,0 +1,10 @@
+# This file can be overwritten in vendor distributions of sail-operator to set
+# vendor-specific defaults. You can configure version-specific defaults for
+# every field in `spec.values`, see the following example:
+# 
+# v1.24.2:
+#   pilot:
+#     env:
+#       test: "true"
+#
+# These defaults are type-checked at compile time.

--- a/pkg/istiovalues/vendor_defaults_test.go
+++ b/pkg/istiovalues/vendor_defaults_test.go
@@ -1,0 +1,79 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istiovalues
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+)
+
+func TestApplyVendorDefaults(t *testing.T) {
+	testcases := []struct {
+		vendorDefaults string
+		version        string
+		preValues      *v1.Values
+		postValues     *v1.Values
+		err            error
+	}{
+		{
+			vendorDefaults: `
+v1.24.2:
+  pilot:
+    env:
+      someEnvVar: "true"
+`,
+			version:   "v1.24.2",
+			preValues: &v1.Values{},
+			postValues: &v1.Values{
+				Pilot: &v1.PilotConfig{
+					Env: map[string]string{
+						"someEnvVar": "true",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		vendorDefaults = MustParseVendorDefaultsYAML([]byte(tc.vendorDefaults))
+		result, err := ApplyVendorDefaults(tc.version, tc.preValues)
+		if err != tc.err {
+			t.Errorf("unexpected error: %v, expected %v", err, tc.err)
+		}
+		if diff := cmp.Diff(tc.postValues, result); diff != "" {
+			t.Errorf("unexpected merge result; diff (-expected, +actual):\n%v", diff)
+		}
+	}
+}
+
+func TestValidateVendorDefaultsFile(t *testing.T) {
+	defaultsYAML, err := os.ReadFile("vendor_defaults.yaml")
+	if err != nil {
+		t.Errorf("failed to read vendor_defaults.yaml: %v", err)
+	}
+	vendorDefaults = MustParseVendorDefaultsYAML(defaultsYAML)
+	if len(vendorDefaults) == 0 {
+		return
+	}
+
+	for version := range vendorDefaults {
+		_, err := ApplyVendorDefaults(version, &v1.Values{})
+		if err != nil {
+			t.Errorf("failed to parse vendor_defaults.yaml at version %s: %v", version, err)
+		}
+	}
+}

--- a/pkg/revision/values.go
+++ b/pkg/revision/values.go
@@ -25,6 +25,7 @@ import (
 
 // ComputeValues computes the Istio Helm values for an IstioRevision as follows:
 // - applies image digests from the operator configuration
+// - applies vendor-specific default values
 // - applies the user-provided values on top of the default values from the default and user-selected profiles
 // - applies overrides that are not configurable by the user
 func ComputeValues(
@@ -34,6 +35,12 @@ func ComputeValues(
 ) (*v1.Values, error) {
 	// apply image digests from configuration, if not already set by user
 	userValues = istiovalues.ApplyDigests(version, userValues, config.Config)
+
+	// apply vendor-specific default values
+	userValues, err := istiovalues.ApplyVendorDefaults(version, userValues)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply vendor defaults: %w", err)
+	}
 
 	// apply userValues on top of defaultValues from profiles
 	mergedHelmValues, err := istiovalues.ApplyProfilesAndPlatform(resourceDir, version, platform, defaultProfile, userProfile, helm.FromValues(userValues))


### PR DESCRIPTION
This adds a `vendor_defaults.yaml` which can be overwritten in a fork in order to define vendor-specific default values. I also added a section to README.md to at least mention these vendor-specific modifications.