### PR TITLE
Enable IstioCNI for dualStack e2e tests

### DIFF
--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -120,6 +120,8 @@ spec:
       ipFamilyPolicy: %s
       env:
         ISTIO_DUAL_STACK: "true"
+      cni:
+        enabled: true
   version: %s
   namespace: %s`
 						istioYAML = fmt.Sprintf(istioYAML, corev1.IPFamilyPolicyRequireDualStack, version.Name, controlPlaneNamespace)


### PR DESCRIPTION
Currently, we install IstioCNI as part of e2e dualStack tests but were not configuring Istiod with CNI status. On OCP platform, CNI gets automatically enabled due to platform settings. This PR updates the e2e tests to use CNI in KinD deployments as well.
