### PR TITLE
Deprecate defaultRevision value

### DIFF
--- a/api/v1/values_types.gen.go
+++ b/api/v1/values_types.gen.go
@@ -936,6 +936,8 @@ type Values struct {
 	IstiodRemote *IstiodRemoteConfig `json:"istiodRemote,omitempty"`
 
 	// The name of the default revision in the cluster.
+	// +hidefromdoc
+	// Deprecated: This field is ignored. The default revision is expected to be configurable elsewhere.
 	DefaultRevision *string `json:"defaultRevision,omitempty"`
 	// Specifies which installation configuration profile to apply.
 	Profile *string `json:"profile,omitempty"`

--- a/bundle/manifests/sailoperator.io_istiorevisions.yaml
+++ b/bundle/manifests/sailoperator.io_istiorevisions.yaml
@@ -103,7 +103,9 @@ spec:
                       be configured with the same defaults as the specified version.
                     type: string
                   defaultRevision:
-                    description: The name of the default revision in the cluster.
+                    description: |-
+                      The name of the default revision in the cluster.
+                      Deprecated: This field is ignored. The default revision is expected to be configurable elsewhere.
                     type: string
                   experimental:
                     description: Specifies experimental helm fields that could be

--- a/bundle/manifests/sailoperator.io_istios.yaml
+++ b/bundle/manifests/sailoperator.io_istios.yaml
@@ -176,7 +176,9 @@ spec:
                       be configured with the same defaults as the specified version.
                     type: string
                   defaultRevision:
-                    description: The name of the default revision in the cluster.
+                    description: |-
+                      The name of the default revision in the cluster.
+                      Deprecated: This field is ignored. The default revision is expected to be configurable elsewhere.
                     type: string
                   experimental:
                     description: Specifies experimental helm fields that could be

--- a/chart/crds/sailoperator.io_istiorevisions.yaml
+++ b/chart/crds/sailoperator.io_istiorevisions.yaml
@@ -103,7 +103,9 @@ spec:
                       be configured with the same defaults as the specified version.
                     type: string
                   defaultRevision:
-                    description: The name of the default revision in the cluster.
+                    description: |-
+                      The name of the default revision in the cluster.
+                      Deprecated: This field is ignored. The default revision is expected to be configurable elsewhere.
                     type: string
                   experimental:
                     description: Specifies experimental helm fields that could be

--- a/chart/crds/sailoperator.io_istios.yaml
+++ b/chart/crds/sailoperator.io_istios.yaml
@@ -176,7 +176,9 @@ spec:
                       be configured with the same defaults as the specified version.
                     type: string
                   defaultRevision:
-                    description: The name of the default revision in the cluster.
+                    description: |-
+                      The name of the default revision in the cluster.
+                      Deprecated: This field is ignored. The default revision is expected to be configurable elsewhere.
                     type: string
                   experimental:
                     description: Specifies experimental helm fields that could be

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -3117,7 +3117,6 @@ _Appears in:_
 | `meshConfig` _[MeshConfig](#meshconfig)_ | Defines runtime configuration of components, including Istiod and istio-agent behavior. See https://istio.io/docs/reference/config/istio.mesh.v1alpha1/ for all available options. TODO can this import the real mesh config API? |  |  |
 | `base` _[BaseConfig](#baseconfig)_ | Configuration for the base component. |  |  |
 | `istiodRemote` _[IstiodRemoteConfig](#istiodremoteconfig)_ | Configuration for istiod-remote. DEPRECATED - istiod-remote chart is removed and replaced with `istio-discovery --set values.istiodRemote.enabled=true`  Deprecated: Marked as deprecated in pkg/apis/values_types.proto. |  |  |
-| `defaultRevision` _string_ | The name of the default revision in the cluster. |  |  |
 | `profile` _string_ | Specifies which installation configuration profile to apply. |  |  |
 | `compatibilityVersion` _string_ | Specifies the compatibility version to use. When this is set, the control plane will be configured with the same defaults as the specified version. |  |  |
 | `experimental` _[RawMessage](#rawmessage)_ | Specifies experimental helm fields that could be removed or changed in the future |  | Schemaless: \{\}   |

--- a/hack/api_transformer/transform.yaml
+++ b/hack/api_transformer/transform.yaml
@@ -141,6 +141,9 @@ inputFiles:
       Values.Experimental:
       - "// +kubebuilder:pruning:PreserveUnknownFields"
       - "// +kubebuilder:validation:Schemaless"
+      Values.DefaultRevision:
+      - "// +hidefromdoc"
+      - "// Deprecated: This field is ignored. The default revision is expected to be configurable elsewhere."
 
 - module: istio.io/api
   path: /mesh/v1alpha1/config.pb.go


### PR DESCRIPTION
This field shouldn't have been  included in the IstioRevision.spec.values. It is a single global value that is not tied to any specific revision. The current plan is to make the default revision configurable elsewhere, possibly through a global singleton CRD called IstioBase.