### PR TITLE
FIPS: Fix missing build tag warnings

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -59,7 +59,7 @@ LD_EXTRAFLAGS += -X ${GO_MODULE}/pkg/istioversion.versionsFilename=${VERSIONS_YA
 IS_FIPS_COMPLIANT ?= false # set to true for FIPS compliance
 ifeq ($(IS_FIPS_COMPLIANT), true)
 	CGO_ENABLED = 1
-	LD_FLAGS = ${LD_EXTRAFLAGS} -s -w
+	LD_FLAGS = ${LD_EXTRAFLAGS} -tags strictfipsruntime -s -w
 else
 	CGO_ENABLED = 0
 	LD_FLAGS = -extldflags -static ${LD_EXTRAFLAGS} -s -w


### PR DESCRIPTION

- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

This PR is fixing a build system warning ` go binary has no build tags set (should have strictfipsruntime) ` when building the operator image in the FIPS compliant way. Thanks.
