### PR TITLE
Rename test APIs according to the testSuite

### DIFF
--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -46,7 +46,7 @@ var (
 	k kubectl.Kubectl
 )
 
-func TestInstall(t *testing.T) {
+func TestControlPlane(t *testing.T) {
 	if ipFamily == "dual" || multicluster {
 		t.Skip("Skipping the control plane tests")
 	}

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -56,7 +56,7 @@ var (
 	k2 kubectl.Kubectl
 )
 
-func TestInstall(t *testing.T) {
+func TestMultiCluster(t *testing.T) {
 	if !multicluster {
 		t.Skip("Skipping test. Only valid for multicluster")
 	}

--- a/tests/e2e/multicontrolplane/multi_control_plane_suite_test.go
+++ b/tests/e2e/multicontrolplane/multi_control_plane_suite_test.go
@@ -51,7 +51,7 @@ var (
 	k kubectl.Kubectl
 )
 
-func TestInstall(t *testing.T) {
+func TestMultiControlPlane(t *testing.T) {
 	if ipFamily == "dual" || multicluster {
 		t.Skip("Skipping the multi control plane tests")
 	}

--- a/tests/e2e/operator/operator_suite_test.go
+++ b/tests/e2e/operator/operator_suite_test.go
@@ -40,7 +40,7 @@ var (
 	k kubectl.Kubectl
 )
 
-func TestInstall(t *testing.T) {
+func TestOperator(t *testing.T) {
 	if multicluster {
 		t.Skip("Skipping test for multicluster")
 	}


### PR DESCRIPTION
Currently, most test suites use the same name, TestInstall, which makes it inconvenient to select a specific test suite when running tests manually. This PR renames the APIs based on the test suite.
