### PR TITLE
Add `make cluster` command

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -334,6 +334,13 @@ create-gh-release: helm-package ## Create a GitHub release and upload the helm c
 		--generate-notes \
 		$(GH_RELEASE_ADDITIONAL_FLAGS)
 
+.PHONY: cluster
+cluster: SKIP_CLEANUP=true
+cluster: ## Creates a KinD cluster(s) to use in local deployments.
+	source ${SOURCE_DIR}/tests/e2e/setup/setup-kind.sh; \
+	export HUB="$${KIND_REGISTRY}"; \
+	OCP=false ${SOURCE_DIR}/tests/e2e/setup/build-and-push-operator.sh
+
 .PHONY: deploy
 deploy: verify-kubeconfig helm ## Deploy controller to an existing cluster.
 	$(info NAMESPACE: $(NAMESPACE))

--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ spec:
 You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
 **Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
+### Quick start using a local KIND cluster
+
+For a quick start using a local cluster run:
+
+```sh
+make cluster
+```
+
+This deploys the cluster and preloads the latest operator image built from source to it.
+You can then follow up by deploying the operator and using it locally.
+
+Alternatively, you can deploy a local multi-cluster setup by running:
+
+```sh
+make cluster MULTICLUSTER=true
+```
+
 ### Deploying the operator
 
 Deploy the operator to the cluster:
@@ -100,6 +117,12 @@ make deploy-olm
 ```
 
 Make sure that the `HUB` and `TAG` environment variables point to your container image repository and that the repository is publicly accessible.
+
+When deploying on a local KIND cluster, make sure to use the local image registry:
+
+```sh
+export HUB=localhost:5000
+```
 
 ### Deploying the Istio Control Plane
 

--- a/tests/e2e/setup/setup-kind.sh
+++ b/tests/e2e/setup/setup-kind.sh
@@ -74,7 +74,9 @@ if [ "${MULTICLUSTER}" == "true" ]; then
 
     export KUBECONFIG="${KUBECONFIGS[0]}"
     export KUBECONFIG2="${KUBECONFIGS[1]}"
+    echo "Your KinD environment is ready, to use it: export KUBECONFIG=$(IFS=:; echo "${KUBECONFIGS[*]}")"
 else
   KUBECONFIG="${ARTIFACTS}/config" setup_kind_cluster "${KIND_CLUSTER_NAME}" "" "" "true" "true"
   setup_kind_registry
+  echo "Your KinD environment is ready, to use it: export KUBECONFIG=${ARTIFACTS}/config"
 fi


### PR DESCRIPTION

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [x] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Add the ability to create a cluster for testing by using `make cluster`. Multiple clusters can be created by utilizing the `MULTICLUSTER=true` option.
This allows developers to easily create a cluster to run manual testing on.

Most of the code has been carved out of `tests/e2e/integ-suite-kind.sh` which now relies on the cluster existing (the Makefile has been updated to create it when running the tests).


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #554 

Related Issue/PR #

#### Additional information:
