### PR TITLE
Add Openshift support for multicluster test suite

### DIFF
--- a/tests/e2e/integ-suite-kind.sh
+++ b/tests/e2e/integ-suite-kind.sh
@@ -72,10 +72,16 @@ function setup_kind_registry() {
       continue
     fi
 
-    kind export kubeconfig --name="${cluster}"
+    if [ "${MULTICLUSTER}" == "true" ]; then
+        export KUBECONFIG="${KUBECONFIG_DIR}/${cluster}"
+    else
+        kind export kubeconfig --name="${cluster}"
+    fi
+
     for node in $(kind get nodes --name="${cluster}"); do
       kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${KIND_REGISTRY_PORT}" --overwrite;
     done
+    unset KUBECONFIG
   done
 }
 

--- a/tests/e2e/multicluster/common.go
+++ b/tests/e2e/multicluster/common.go
@@ -59,7 +59,7 @@ func verifyResponsesAreReceivedFromExpectedVersions(k kubectl.Kubectl, expectedV
 		expectedVersions = []string{"v1", "v2"}
 	}
 	for _, v := range expectedVersions {
-		Eventually(k.WithNamespace("sample").Exec, 10*time.Second, 10*time.Millisecond).
+		Eventually(k.WithNamespace("sample").Exec, 160*time.Second, 2*time.Second).
 			WithArguments("deploy/sleep", "sleep", "curl -sS helloworld.sample:5000/hello").
 			Should(ContainSubstring(fmt.Sprintf("Hello version: %s", v)),
 				fmt.Sprintf("sleep pod in %s did not receive any response from %s", k.ClusterName, v))

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -35,12 +35,13 @@ var (
 	clPrimary                     client.Client
 	clRemote                      client.Client
 	err                           error
-	ocp                           = env.GetBool("OCP", false)
 	namespace                     = env.Get("NAMESPACE", "sail-operator")
 	deploymentName                = env.Get("DEPLOYMENT_NAME", "sail-operator")
 	controlPlaneNamespace         = env.Get("CONTROL_PLANE_NS", "istio-system")
 	externalControlPlaneNamespace = env.Get("EXTERNAL_CONTROL_PLANE_NS", "external-istiod")
 	istioName                     = env.Get("ISTIO_NAME", "default")
+	istioCniNamespace             = env.Get("ISTIOCNI_NAMESPACE", "istio-cni")
+	istioCniName                  = env.Get("ISTIOCNI_NAME", "default")
 	image                         = env.Get("IMAGE", "quay.io/maistra-dev/sail-operator:latest")
 	skipDeploy                    = env.GetBool("SKIP_DEPLOY", false)
 	multicluster                  = env.GetBool("MULTICLUSTER", false)
@@ -63,10 +64,8 @@ func TestMultiCluster(t *testing.T) {
 	if !multicluster {
 		t.Skip("Skipping test. Only valid for multicluster")
 	}
-	if ocp {
-		t.Skip("Skipping test. Not valid for OCP")
-		// TODO: Implement the steps to run the test on OCP
-		// https://github.com/istio-ecosystem/sail-operator/issues/365
+	if kubeconfig == "" && kubeconfig2 == "" {
+		t.Skip("Skipping test. Two clusters required for multicluster test")
 	}
 	RegisterFailHandler(Fail)
 	setup(t)

--- a/tests/e2e/util/istioctl/istioctl.go
+++ b/tests/e2e/util/istioctl/istioctl.go
@@ -48,8 +48,8 @@ func istioctl(format string, args ...interface{}) string {
 // - remoteKubeconfig: kubeconfig of the remote cluster
 // - secretName: name of the secret
 // - internalIP: internal IP of the remote cluster
-func CreateRemoteSecret(remoteKubeconfig string, secretName string, internalIP string, additionalFlags ...string) (string, error) {
-	cmd := istioctl("create-remote-secret --kubeconfig %s --name %s --server=https://%s:6443", remoteKubeconfig, secretName, internalIP)
+func CreateRemoteSecret(remoteKubeconfig, namespace, secretName, internalIP string, additionalFlags ...string) (string, error) {
+	cmd := istioctl("create-remote-secret --kubeconfig %s --namespace %s --name %s --server=%s", remoteKubeconfig, namespace, secretName, internalIP)
 	if len(additionalFlags) != 0 {
 		cmd += (" " + strings.Join(additionalFlags, " "))
 	}

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -257,6 +257,16 @@ func (k Kubectl) GetInternalIP(label string) (string, error) {
 	return output, nil
 }
 
+func (k Kubectl) GetClusterAPIURL() (string, error) {
+	cmd := k.build(" config view --minify -o jsonpath='{.clusters[0].cluster.server}'")
+	output, err := k.executeCommand(cmd)
+	if err != nil {
+		return "", fmt.Errorf("error getting cluster api url: %w, output: %s", err, output)
+	}
+
+	return output, nil
+}
+
 // GetSecret returns the secret of a namespace
 func (k Kubectl) GetSecret(secret string) (string, error) {
 	cmd := k.build(fmt.Sprintf(" get secret %s -o yaml", secret))


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Add Openshift support for multicluster test suite.
- Add IstioCNI deployment and test flows.
- Modify node annotation flow. Otherwise, in "Kind" based environment,
  the remote cluster changes its address from - https://172.18.0.2:6443/
  to https://127.0.0.1:54974/, which prevents futher testing flow.
- Extend the helloworld service timeout for checking the expected
  output, since for Openshift it could take longer to settle everything
  down.
- Modify cluster address to api url within remote secret and remote
  config to be able to reach out to the real clusters.
- Add verification to execute multicluster tests only when 2 kubeconfig
  files provided.
- Update "GetSVCLoadBalancerAddress" function to fetch Ingress
  LoadBalancer address as hostname, if available or ip if not. That is
  used for public cloud clusters.
- Add "ResolveHostDomainToIP" function to resolve hostname into ip addr.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #365 

#### Additional information:
