### PR TITLE
Fix appVersion inconsistencies in revisiontags chart

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -391,7 +391,7 @@ gen-charts: ## Pull charts from istio repository.
 	@# use yq to generate a list of download-charts.sh commands for each version in versions.yaml; these commands are
 	@# passed to sh and executed; in a nutshell, the yq command generates commands like:
 	@# ./hack/download-charts.sh <version> <git repo> <commit> [chart1] [chart2] ...
-	@yq eval '.versions[] | "./hack/download-charts.sh " + .name + " " + .repo + " " + .commit + " " + ((.charts // []) | join(" "))' < $(VERSIONS_YAML_DIR)/$(VERSIONS_YAML_FILE) | sh
+	@yq eval '.versions[] | "./hack/download-charts.sh " + .name + " " + .version + " " + .repo + " " + .commit + " " + ((.charts // []) | join(" "))' < $(VERSIONS_YAML_DIR)/$(VERSIONS_YAML_FILE) | sh
 
 	@# remove old version directories
 	@hack/remove-old-versions.sh

--- a/hack/download-charts.sh
+++ b/hack/download-charts.sh
@@ -16,14 +16,15 @@
 
 set -e -u -o pipefail
 
-: "${ISTIO_VERSION:=$1}"
-: "${ISTIO_REPO:=$2}"
-: "${ISTIO_COMMIT:=$3}"
-CHART_URLS=("${@:4}")
+: "${ISTIO_VERSION_NAME:=$1}"
+: "${ISTIO_VERSION:=$2}"
+: "${ISTIO_REPO:=$3}"
+: "${ISTIO_COMMIT:=$4}"
+CHART_URLS=("${@:5}")
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$(dirname "${SCRIPT_DIR}")
-MANIFEST_DIR="${REPO_ROOT}/resources/${ISTIO_VERSION}"
+MANIFEST_DIR="${REPO_ROOT}/resources/${ISTIO_VERSION_NAME}"
 CHARTS_DIR="${MANIFEST_DIR}/charts"
 PROFILES_DIR="${MANIFEST_DIR}/profiles"
 

--- a/resources/v1.21.6/charts/revisiontags/Chart.yaml
+++ b/resources/v1.21.6/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.21.6
+appVersion: 1.21.6
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.22.5/charts/revisiontags/Chart.yaml
+++ b/resources/v1.22.5/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.22.5
+appVersion: 1.22.5
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.22.6/charts/revisiontags/Chart.yaml
+++ b/resources/v1.22.6/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.22.6
+appVersion: 1.22.6
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.22.7/charts/revisiontags/Chart.yaml
+++ b/resources/v1.22.7/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.22.7
+appVersion: 1.22.7
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.22.8/charts/revisiontags/Chart.yaml
+++ b/resources/v1.22.8/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.22.8
+appVersion: 1.22.8
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.23.2/charts/revisiontags/Chart.yaml
+++ b/resources/v1.23.2/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.23.2
+appVersion: 1.23.2
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.23.3/charts/revisiontags/Chart.yaml
+++ b/resources/v1.23.3/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.23.3
+appVersion: 1.23.3
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.23.4/charts/revisiontags/Chart.yaml
+++ b/resources/v1.23.4/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.23.4
+appVersion: 1.23.4
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.23.5/charts/revisiontags/Chart.yaml
+++ b/resources/v1.23.5/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.23.5
+appVersion: 1.23.5
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.24.0/charts/revisiontags/Chart.yaml
+++ b/resources/v1.24.0/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.24.0
+appVersion: 1.24.0
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.24.1/charts/revisiontags/Chart.yaml
+++ b/resources/v1.24.1/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.24.1
+appVersion: 1.24.1
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.24.2/charts/revisiontags/Chart.yaml
+++ b/resources/v1.24.2/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.24.2
+appVersion: 1.24.2
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.24.3/charts/revisiontags/Chart.yaml
+++ b/resources/v1.24.3/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.24.3
+appVersion: 1.24.3
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.24.4/charts/revisiontags/Chart.yaml
+++ b/resources/v1.24.4/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.24.4
+appVersion: 1.24.4
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.25-alpha.c2ac935c/charts/revisiontags/Chart.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.25-alpha.c2ac935c
+appVersion: 1.25-alpha.c2ac935c588899579e1cee38b205e4e6824a4638
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:

--- a/resources/v1.25.1/charts/revisiontags/Chart.yaml
+++ b/resources/v1.25.1/charts/revisiontags/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.25.1
+appVersion: 1.25.1
 description: Helm chart for istio revision tags
 name: revisiontags
 sources:


### PR DESCRIPTION
1. The revisiontags chart shows the appVersion as v1.25.1, whereas all other charts show it as 1.25.1.

```
$ helm ls
NAME                       	NAMESPACE   	... APP VERSION
default-revisiontags       	istio-system	... v1.25.1
myistio-v1-25-latest-istiod	istio-system	... 1.25.1
```

2. The `master` release only includes a partial commit hash, whereas all other charts include the full commit hash:

```
$ cat resources/v1.25-alpha.c2ac935c/charts/revisiontags/Chart.yaml | grep appVersion
appVersion: v1.25-alpha.c2ac935c

$ cat resources/v1.25-alpha.c2ac935c/charts/istiod/Chart.yaml | grep appVersion
appVersion: 1.25-alpha.c2ac935c588899579e1cee38b205e4e6824a4638
```

This change fixes both issues.