### PR TITLE
Remove special CODEOWNERS for tools/ directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
 *           @istio-ecosystem/sail-maintainers
-tools/      @jwendell @dgn @howardjohn @ericvn


### PR DESCRIPTION
We're not running the relevant jobs in Istio's prow anymore, so no reason to have special approvals.
