### PR TITLE
Add ConfigMap with final Helm values to charts that don't have one

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,10 @@
 # User Documentation
 Sail Operator manages the lifecycle of your Istio control planes. Instead of creating a new configuration schema, Sail Operator APIs are built around Istio's helm chart APIs. All installation and configuration options that are exposed by Istio's helm charts are available through the Sail Operator CRDs' `values` fields.
 
+Similar to using Istio's Helm charts, the final set of values used to render the charts is determined by a combination of user-provided values, default chart values, and values from selected profiles. 
+These profiles can include the user-defined profile, the platform profile, and the compatibility version profile.
+To view the final set of values, inspect the ConfigMap named `values` (or `values-<revision>`) in the namespace where the control plane is installed.
+
 ## Concepts
 
 ### Istio resource

--- a/hack/download-charts.sh
+++ b/hack/download-charts.sh
@@ -100,6 +100,43 @@ function patchIstioCharts() {
 
   # remove install.operator.istio.io/owning-resource label from all charts
   sed -i '/install.operator.istio.io\/owning-resource/d' "${CHARTS_DIR}"/*/templates/*.yaml
+
+  # add values ConfigMap template if it doesn't exist
+  if [ ! -f "${CHARTS_DIR}/istiod/templates/configmap-values.yaml" ]; then
+    cat <<EOF > "${CHARTS_DIR}/istiod/templates/configmap-values.yaml"
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" . | nindent 4 }}
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- \$_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}
+EOF
+
+    # remove "include istio.labels" line if istio.labels is not defined in zzz_profile.yaml
+    if ! grep -q 'define "istio.labels"' "${CHARTS_DIR}/istiod/templates/zzz_profile.yaml"; then
+      sed -i '/istio.labels/d' "${CHARTS_DIR}/istiod/templates/configmap-values.yaml"
+    fi
+  fi
+
+  # shellcheck disable=SC2016
+  if ! grep -q '$x := set $.Values "_original" (deepCopy $.Values)' "${CHARTS_DIR}/istiod/templates/zzz_profile.yaml"; then
+    # shellcheck disable=SC2016
+    sed -i '/mustMergeOverwrite \$defaults \$.Values/i {{- $x := set $.Values "_original" (deepCopy $.Values) }}' "${CHARTS_DIR}/istiod/templates/zzz_profile.yaml"
+  fi
 }
 
 # The charts use docker.io as the default registry, but this leads to issues

--- a/resources/v1.21.6/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.21.6/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/zzz_profile.yaml
@@ -31,4 +31,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if $profile }}
 {{- $a := mustMergeOverwrite $defaults $profile }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.21.6/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.21.6/charts/revisiontags/templates/zzz_profile.yaml
@@ -31,4 +31,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if $profile }}
 {{- $a := mustMergeOverwrite $defaults $profile }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.22.5/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.22.5/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.22.5/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.22.5/charts/revisiontags/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.22.6/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.22.6/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.22.6/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.22.6/charts/revisiontags/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.22.7/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.22.7/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.22.7/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.22.7/charts/revisiontags/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.22.8/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.22.8/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.22.8/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.22.8/charts/revisiontags/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.23.2/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.23.2/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.23.2/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.23.2/charts/revisiontags/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.23.3/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.23.3/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.23.3/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.23.3/charts/revisiontags/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.23.4/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.23.4/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.23.4/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.23.4/charts/revisiontags/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.23.5/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.23.5/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.23.5/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.23.5/charts/revisiontags/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.23.6/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.23.6/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.23.6/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.23.6/charts/istiod/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.23.6/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.23.6/charts/revisiontags/templates/zzz_profile.yaml
@@ -40,4 +40,5 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults $globals  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/resources/v1.24.0/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" . | nindent 4 }}
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.24.0/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.0/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.24.0/charts/revisiontags/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.1/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" . | nindent 4 }}
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.24.1/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.1/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.24.1/charts/revisiontags/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.2/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" . | nindent 4 }}
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.24.2/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.2/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.24.2/charts/revisiontags/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.3/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" . | nindent 4 }}
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.24.3/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.3/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.24.3/charts/revisiontags/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.4/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" . | nindent 4 }}
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.24.4/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.4/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.24.4/charts/revisiontags/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.5/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.24.5/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" . | nindent 4 }}
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.24.5/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.24.5/charts/istiod/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.24.5/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.24.5/charts/revisiontags/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.25.1/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" . | nindent 4 }}
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.25.1/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.25.1/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.25.1/charts/revisiontags/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.25.2/charts/istiod/templates/configmap-values.yaml
+++ b/resources/v1.25.2/charts/istiod/templates/configmap-values.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" . | nindent 4 }}
+data:
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/resources/v1.25.2/charts/istiod/templates/zzz_profile.yaml
+++ b/resources/v1.25.2/charts/istiod/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/resources/v1.25.2/charts/revisiontags/templates/zzz_profile.yaml
+++ b/resources/v1.25.2/charts/revisiontags/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/tests/documentation_tests/README-runme.md
+++ b/tests/documentation_tests/README-runme.md
@@ -69,6 +69,10 @@
 # User Documentation
 Sail Operator manages the lifecycle of your Istio control planes. Instead of creating a new configuration schema, Sail Operator APIs are built around Istio's helm chart APIs. All installation and configuration options that are exposed by Istio's helm charts are available through the Sail Operator CRDs' `values` fields.
 
+Similar to using Istio's Helm charts, the final set of values used to render the charts is determined by a combination of user-provided values, default chart values, and values from selected profiles. 
+These profiles can include the user-defined profile, the platform profile, and the compatibility version profile.
+To view the final set of values, inspect the ConfigMap named `values` (or `values-<revision>`) in the namespace where the control plane is installed.
+
 ## Concepts
 
 ### Istio resource


### PR DESCRIPTION
Ever since the profiles were reimplemented within the Helm charts, there has been no way to see the actual values that were used to render the charts. This includes the values from the user-selected profile, the platform profile, and the compatibility version profile.

Previously, when the values from the profiles were applied before Helm was invoked, you could use `helm get values` to see the final set of values. Now, this is no longer possible, because the profile values are applied within the rendering process by the zzz_profile.yaml template and aren't stored anywhere.

This commit introduces a new ConfigMap with the name `values` for the default revision, and `values-<revision>` for all others. This ConfigMap will allow the operator (and users) to look up the actual values used to render the charts.