### PR TITLE
Remove TYPE column from IstioRevision

### DIFF
--- a/api/v1/istiorevision_types.go
+++ b/api/v1/istiorevision_types.go
@@ -177,7 +177,6 @@ const (
 // +kubebuilder:resource:scope=Cluster,shortName=istiorev,categories=istio-io
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Namespace",type="string",JSONPath=".spec.namespace",description="The namespace for the control plane components."
-// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",description="Whether the control plane is installed locally or in a remote cluster."
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description="Whether the control plane installation is ready to handle requests."
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="The current state of this object."
 // +kubebuilder:printcolumn:name="In use",type="string",JSONPath=".status.conditions[?(@.type==\"InUse\")].status",description="Whether the revision is being used by workloads."

--- a/bundle/manifests/sailoperator.io_istiorevisions.yaml
+++ b/bundle/manifests/sailoperator.io_istiorevisions.yaml
@@ -23,10 +23,6 @@ spec:
       jsonPath: .spec.namespace
       name: Namespace
       type: string
-    - description: Whether the control plane is installed locally or in a remote cluster.
-      jsonPath: .spec.type
-      name: Type
-      type: string
     - description: Whether the control plane installation is ready to handle requests.
       jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready

--- a/chart/crds/sailoperator.io_istiorevisions.yaml
+++ b/chart/crds/sailoperator.io_istiorevisions.yaml
@@ -23,10 +23,6 @@ spec:
       jsonPath: .spec.namespace
       name: Namespace
       type: string
-    - description: Whether the control plane is installed locally or in a remote cluster.
-      jsonPath: .spec.type
-      name: Type
-      type: string
     - description: Whether the control plane installation is ready to handle requests.
       jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready


### PR DESCRIPTION
This column is always empty, because there is no `spec.type` field in `IstioRevision`.