### PR TITLE
Fix sample yaml in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ metadata:
   name: example
 spec:
   namespace: istio-system
-  version: v1.24.0
 ```
+
+**Note:** You can explicitly specify the version using the `spec.version` field. If not specified, the default version supported by the Operator will be used.
 
 When you create an `Istio` resource, the sail operator then creates an `IstioRevision` that represents a control plane deployment.
 
@@ -53,7 +54,6 @@ metadata:
   ...
 spec:
   namespace: istio-system
-  version: v1.24.0
 status:
   ...
   state: Healthy
@@ -67,7 +67,6 @@ kind: Istio
 metadata:
   name: example
 spec:
-  version: v1.24.0
   namespace: istio-system
   values:
     global:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ metadata:
   name: example
 spec:
   namespace: istio-system
-  version: v1.22.0
+  version: v1.24.0
 ```
 
 When you create an `Istio` resource, the sail operator then creates an `IstioRevision` that represents a control plane deployment.
@@ -53,7 +53,7 @@ metadata:
   ...
 spec:
   namespace: istio-system
-  version: v1.22.0
+  version: v1.24.0
 status:
   ...
   state: Healthy
@@ -67,13 +67,13 @@ kind: Istio
 metadata:
   name: example
 spec:
-  version: v1.20.0
+  version: v1.24.0
+  namespace: istio-system
   values:
     global:
-      mtls:
-        enabled: true
-      trustDomainAliases:
-      - example.net
+      variant: debug
+      logging:
+        level: "all:debug"
     meshConfig:
       trustDomain: example.com
       trustDomainAliases:


### PR DESCRIPTION
The sample yaml includes `mtls` and `trustDomainAliases` as part of `spec.values.global` but they should be part of `spec.values.meshConfig`. This PR modifies the sample yaml to use a working example and also updates the `version` as part of this change.
