### PR TITLE
Check IstioCNI status for IstioRevisions that depend on IstioCNI

### DIFF
--- a/api/v1/istio_types.go
+++ b/api/v1/istio_types.go
@@ -235,6 +235,23 @@ const (
 )
 
 const (
+	// IstioConditionDependenciesHealthy signifies whether the dependencies required by this Istio are healthy.
+	// For example, an Istio with spec.values.pilot.cni.enabled=true requires the IstioCNI resource to be deployed
+	// and ready for the Istio revision to be considered healthy. The DependenciesHealthy condition is used to indicate that
+	// the IstioCNI resource is healthy.
+	IstioConditionDependenciesHealthy IstioConditionType = "DependenciesHealthy"
+
+	// IstioReasonIstioCNINotFound indicates that the IstioCNI resource is not found.
+	IstioReasonIstioCNINotFound IstioConditionReason = "IstioCNINotFound"
+
+	// IstioReasonIstioCNINotHealthy indicates that the IstioCNI resource is not healthy.
+	IstioReasonIstioCNINotHealthy IstioConditionReason = "IstioCNINotHealthy"
+
+	// IstioReasonDependencyCheckFailed indicates that the status of the dependencies could not be ascertained.
+	IstioReasonDependencyCheckFailed IstioConditionReason = "DependencyCheckFailed"
+)
+
+const (
 	// IstioReasonHealthy indicates that the control plane is fully reconciled and that all components are ready.
 	IstioReasonHealthy IstioConditionReason = "Healthy"
 )

--- a/api/v1/istiorevision_types.go
+++ b/api/v1/istiorevision_types.go
@@ -169,6 +169,23 @@ const (
 )
 
 const (
+	// IstioRevisionConditionDependenciesHealthy signifies whether the dependencies required by this IstioRevision are healthy.
+	// For example, an IstioRevision with spec.values.pilot.cni.enabled=true requires the IstioCNI resource to be deployed
+	// and ready for the Istio revision to be considered healthy. The DependenciesHealthy condition is used to indicate that
+	// the IstioCNI resource is healthy.
+	IstioRevisionConditionDependenciesHealthy IstioRevisionConditionType = "DependenciesHealthy"
+
+	// IstioRevisionReasonIstioCNINotFound indicates that the IstioCNI resource is not found.
+	IstioRevisionReasonIstioCNINotFound IstioRevisionConditionReason = "IstioCNINotFound"
+
+	// IstioRevisionReasonIstioCNINotHealthy indicates that the IstioCNI resource is not healthy.
+	IstioRevisionReasonIstioCNINotHealthy IstioRevisionConditionReason = "IstioCNINotHealthy"
+
+	// IstioRevisionDependencyCheckFailed indicates that the status of the dependencies could not be ascertained.
+	IstioRevisionDependencyCheckFailed IstioRevisionConditionReason = "DependencyCheckFailed"
+)
+
+const (
 	// IstioRevisionReasonHealthy indicates that the control plane is fully reconciled and that all components are ready.
 	IstioRevisionReasonHealthy IstioRevisionConditionReason = "Healthy"
 )

--- a/controllers/istio/istio_controller.go
+++ b/controllers/istio/istio_controller.go
@@ -257,6 +257,7 @@ func (r *Reconciler) determineStatus(ctx context.Context, istio *v1.Istio, recon
 		} else if err == nil {
 			status.SetCondition(convertCondition(rev.Status.GetCondition(v1.IstioRevisionConditionReconciled)))
 			status.SetCondition(convertCondition(rev.Status.GetCondition(v1.IstioRevisionConditionReady)))
+			status.SetCondition(convertCondition(rev.Status.GetCondition(v1.IstioRevisionConditionDependenciesHealthy)))
 			status.State = convertState(rev.Status.State)
 		} else {
 			activeRevisionGetFailed := func(conditionType v1.IstioConditionType) v1.IstioCondition {

--- a/controllers/istio/istio_controller_test.go
+++ b/controllers/istio/istio_controller_test.go
@@ -265,6 +265,7 @@ func TestDetermineStatus(t *testing.T) {
 				Conditions: []v1.IstioRevisionCondition{
 					{Type: v1.IstioRevisionConditionReconciled, Status: toConditionStatus(reconciled)},
 					{Type: v1.IstioRevisionConditionReady, Status: toConditionStatus(ready)},
+					{Type: v1.IstioRevisionConditionDependenciesHealthy, Status: toConditionStatus(true)},
 					{Type: v1.IstioRevisionConditionInUse, Status: toConditionStatus(inUse)},
 				},
 			},
@@ -330,6 +331,12 @@ func TestDetermineStatus(t *testing.T) {
 								Reason:  v1.IstioRevisionReasonHealthy,
 								Message: "ready message",
 							},
+							{
+								Type:    v1.IstioRevisionConditionDependenciesHealthy,
+								Status:  metav1.ConditionTrue,
+								Reason:  v1.IstioRevisionReasonHealthy,
+								Message: "dependencies healthy message",
+							},
 						},
 					},
 				},
@@ -376,6 +383,12 @@ func TestDetermineStatus(t *testing.T) {
 						Reason:  v1.IstioReasonHealthy,
 						Message: "ready message",
 					},
+					{
+						Type:    v1.IstioConditionDependenciesHealthy,
+						Status:  metav1.ConditionTrue,
+						Reason:  v1.IstioReasonHealthy,
+						Message: "dependencies healthy message",
+					},
 				},
 				ActiveRevisionName: istioKey.Name,
 				Revisions: v1.RevisionSummary{
@@ -406,6 +419,10 @@ func TestDetermineStatus(t *testing.T) {
 					},
 					{
 						Type:   v1.IstioConditionReady,
+						Status: metav1.ConditionTrue,
+					},
+					{
+						Type:   v1.IstioConditionDependenciesHealthy,
 						Status: metav1.ConditionTrue,
 					},
 				},
@@ -639,6 +656,11 @@ func TestUpdateStatus(t *testing.T) {
 							Message:            "ready message",
 							LastTransitionTime: *oneMinuteAgo,
 						},
+						{
+							Type:               v1.IstioConditionDependenciesHealthy,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: *oneMinuteAgo,
+						},
 					},
 					ActiveRevisionName: istioKey.Name,
 				},
@@ -668,6 +690,11 @@ func TestUpdateStatus(t *testing.T) {
 								Message:            "ready message",
 								LastTransitionTime: *oneMinuteAgo,
 							},
+							{
+								Type:               v1.IstioRevisionConditionDependenciesHealthy,
+								Status:             metav1.ConditionTrue,
+								LastTransitionTime: *oneMinuteAgo,
+							},
 						},
 					},
 				},
@@ -687,6 +714,10 @@ func TestUpdateStatus(t *testing.T) {
 						Status:  metav1.ConditionTrue,
 						Reason:  v1.IstioReasonHealthy,
 						Message: "ready message",
+					},
+					{
+						Type:   v1.IstioConditionDependenciesHealthy,
+						Status: metav1.ConditionTrue,
 					},
 				},
 				ActiveRevisionName: istioKey.Name,

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -713,6 +713,9 @@ _Appears in:_
 | `IstiodNotReady` | IstioReasonIstiodNotReady indicates that the control plane is fully reconciled, but istiod is not ready.  |
 | `RemoteIstiodNotReady` | IstioReasonRemoteIstiodNotReady indicates that the control plane is fully reconciled, but the remote istiod is not ready.  |
 | `ReadinessCheckFailed` | IstioReasonReadinessCheckFailed indicates that readiness could not be ascertained.  |
+| `IstioCNINotFound` | IstioReasonIstioCNINotFound indicates that the IstioCNI resource is not found.  |
+| `IstioCNINotHealthy` | IstioReasonIstioCNINotHealthy indicates that the IstioCNI resource is not healthy.  |
+| `DependencyCheckFailed` | IstioReasonDependencyCheckFailed indicates that the status of the dependencies could not be ascertained.  |
 | `Healthy` | IstioReasonHealthy indicates that the control plane is fully reconciled and that all components are ready.  |
 
 
@@ -732,6 +735,7 @@ _Appears in:_
 | --- | --- |
 | `Reconciled` | IstioConditionReconciled signifies whether the controller has successfully reconciled the resources defined through the CR.  |
 | `Ready` | IstioConditionReady signifies whether any Deployment, StatefulSet, etc. resources are Ready.  |
+| `DependenciesHealthy` | IstioConditionDependenciesHealthy signifies whether the dependencies required by this Istio are healthy. For example, an Istio with spec.values.pilot.cni.enabled=true requires the IstioCNI resource to be deployed and ready for the Istio revision to be considered healthy. The DependenciesHealthy condition is used to indicate that the IstioCNI resource is healthy.  |
 
 
 #### IstioList
@@ -821,6 +825,9 @@ _Appears in:_
 | `ReferencedByWorkloads` | IstioRevisionReasonReferencedByWorkloads indicates that the revision is referenced by at least one pod or namespace.  |
 | `NotReferencedByAnything` | IstioRevisionReasonNotReferenced indicates that the revision is not referenced by any pod or namespace.  |
 | `UsageCheckFailed` | IstioRevisionReasonUsageCheckFailed indicates that the operator could not check whether any workloads use the revision.  |
+| `IstioCNINotFound` | IstioRevisionReasonIstioCNINotFound indicates that the IstioCNI resource is not found.  |
+| `IstioCNINotHealthy` | IstioRevisionReasonIstioCNINotHealthy indicates that the IstioCNI resource is not healthy.  |
+| `DependencyCheckFailed` | IstioRevisionDependencyCheckFailed indicates that the status of the dependencies could not be ascertained.  |
 | `Healthy` | IstioRevisionReasonHealthy indicates that the control plane is fully reconciled and that all components are ready.  |
 
 
@@ -841,6 +848,7 @@ _Appears in:_
 | `Reconciled` | IstioRevisionConditionReconciled signifies whether the controller has successfully reconciled the resources defined through the CR.  |
 | `Ready` | IstioRevisionConditionReady signifies whether any Deployment, StatefulSet, etc. resources are Ready.  |
 | `InUse` | IstioRevisionConditionInUse signifies whether any workload is configured to use the revision.  |
+| `DependenciesHealthy` | IstioRevisionConditionDependenciesHealthy signifies whether the dependencies required by this IstioRevision are healthy. For example, an IstioRevision with spec.values.pilot.cni.enabled=true requires the IstioCNI resource to be deployed and ready for the Istio revision to be considered healthy. The DependenciesHealthy condition is used to indicate that the IstioCNI resource is healthy.  |
 
 
 #### IstioRevisionList

--- a/pkg/revision/dependency.go
+++ b/pkg/revision/dependency.go
@@ -1,0 +1,30 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revision
+
+import v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+
+// DependsOnIstioCNI returns true if CNI is enabled in the revision
+func DependsOnIstioCNI(rev *v1.IstioRevision) bool {
+	// TODO: get actual final values and inspect pilot.cni.enabled
+	values := rev.Spec.Values
+	if values == nil {
+		return false
+	}
+	global := values.Global
+	pilot := values.Pilot
+	return (global != nil && global.Platform != nil && *global.Platform == "openshift") ||
+		(pilot != nil && pilot.Cni != nil && pilot.Cni.Enabled != nil && *pilot.Cni.Enabled)
+}

--- a/pkg/revision/dependency_test.go
+++ b/pkg/revision/dependency_test.go
@@ -1,0 +1,168 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revision
+
+import (
+	"testing"
+
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/stretchr/testify/assert"
+
+	"istio.io/istio/pkg/ptr"
+)
+
+func TestDependsOnIstioCNI(t *testing.T) {
+	tests := []struct {
+		name     string
+		rev      *v1.IstioRevision
+		expected bool
+	}{
+		{
+			name: "NilValues",
+			rev: &v1.IstioRevision{
+				Spec: v1.IstioRevisionSpec{
+					Values: nil,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "NilGlobal",
+			rev: &v1.IstioRevision{
+				Spec: v1.IstioRevisionSpec{
+					Values: &v1.Values{
+						Global: nil,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "NilGlobalPlatform",
+			rev: &v1.IstioRevision{
+				Spec: v1.IstioRevisionSpec{
+					Values: &v1.Values{
+						Global: &v1.GlobalConfig{
+							Platform: nil,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "GlobalPlatformOpenshift",
+			rev: &v1.IstioRevision{
+				Spec: v1.IstioRevisionSpec{
+					Values: &v1.Values{
+						Global: &v1.GlobalConfig{
+							Platform: ptr.Of("openshift"),
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "GlobalPlatformNotOpenshift",
+			rev: &v1.IstioRevision{
+				Spec: v1.IstioRevisionSpec{
+					Values: &v1.Values{
+						Global: &v1.GlobalConfig{
+							Platform: ptr.Of("kind"),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "NilPilot",
+			rev: &v1.IstioRevision{
+				Spec: v1.IstioRevisionSpec{
+					Values: &v1.Values{
+						Pilot: nil,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "NilPilotCni",
+			rev: &v1.IstioRevision{
+				Spec: v1.IstioRevisionSpec{
+					Values: &v1.Values{
+						Pilot: &v1.PilotConfig{
+							Cni: nil,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "NilPilotCniEnabled",
+			rev: &v1.IstioRevision{
+				Spec: v1.IstioRevisionSpec{
+					Values: &v1.Values{
+						Pilot: &v1.PilotConfig{
+							Cni: &v1.CNIUsageConfig{
+								Enabled: nil,
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "PilotCniEnabled",
+			rev: &v1.IstioRevision{
+				Spec: v1.IstioRevisionSpec{
+					Values: &v1.Values{
+						Pilot: &v1.PilotConfig{
+							Cni: &v1.CNIUsageConfig{
+								Enabled: ptr.Of(true),
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "PilotCniDisabled",
+			rev: &v1.IstioRevision{
+				Spec: v1.IstioRevisionSpec{
+					Values: &v1.Values{
+						Pilot: &v1.PilotConfig{
+							Cni: &v1.CNIUsageConfig{
+								Enabled: ptr.Of(false),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DependsOnIstioCNI(tt.rev)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Previously, when an IstioRevision depended on IstioCNI, either because the user enabled the use of IstioCNI through `values.pilot.cni.enabled` or because the platform profile enables it, the IstioRevision resource would show as healthy even though workloads would fail because IstioCNI hasn't been deployed. This commit adds a new `DependenciesHealthy` condition to IstioRevision and makes `IstioRevision.status.state` and the `STATUS` column report the fact that IstioCNI is missing or unhealthy. This makes it easier for users to see that their setup is misconfigured.