### PR TITLE
Disables pruning for istios that potentially manage external revs

### DIFF
--- a/controllers/istio/istio_controller_test.go
+++ b/controllers/istio/istio_controller_test.go
@@ -872,6 +872,47 @@ func TestGetPruningGracePeriod(t *testing.T) {
 	}
 }
 
+func TestManagesExternalRevision(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     v1.IstioSpec
+		expected bool
+	}{
+		{
+			name:     "Empty spec.values does not manage",
+			spec:     v1.IstioSpec{},
+			expected: false,
+		},
+		{
+			name:     "Empty spec.values.pilot does not manage",
+			spec:     v1.IstioSpec{Values: &v1.Values{}},
+			expected: false,
+		},
+		{
+			name:     "Empty spec.values.pilot.env does not manage",
+			spec:     v1.IstioSpec{Values: &v1.Values{Pilot: &v1.PilotConfig{}}},
+			expected: false,
+		},
+		{
+			name:     "env with EXTERNAL_ISTIOD=true does manage",
+			spec:     v1.IstioSpec{Values: &v1.Values{Pilot: &v1.PilotConfig{Env: map[string]string{"EXTERNAL_ISTIOD": "true"}}}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			istio := &v1.Istio{
+				Spec: tt.spec,
+			}
+			got := managesExternalRevision(istio)
+			if got != tt.expected {
+				t.Errorf("managesExternalRevision() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func Must(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Disables pruning of istios that manage external clusters because the operator has no way of knowing if it is in use or not on the remote cluster(s).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #
Relates to https://github.com/istio-ecosystem/sail-operator/issues/457

#### Additional information:
