### PR TITLE
Rollback gitleaks version until issue with 1.24 is fixed

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -488,7 +488,7 @@ HELM_VERSION ?= v3.17.1
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 OPM_VERSION ?= v1.50.0
 OLM_VERSION ?= v0.31.0
-GITLEAKS_VERSION ?= v8.23.3
+GITLEAKS_VERSION ?= v8.23.2
 ISTIOCTL_VERSION ?= 1.23.0
 
 # GENERATE_RELATED_IMAGES defines whether `spec.relatedImages` is going to be generated or not

--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -70,8 +70,9 @@ if docker manifest inspect "gcr.io/kubebuilder/kube-rbac-proxy:${RBAC_PROXY_LATE
 fi
 
 # Update gitleaks
-GITLEAKS_VERSION=$(getLatestVersion gitleaks/gitleaks)
-sed -i "s|GITLEAKS_VERSION ?= .*|GITLEAKS_VERSION ?= ${GITLEAKS_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+# Avoiding update gitleaks until https://github.com/gitleaks/gitleaks/issues/1751 is fixed or exist a valid workaround
+# GITLEAKS_VERSION=$(getLatestVersion gitleaks/gitleaks)
+# sed -i "s|GITLEAKS_VERSION ?= .*|GITLEAKS_VERSION ?= ${GITLEAKS_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Regenerate files
 make update-istio gen


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
We are getting lint issues when gitleaks is being executed on go.1.24.0, there is an [issue](https://github.com/gitleaks/gitleaks/issues/1751) already opened in the gitleaks repo. Until the issue is solved or we found a valid workaround we will use the previous gitleaks version

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #659

#### Additional information:
