### PR TITLE
[release-1.0] Ensure e2e tests use the correct versions yaml file (#667)

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,12 +1,10 @@
-//go:build e2e
-
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,8 +17,6 @@ package env
 import (
 	"os"
 	"strconv"
-
-	g "github.com/onsi/ginkgo/v2"
 )
 
 func Get(key, defaultValue string) string {
@@ -28,9 +24,6 @@ func Get(key, defaultValue string) string {
 	if value == "" {
 		return defaultValue
 	}
-
-	g.GinkgoWriter.Printf("Env variable %s is set to %s\n", key, value)
-
 	return value
 }
 

--- a/pkg/istioversion/version.go
+++ b/pkg/istioversion/version.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"gopkg.in/yaml.v3"
 
 	"istio.io/istio/pkg/log"
@@ -28,7 +29,8 @@ var (
 	//go:embed *.yaml
 	versionsFiles embed.FS
 
-	versionsFilename = "versions.yaml"
+	// versionsFilename is set via ldflags when building the binary and via an environment variable when running tests
+	versionsFilename = env.Get("VERSIONS_YAML_FILE", "versions.yaml")
 )
 
 // Versions represents the top-level structure of versions.yaml

--- a/tests/e2e/ambient/ambient_suite_test.go
+++ b/tests/e2e/ambient/ambient_suite_test.go
@@ -19,9 +19,9 @@ package ambient
 import (
 	"testing"
 
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
-	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/env"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -19,9 +19,9 @@ package controlplane
 import (
 	"testing"
 
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
-	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/env"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/tests/e2e/dualstack/dualstack_suite_test.go
+++ b/tests/e2e/dualstack/dualstack_suite_test.go
@@ -19,9 +19,9 @@ package dualstack
 import (
 	"testing"
 
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
-	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/env"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -22,10 +22,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/certs"
 	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
-	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/env"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/tests/e2e/operator/operator_suite_test.go
+++ b/tests/e2e/operator/operator_suite_test.go
@@ -19,9 +19,9 @@ package operator
 import (
 	"testing"
 
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
-	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/env"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -26,10 +26,10 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
-	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/env"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/helm"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"

--- a/tests/e2e/util/istioctl/istioctl.go
+++ b/tests/e2e/util/istioctl/istioctl.go
@@ -19,7 +19,7 @@ package istioctl
 import (
 	"fmt"
 
-	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/env"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/shell"
 )
 


### PR DESCRIPTION
We use `-ldflags` to set the `istioversion.versionsFilename` variable, but this only works when building the binary. It doesn't work when running ginkgo-based e2e tests. When the `versionsFilename` is not set via ldflags, it will now use the environment variable `VERSIONS_YAML_FILE`. If this env var isn't set, we default to `versions.yaml`.

(cherry picked from commit 148eb64bd1dd32ff8b7b62b534ea8f11fc22a698)
Fixes: https://github.com/istio-ecosystem/sail-operator/issues/668
