### PR TITLE
Add missing ztunnel config params in ztunnel crd

### DIFF
--- a/api/v1/values_types_extra.go
+++ b/api/v1/values_types_extra.go
@@ -49,6 +49,9 @@ type ZTunnelConfig struct {
 	// Image name to pull from. Image will be `Hub/Image:Tag-Variant`.
 	// If Image contains a "/", it will replace the entire `image` in the pod.
 	Image *string `json:"image,omitempty"`
+	// resourceName, if set, will override the naming of resources. If not set, will default to the release name.
+	// It is recommended to not set this; this is primarily for backwards compatibility.
+	ResourceName *string `json:"resourceName,omitempty"`
 	// Annotations to apply to all top level resources
 	Annotations map[string]string `json:"Annotations,omitempty"`
 	// Labels to apply to all top level resources
@@ -82,6 +85,12 @@ type ZTunnelConfig struct {
 	// meshConfig defines runtime configuration of components.
 	// For ztunnel, only defaultConfig is used, but this is nested under `meshConfig` for consistency with other components.
 	MeshConfig *MeshConfig `json:"meshConfig,omitempty"`
+	// This value defines:
+	// 1. how many seconds kube waits for ztunnel pod to gracefully exit before forcibly terminating it (this value)
+	// 2. how many seconds ztunnel waits to drain its own connections (this value - 1 sec)
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=30
+	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 	// Configures the revision this control plane is a part of
 	Revision *string `json:"revision,omitempty"`
 	// The address of the CA for CSR.
@@ -91,6 +100,8 @@ type ZTunnelConfig struct {
 	// Specifies the default namespace for the Istio control plane components.
 	IstioNamespace *string `json:"istioNamespace,omitempty"`
 	// Configuration log level of ztunnel binary, default is info. Valid values are: trace, debug, info, warn, error.
+	// +kubebuilder:default=info
+	// +kubebuilder:validation:Enum=trace;debug;info;warn;error;
 	LogLevel *string `json:"logLevel,omitempty"`
 	// Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.
 	LogAsJSON *bool `json:"logAsJson,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -5307,6 +5307,11 @@ func (in *ZTunnelConfig) DeepCopyInto(out *ZTunnelConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ResourceName != nil {
+		in, out := &in.ResourceName, &out.ResourceName
+		*out = new(string)
+		**out = **in
+	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
 		*out = make(map[string]string, len(*in))
@@ -5380,6 +5385,11 @@ func (in *ZTunnelConfig) DeepCopyInto(out *ZTunnelConfig) {
 		in, out := &in.MeshConfig, &out.MeshConfig
 		*out = new(MeshConfig)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.TerminationGracePeriodSeconds != nil {
+		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
+		*out = new(int64)
+		**out = **in
 	}
 	if in.Revision != nil {
 		in, out := &in.Revision, &out.Revision

--- a/bundle/manifests/sailoperator.io_ztunnels.yaml
+++ b/bundle/manifests/sailoperator.io_ztunnels.yaml
@@ -276,8 +276,15 @@ spec:
                           each container.
                         type: boolean
                       logLevel:
+                        default: info
                         description: 'Configuration log level of ztunnel binary, default
                           is info. Valid values are: trace, debug, info, warn, error.'
+                        enum:
+                        - trace
+                        - debug
+                        - info
+                        - warn
+                        - error
                         type: string
                       meshConfig:
                         description: |-
@@ -3626,6 +3633,11 @@ spec:
                           type: string
                         description: Additional labels to apply on the pod level.
                         type: object
+                      resourceName:
+                        description: |-
+                          resourceName, if set, will override the naming of resources. If not set, will default to the release name.
+                          It is recommended to not set this; this is primarily for backwards compatibility.
+                        type: string
                       resources:
                         description: The k8s resource requests and limits for the
                           ztunnel Pods.
@@ -3694,6 +3706,15 @@ spec:
                         description: The container image tag to pull. Image will be
                           `Hub/Image:Tag-Variant`.
                         type: string
+                      terminationGracePeriodSeconds:
+                        default: 30
+                        description: |-
+                          This value defines:
+                          1. how many seconds kube waits for ztunnel pod to gracefully exit before forcibly terminating it (this value)
+                          2. how many seconds ztunnel waits to drain its own connections (this value - 1 sec)
+                        format: int64
+                        minimum: 0
+                        type: integer
                       variant:
                         description: The container image variant to pull. Options
                           are "debug" or "distroless". Unset will use the default

--- a/chart/crds/sailoperator.io_ztunnels.yaml
+++ b/chart/crds/sailoperator.io_ztunnels.yaml
@@ -276,8 +276,15 @@ spec:
                           each container.
                         type: boolean
                       logLevel:
+                        default: info
                         description: 'Configuration log level of ztunnel binary, default
                           is info. Valid values are: trace, debug, info, warn, error.'
+                        enum:
+                        - trace
+                        - debug
+                        - info
+                        - warn
+                        - error
                         type: string
                       meshConfig:
                         description: |-
@@ -3626,6 +3633,11 @@ spec:
                           type: string
                         description: Additional labels to apply on the pod level.
                         type: object
+                      resourceName:
+                        description: |-
+                          resourceName, if set, will override the naming of resources. If not set, will default to the release name.
+                          It is recommended to not set this; this is primarily for backwards compatibility.
+                        type: string
                       resources:
                         description: The k8s resource requests and limits for the
                           ztunnel Pods.
@@ -3694,6 +3706,15 @@ spec:
                         description: The container image tag to pull. Image will be
                           `Hub/Image:Tag-Variant`.
                         type: string
+                      terminationGracePeriodSeconds:
+                        default: 30
+                        description: |-
+                          This value defines:
+                          1. how many seconds kube waits for ztunnel pod to gracefully exit before forcibly terminating it (this value)
+                          2. how many seconds ztunnel waits to drain its own connections (this value - 1 sec)
+                        format: int64
+                        minimum: 0
+                        type: integer
                       variant:
                         description: The container image variant to pull. Options
                           are "debug" or "distroless". Unset will use the default

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -3166,6 +3166,7 @@ _Appears in:_
 | `tag` _string_ | The container image tag to pull. Image will be `Hub/Image:Tag-Variant`. |  |  |
 | `variant` _string_ | The container image variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version. |  |  |
 | `image` _string_ | Image name to pull from. Image will be `Hub/Image:Tag-Variant`. If Image contains a "/", it will replace the entire `image` in the pod. |  |  |
+| `resourceName` _string_ | resourceName, if set, will override the naming of resources. If not set, will default to the release name. It is recommended to not set this; this is primarily for backwards compatibility. |  |  |
 | `Annotations` _object (keys:string, values:string)_ | Annotations to apply to all top level resources |  |  |
 | `Labels` _object (keys:string, values:string)_ | Labels to apply to all top level resources |  |  |
 | `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#volumemount-v1-core) array_ | Additional volumeMounts to the ztunnel container |  |  |
@@ -3178,11 +3179,12 @@ _Appears in:_
 | `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#pullpolicy-v1-core)_ | Specifies the image pull policy for the Istio images. one of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated.  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  | Enum: [Always Never IfNotPresent]   |
 | `multiCluster` _[MultiClusterConfig](#multiclusterconfig)_ | Settings for multicluster. The name of the cluster we are installing in. Note this is a user-defined name, which must be consistent with Istiod configuration. |  |  |
 | `meshConfig` _[MeshConfig](#meshconfig)_ | meshConfig defines runtime configuration of components. For ztunnel, only defaultConfig is used, but this is nested under `meshConfig` for consistency with other components. |  |  |
+| `terminationGracePeriodSeconds` _integer_ | This value defines: 1. how many seconds kube waits for ztunnel pod to gracefully exit before forcibly terminating it (this value) 2. how many seconds ztunnel waits to drain its own connections (this value - 1 sec) | 30 | Minimum: 0   |
 | `revision` _string_ | Configures the revision this control plane is a part of |  |  |
 | `caAddress` _string_ | The address of the CA for CSR. |  |  |
 | `xdsAddress` _string_ | The customized XDS address to retrieve configuration. |  |  |
 | `istioNamespace` _string_ | Specifies the default namespace for the Istio control plane components. |  |  |
-| `logLevel` _string_ | Configuration log level of ztunnel binary, default is info. Valid values are: trace, debug, info, warn, error. |  |  |
+| `logLevel` _string_ | Configuration log level of ztunnel binary, default is info. Valid values are: trace, debug, info, warn, error. | info | Enum: [trace debug info warn error]   |
 | `logAsJson` _boolean_ | Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container. |  |  |
 
 


### PR DESCRIPTION
The ztunnel Helm chart was recently updated with some new parameters. While we explore ways to automate this process, this PR currently includes them in the ZTunnelConfig.

Related to: https://github.com/istio-ecosystem/sail-operator/issues/763
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
