### PR TITLE
make spec.namespace field of `IstioCNI` immutable

### DIFF
--- a/api/v1/istiocni_types.go
+++ b/api/v1/istiocni_types.go
@@ -43,9 +43,10 @@ type IstioCNISpec struct {
 	// +kubebuilder:validation:Enum=ambient;default;demo;empty;external;openshift-ambient;openshift;preview;remote;stable
 	Profile string `json:"profile,omitempty"`
 
-	// Namespace to which the Istio CNI component should be installed.
+	// Namespace to which the Istio CNI component should be installed. Note that this field is immutable.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Namespace"}
 	// +kubebuilder:default=istio-cni
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	Namespace string `json:"namespace"`
 
 	// Defines the values to be passed to the Helm charts when installing Istio CNI.

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/sail-dev/sail-operator:1.1-latest
-    createdAt: "2025-02-14T12:02:06Z"
+    createdAt: "2025-03-07T09:31:20Z"
     description: Experimental operator for installing Istio service mesh
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -187,6 +187,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:master
         - urn:alm:descriptor:com.tectonic.ui:select:v1.25-alpha.c2ac935c
       - description: Namespace to which the Istio CNI component should be installed.
+          Note that this field is immutable.
         displayName: Namespace
         path: namespace
         x-descriptors:

--- a/bundle/manifests/sailoperator.io_istiocnis.yaml
+++ b/bundle/manifests/sailoperator.io_istiocnis.yaml
@@ -64,8 +64,11 @@ spec:
               namespace:
                 default: istio-cni
                 description: Namespace to which the Istio CNI component should be
-                  installed.
+                  installed. Note that this field is immutable.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               profile:
                 description: |-
                   The built-in installation configuration profile to use.

--- a/chart/crds/sailoperator.io_istiocnis.yaml
+++ b/chart/crds/sailoperator.io_istiocnis.yaml
@@ -64,8 +64,11 @@ spec:
               namespace:
                 default: istio-cni
                 description: Namespace to which the Istio CNI component should be
-                  installed.
+                  installed. Note that this field is immutable.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               profile:
                 description: |-
                   The built-in installation configuration profile to use.

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -649,7 +649,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `version` _string_ | Defines the version of Istio to install. Must be one of: v1.24-latest, v1.24.2, v1.24.1, v1.24.0, v1.23-latest, v1.23.4, v1.23.3, v1.23.2, v1.22-latest, v1.22.8, v1.22.7, v1.22.6, v1.22.5, v1.21.6, master, v1.25-alpha.c2ac935c. | v1.24.2 | Enum: [v1.24-latest v1.24.2 v1.24.1 v1.24.0 v1.23-latest v1.23.4 v1.23.3 v1.23.2 v1.22-latest v1.22.8 v1.22.7 v1.22.6 v1.22.5 v1.21.6 master v1.25-alpha.c2ac935c]   |
 | `profile` _string_ | The built-in installation configuration profile to use. The 'default' profile is always applied. On OpenShift, the 'openshift' profile is also applied on top of 'default'. Must be one of: ambient, default, demo, empty, external, openshift-ambient, openshift, preview, remote, stable. |  | Enum: [ambient default demo empty external openshift-ambient openshift preview remote stable]   |
-| `namespace` _string_ | Namespace to which the Istio CNI component should be installed. | istio-cni |  |
+| `namespace` _string_ | Namespace to which the Istio CNI component should be installed. Note that this field is immutable. | istio-cni |  |
 | `values` _[CNIValues](#cnivalues)_ | Defines the values to be passed to the Helm charts when installing Istio CNI. |  |  |
 
 

--- a/tests/integration/api/istiocni_test.go
+++ b/tests/integration/api/istiocni_test.go
@@ -267,6 +267,14 @@ var _ = Describe("IstioCNI", Ordered, func() {
 			})
 		})
 
+		When("namespace is updated", func() {
+			It("throws a validation error as the field is immutable", func() {
+				Expect(k8sClient.Get(ctx, cniKey, cni)).To(Succeed())
+				cni.Spec.Namespace = "other"
+				Expect(k8sClient.Update(ctx, cni)).To(MatchError(ContainSubstring("immutable")))
+			})
+		})
+
 		When("the resource is deleted", func() {
 			BeforeAll(func() {
 				Expect(k8sClient.DeleteAllOf(ctx, &v1.IstioCNI{})).To(Succeed())


### PR DESCRIPTION
We don't support migrating `IstioCNI` to another namespace, so we should make the field immutable for now. We already did it for the spec.namespace field of the `Istio` resource. Once we implement support for namespace migrations of these resources, we can revert this.

Fixes https://github.com/istio-ecosystem/sail-operator/issues/698