### PR TITLE
Fix appVersion inconsistency in revisiontags chart

### DIFF
--- a/hack/download-charts.sh
+++ b/hack/download-charts.sh
@@ -131,7 +131,7 @@ function convertIstioProfiles() {
 function createRevisionTagChart() {
   mkdir -p "${CHARTS_DIR}/revisiontags/templates"
   echo "apiVersion: v2
-appVersion: ${ISTIO_VERSION}
+appVersion: ${ISTIO_VERSION#v}
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.21.6/charts/revisiontags/Chart.yaml
+++ b/resources/v1.21.6/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.21.6
+appVersion: 1.21.6
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.22.5/charts/revisiontags/Chart.yaml
+++ b/resources/v1.22.5/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.22.5
+appVersion: 1.22.5
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.22.6/charts/revisiontags/Chart.yaml
+++ b/resources/v1.22.6/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.22.6
+appVersion: 1.22.6
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.22.7/charts/revisiontags/Chart.yaml
+++ b/resources/v1.22.7/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.22.7
+appVersion: 1.22.7
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.22.8/charts/revisiontags/Chart.yaml
+++ b/resources/v1.22.8/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.22.8
+appVersion: 1.22.8
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.23.2/charts/revisiontags/Chart.yaml
+++ b/resources/v1.23.2/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.23.2
+appVersion: 1.23.2
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.23.3/charts/revisiontags/Chart.yaml
+++ b/resources/v1.23.3/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.23.3
+appVersion: 1.23.3
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.23.4/charts/revisiontags/Chart.yaml
+++ b/resources/v1.23.4/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.23.4
+appVersion: 1.23.4
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.23.5/charts/revisiontags/Chart.yaml
+++ b/resources/v1.23.5/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.23.5
+appVersion: 1.23.5
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.24.0/charts/revisiontags/Chart.yaml
+++ b/resources/v1.24.0/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.24.0
+appVersion: 1.24.0
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.24.1/charts/revisiontags/Chart.yaml
+++ b/resources/v1.24.1/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.24.1
+appVersion: 1.24.1
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.24.2/charts/revisiontags/Chart.yaml
+++ b/resources/v1.24.2/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.24.2
+appVersion: 1.24.2
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.24.3/charts/revisiontags/Chart.yaml
+++ b/resources/v1.24.3/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.24.3
+appVersion: 1.24.3
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.24.4/charts/revisiontags/Chart.yaml
+++ b/resources/v1.24.4/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.24.4
+appVersion: 1.24.4
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.25-alpha.c2ac935c/charts/revisiontags/Chart.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.25-alpha.c2ac935c
+appVersion: 1.25-alpha.c2ac935c
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.25.1/charts/revisiontags/Chart.yaml
+++ b/resources/v1.25.1/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.25.1
+appVersion: 1.25.1
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:


### PR DESCRIPTION
The revisiontags chart shows the appVersion as v1.25.1, whereas all other charts show it as 1.25.1.
```
$ helm ls
NAME                       	NAMESPACE   	... APP VERSION
default-revisiontags       	istio-system	... v1.25.1
myistio-v1-25-latest-istiod	istio-system	... 1.25.1
```

This change removes the v prefix.