### PR TITLE
Remove the `install.operator.istio.io/owning-resource` label from all resources

### DIFF
--- a/hack/api_transformer/transform.yaml
+++ b/hack/api_transformer/transform.yaml
@@ -68,7 +68,7 @@ inputFiles:
     - Values.Cni                           # moved to IstioCNIValues
     - Values.IstioCni                      # deprecated; replaced with Pilot.CNI
     - Values.Gateways                      # operator doesn't support deployment of ingress/egress gateways
-    - Values.OwnerName                     # operator sets this internally
+    - Values.OwnerName                     # sail operator doesn't use this
     - Values.Ztunnel                       # moved to ZTunnelValues
     - Values.RevisionTags                  # Revision Tags are only supported through IstioRevisionTag CRD
     - SidecarInjectorConfig.ObjectSelector # appears to be unused

--- a/hack/download-charts.sh
+++ b/hack/download-charts.sh
@@ -97,6 +97,9 @@ function patchIstioCharts() {
 
   # remove CRDs from istiod-remote chart, since they are installed by OLM, not by the operator
   rm -f "${CHARTS_DIR}/istiod-remote/templates/crd-all.gen.yaml"
+
+  # remove install.operator.istio.io/owning-resource label from all charts
+  sed -i '/install.operator.istio.io\/owning-resource/d' "${CHARTS_DIR}"/*/templates/*.yaml
 }
 
 # The charts use docker.io as the default registry, but this leads to issues

--- a/resources/v1.21.6/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.21.6/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: ["security.openshift.io"] 
@@ -32,7 +31,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
   - apiGroups: [""]
@@ -64,7 +62,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]

--- a/resources/v1.21.6/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.21.6/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -25,7 +24,6 @@ metadata:
   labels:
     k8s-app: istio-cni-repair
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
 - kind: ServiceAccount
@@ -45,7 +43,6 @@ metadata:
   labels:
     k8s-app: istio-cni-repair
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
   - kind: ServiceAccount

--- a/resources/v1.21.6/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.21.6/charts/cni/templates/configmap-cni.yaml
@@ -12,7 +12,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 data:
   # The CNI network configuration to add to the plugin chain on each node.  The special

--- a/resources/v1.21.6/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.21.6/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: istio-cni-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 spec:
   selector:

--- a/resources/v1.21.6/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.21.6/charts/cni/templates/serviceaccount.yaml
@@ -13,5 +13,4 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"

--- a/resources/v1.21.6/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/autoscale.yaml
@@ -9,7 +9,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}
@@ -44,7 +43,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}

--- a/resources/v1.21.6/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/configmap-jwks.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 data:
   extra.pem: {{ .Values.pilot.jwksResolverExtraRootCA | quote }}

--- a/resources/v1.21.6/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.21.6/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -36,7 +35,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.21.6/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.21.6/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/mutatingwebhook.yaml
@@ -42,7 +42,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.21.6/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/poddisruptionbudget.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.21.6/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.21.6/charts/istiod/templates/service.yaml
+++ b/resources/v1.21.6/charts/istiod/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.21.6/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.21.6/charts/revisiontags/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.22.5/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.22.5/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: ["security.openshift.io"] 
@@ -32,7 +31,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
   - apiGroups: [""]
@@ -64,7 +62,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]

--- a/resources/v1.22.5/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.22.5/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -25,7 +24,6 @@ metadata:
   labels:
     k8s-app: istio-cni-repair
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
 - kind: ServiceAccount
@@ -45,7 +43,6 @@ metadata:
   labels:
     k8s-app: istio-cni-repair
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
   - kind: ServiceAccount

--- a/resources/v1.22.5/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.22.5/charts/cni/templates/configmap-cni.yaml
@@ -12,7 +12,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 data:
   # The CNI network configuration to add to the plugin chain on each node.  The special

--- a/resources/v1.22.5/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.22.5/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: istio-cni-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 spec:
   selector:

--- a/resources/v1.22.5/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.22.5/charts/cni/templates/serviceaccount.yaml
@@ -13,5 +13,4 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"

--- a/resources/v1.22.5/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/autoscale.yaml
@@ -8,7 +8,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}

--- a/resources/v1.22.5/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/configmap-jwks.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 data:
   extra.pem: {{ .Values.pilot.jwksResolverExtraRootCA | quote }}

--- a/resources/v1.22.5/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.22.5/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -36,7 +35,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.22.5/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.22.5/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.22.5/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/poddisruptionbudget.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.22.5/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.22.5/charts/istiod/templates/service.yaml
+++ b/resources/v1.22.5/charts/istiod/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.22.5/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.22.5/charts/revisiontags/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.22.5/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.22.5/charts/ztunnel/templates/rbac.yaml
@@ -24,7 +24,6 @@ metadata:
     app: ztunnel
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
 rules:
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
@@ -39,7 +38,6 @@ metadata:
     app: ztunnel
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/resources/v1.22.6/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.22.6/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: ["security.openshift.io"] 
@@ -32,7 +31,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
   - apiGroups: [""]
@@ -64,7 +62,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]

--- a/resources/v1.22.6/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.22.6/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -25,7 +24,6 @@ metadata:
   labels:
     k8s-app: istio-cni-repair
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
 - kind: ServiceAccount
@@ -45,7 +43,6 @@ metadata:
   labels:
     k8s-app: istio-cni-repair
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
   - kind: ServiceAccount

--- a/resources/v1.22.6/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.22.6/charts/cni/templates/configmap-cni.yaml
@@ -12,7 +12,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 data:
   # The CNI network configuration to add to the plugin chain on each node.  The special

--- a/resources/v1.22.6/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.22.6/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: istio-cni-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 spec:
   selector:

--- a/resources/v1.22.6/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.22.6/charts/cni/templates/serviceaccount.yaml
@@ -13,5 +13,4 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"

--- a/resources/v1.22.6/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/autoscale.yaml
@@ -8,7 +8,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}

--- a/resources/v1.22.6/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/configmap-jwks.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 data:
   extra.pem: {{ .Values.pilot.jwksResolverExtraRootCA | quote }}

--- a/resources/v1.22.6/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.22.6/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -36,7 +35,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.22.6/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.22.6/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.22.6/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/poddisruptionbudget.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.22.6/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.22.6/charts/istiod/templates/service.yaml
+++ b/resources/v1.22.6/charts/istiod/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.22.6/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.22.6/charts/revisiontags/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.22.6/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.22.6/charts/ztunnel/templates/rbac.yaml
@@ -24,7 +24,6 @@ metadata:
     app: ztunnel
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
 rules:
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
@@ -39,7 +38,6 @@ metadata:
     app: ztunnel
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/resources/v1.22.7/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.22.7/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: ["security.openshift.io"] 
@@ -32,7 +31,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
   - apiGroups: [""]
@@ -64,7 +62,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]

--- a/resources/v1.22.7/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.22.7/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -25,7 +24,6 @@ metadata:
   labels:
     k8s-app: istio-cni-repair
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
 - kind: ServiceAccount
@@ -45,7 +43,6 @@ metadata:
   labels:
     k8s-app: istio-cni-repair
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
   - kind: ServiceAccount

--- a/resources/v1.22.7/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.22.7/charts/cni/templates/configmap-cni.yaml
@@ -12,7 +12,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 data:
   # The CNI network configuration to add to the plugin chain on each node.  The special

--- a/resources/v1.22.7/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.22.7/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: istio-cni-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 spec:
   selector:

--- a/resources/v1.22.7/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.22.7/charts/cni/templates/serviceaccount.yaml
@@ -13,5 +13,4 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"

--- a/resources/v1.22.7/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/autoscale.yaml
@@ -8,7 +8,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}

--- a/resources/v1.22.7/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/configmap-jwks.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 data:
   extra.pem: {{ .Values.pilot.jwksResolverExtraRootCA | quote }}

--- a/resources/v1.22.7/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.22.7/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -36,7 +35,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.22.7/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.22.7/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.22.7/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/poddisruptionbudget.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.22.7/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.22.7/charts/istiod/templates/service.yaml
+++ b/resources/v1.22.7/charts/istiod/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.22.7/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.22.7/charts/revisiontags/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.22.7/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.22.7/charts/ztunnel/templates/rbac.yaml
@@ -24,7 +24,6 @@ metadata:
     app: ztunnel
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
 rules:
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
@@ -39,7 +38,6 @@ metadata:
     app: ztunnel
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/resources/v1.22.8/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.22.8/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: ["security.openshift.io"] 
@@ -32,7 +31,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
   - apiGroups: [""]
@@ -64,7 +62,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]

--- a/resources/v1.22.8/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.22.8/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -25,7 +24,6 @@ metadata:
   labels:
     k8s-app: istio-cni-repair
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
 - kind: ServiceAccount
@@ -45,7 +43,6 @@ metadata:
   labels:
     k8s-app: istio-cni-repair
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
   - kind: ServiceAccount

--- a/resources/v1.22.8/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.22.8/charts/cni/templates/configmap-cni.yaml
@@ -12,7 +12,6 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 data:
   # The CNI network configuration to add to the plugin chain on each node.  The special

--- a/resources/v1.22.8/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.22.8/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: istio-cni-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 spec:
   selector:

--- a/resources/v1.22.8/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.22.8/charts/cni/templates/serviceaccount.yaml
@@ -13,5 +13,4 @@ metadata:
     app: istio-cni
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"

--- a/resources/v1.22.8/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/autoscale.yaml
@@ -8,7 +8,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}

--- a/resources/v1.22.8/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/configmap-jwks.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 data:
   extra.pem: {{ .Values.pilot.jwksResolverExtraRootCA | quote }}

--- a/resources/v1.22.8/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.22.8/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -36,7 +35,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.22.8/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.22.8/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.22.8/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/poddisruptionbudget.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.22.8/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.22.8/charts/istiod/templates/service.yaml
+++ b/resources/v1.22.8/charts/istiod/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.22.8/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.22.8/charts/revisiontags/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.22.8/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.22.8/charts/ztunnel/templates/rbac.yaml
@@ -24,7 +24,6 @@ metadata:
     app: ztunnel
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
 rules:
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
@@ -39,7 +38,6 @@ metadata:
     app: ztunnel
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/resources/v1.23.2/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.23.2/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: ["security.openshift.io"] 
@@ -32,7 +31,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
   - apiGroups: [""]
@@ -64,7 +62,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]

--- a/resources/v1.23.2/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.23.2/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -26,7 +25,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
 - kind: ServiceAccount
@@ -47,7 +45,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
   - kind: ServiceAccount

--- a/resources/v1.23.2/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.23.2/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 data:
   CURRENT_AGENT_VERSION: {{ .Values.cni.tag | default .Values.global.tag | quote }}

--- a/resources/v1.23.2/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.23.2/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 spec:
   selector:

--- a/resources/v1.23.2/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.23.2/charts/cni/templates/serviceaccount.yaml
@@ -13,5 +13,4 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"

--- a/resources/v1.23.2/charts/istiod-remote/templates/configmap.yaml
+++ b/resources/v1.23.2/charts/istiod-remote/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.2/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.23.2/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.2/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/resources/v1.23.2/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.23.2/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/autoscale.yaml
@@ -8,7 +8,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}

--- a/resources/v1.23.2/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/configmap-jwks.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 data:
   extra.pem: {{ .Values.pilot.jwksResolverExtraRootCA | quote }}

--- a/resources/v1.23.2/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.2/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -36,7 +35,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.23.2/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.2/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.23.2/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/poddisruptionbudget.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.23.2/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.23.2/charts/istiod/templates/service.yaml
+++ b/resources/v1.23.2/charts/istiod/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.23.2/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.23.2/charts/revisiontags/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.23.2/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.23.2/charts/ztunnel/templates/rbac.yaml
@@ -28,7 +28,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
   annotations:
 {{- if .Values.revision }}
     {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
@@ -49,7 +48,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
   annotations:
 {{- if .Values.revision }}
     {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}

--- a/resources/v1.23.3/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.23.3/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: ["security.openshift.io"] 
@@ -32,7 +31,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
   - apiGroups: [""]
@@ -64,7 +62,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]

--- a/resources/v1.23.3/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.23.3/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -26,7 +25,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
 - kind: ServiceAccount
@@ -47,7 +45,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
   - kind: ServiceAccount

--- a/resources/v1.23.3/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.23.3/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 data:
   CURRENT_AGENT_VERSION: {{ .Values.cni.tag | default .Values.global.tag | quote }}

--- a/resources/v1.23.3/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.23.3/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 spec:
   selector:

--- a/resources/v1.23.3/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.23.3/charts/cni/templates/serviceaccount.yaml
@@ -13,5 +13,4 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"

--- a/resources/v1.23.3/charts/istiod-remote/templates/configmap.yaml
+++ b/resources/v1.23.3/charts/istiod-remote/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.3/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.23.3/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.3/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/resources/v1.23.3/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.23.3/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/autoscale.yaml
@@ -8,7 +8,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}

--- a/resources/v1.23.3/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/configmap-jwks.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 data:
   extra.pem: {{ .Values.pilot.jwksResolverExtraRootCA | quote }}

--- a/resources/v1.23.3/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.3/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -36,7 +35,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.23.3/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.3/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.23.3/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/poddisruptionbudget.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.23.3/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.23.3/charts/istiod/templates/service.yaml
+++ b/resources/v1.23.3/charts/istiod/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.23.3/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.23.3/charts/revisiontags/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.23.3/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.23.3/charts/ztunnel/templates/rbac.yaml
@@ -28,7 +28,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
   annotations:
 {{- if .Values.revision }}
     {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
@@ -49,7 +48,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
   annotations:
 {{- if .Values.revision }}
     {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}

--- a/resources/v1.23.4/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.23.4/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: ["security.openshift.io"] 
@@ -32,7 +31,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
   - apiGroups: [""]
@@ -64,7 +62,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]

--- a/resources/v1.23.4/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.23.4/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -26,7 +25,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
 - kind: ServiceAccount
@@ -47,7 +45,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
   - kind: ServiceAccount

--- a/resources/v1.23.4/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.23.4/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 data:
   CURRENT_AGENT_VERSION: {{ .Values.cni.tag | default .Values.global.tag | quote }}

--- a/resources/v1.23.4/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.23.4/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 spec:
   selector:

--- a/resources/v1.23.4/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.23.4/charts/cni/templates/serviceaccount.yaml
@@ -13,5 +13,4 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"

--- a/resources/v1.23.4/charts/istiod-remote/templates/configmap.yaml
+++ b/resources/v1.23.4/charts/istiod-remote/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.4/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.23.4/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.4/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/resources/v1.23.4/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.23.4/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/autoscale.yaml
@@ -8,7 +8,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}

--- a/resources/v1.23.4/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/configmap-jwks.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 data:
   extra.pem: {{ .Values.pilot.jwksResolverExtraRootCA | quote }}

--- a/resources/v1.23.4/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.4/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -36,7 +35,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.23.4/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.4/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.23.4/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/poddisruptionbudget.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.23.4/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.23.4/charts/istiod/templates/service.yaml
+++ b/resources/v1.23.4/charts/istiod/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.23.4/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.23.4/charts/revisiontags/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.23.4/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.23.4/charts/ztunnel/templates/rbac.yaml
@@ -28,7 +28,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
   annotations:
 {{- if .Values.revision }}
     {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
@@ -49,7 +48,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
   annotations:
 {{- if .Values.revision }}
     {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}

--- a/resources/v1.23.5/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.23.5/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: ["security.openshift.io"] 
@@ -32,7 +31,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
   - apiGroups: [""]
@@ -64,7 +62,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]

--- a/resources/v1.23.5/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.23.5/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -26,7 +25,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
 - kind: ServiceAccount
@@ -47,7 +45,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 subjects:
   - kind: ServiceAccount

--- a/resources/v1.23.5/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.23.5/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 data:
   CURRENT_AGENT_VERSION: {{ .Values.cni.tag | default .Values.global.tag | quote }}

--- a/resources/v1.23.5/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.23.5/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
 spec:
   selector:

--- a/resources/v1.23.5/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.23.5/charts/cni/templates/serviceaccount.yaml
@@ -13,5 +13,4 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"

--- a/resources/v1.23.5/charts/istiod-remote/templates/configmap.yaml
+++ b/resources/v1.23.5/charts/istiod-remote/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.5/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.23.5/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.5/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/resources/v1.23.5/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.23.5/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/autoscale.yaml
@@ -8,7 +8,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}

--- a/resources/v1.23.5/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/configmap-jwks.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 data:
   extra.pem: {{ .Values.pilot.jwksResolverExtraRootCA | quote }}

--- a/resources/v1.23.5/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/configmap.yaml
@@ -88,7 +88,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.5/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -36,7 +35,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.23.5/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
 data:

--- a/resources/v1.23.5/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/mutatingwebhook.yaml
@@ -46,7 +46,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.23.5/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/poddisruptionbudget.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.23.5/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.23.5/charts/istiod/templates/service.yaml
+++ b/resources/v1.23.5/charts/istiod/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.23.5/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.23.5/charts/revisiontags/templates/revision-tags.yaml
@@ -42,7 +42,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.23.5/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.23.5/charts/ztunnel/templates/rbac.yaml
@@ -28,7 +28,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
   annotations:
 {{- if .Values.revision }}
     {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
@@ -49,7 +48,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
   annotations:
 {{- if .Values.revision }}
     {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}

--- a/resources/v1.24.0/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.24.0/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -34,7 +33,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -68,7 +66,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.0/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.24.0/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -28,7 +27,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -51,7 +49,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.0/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.24.0/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.0/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.24.0/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.0/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.24.0/charts/cni/templates/serviceaccount.yaml
@@ -13,7 +13,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.0/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/autoscale.yaml
@@ -10,7 +10,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.0/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/configmap-jwks.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.0/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/configmap.yaml
@@ -84,7 +84,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.24.0/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -40,7 +39,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.24.0/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.24.0/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/mutatingwebhook.yaml
@@ -47,7 +47,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.24.0/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/poddisruptionbudget.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.24.0/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.24.0/charts/istiod/templates/service.yaml
+++ b/resources/v1.24.0/charts/istiod/templates/service.yaml
@@ -11,7 +11,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.24.0/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.24.0/charts/revisiontags/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.24.0/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.24.0/charts/ztunnel/templates/rbac.yaml
@@ -29,7 +29,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:
@@ -52,7 +51,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:

--- a/resources/v1.24.1/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.24.1/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -34,7 +33,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -68,7 +66,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.1/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.24.1/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -28,7 +27,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -51,7 +49,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.1/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.24.1/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.1/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.24.1/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.1/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.24.1/charts/cni/templates/serviceaccount.yaml
@@ -13,7 +13,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.1/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/autoscale.yaml
@@ -10,7 +10,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.1/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/configmap-jwks.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.1/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/configmap.yaml
@@ -84,7 +84,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.24.1/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -40,7 +39,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.24.1/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.24.1/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/mutatingwebhook.yaml
@@ -47,7 +47,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.24.1/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/poddisruptionbudget.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.24.1/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.24.1/charts/istiod/templates/service.yaml
+++ b/resources/v1.24.1/charts/istiod/templates/service.yaml
@@ -11,7 +11,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.24.1/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.24.1/charts/revisiontags/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.24.1/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.24.1/charts/ztunnel/templates/rbac.yaml
@@ -29,7 +29,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:
@@ -52,7 +51,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:

--- a/resources/v1.24.2/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.24.2/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -34,7 +33,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -68,7 +66,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.2/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.24.2/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -28,7 +27,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -51,7 +49,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.2/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.24.2/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.2/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.24.2/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.2/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.24.2/charts/cni/templates/serviceaccount.yaml
@@ -13,7 +13,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.2/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/autoscale.yaml
@@ -10,7 +10,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.2/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/configmap-jwks.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.2/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/configmap.yaml
@@ -84,7 +84,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.24.2/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -40,7 +39,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.24.2/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.24.2/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/mutatingwebhook.yaml
@@ -47,7 +47,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.24.2/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/poddisruptionbudget.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.24.2/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.24.2/charts/istiod/templates/service.yaml
+++ b/resources/v1.24.2/charts/istiod/templates/service.yaml
@@ -11,7 +11,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.24.2/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.24.2/charts/revisiontags/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.24.2/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.24.2/charts/ztunnel/templates/rbac.yaml
@@ -29,7 +29,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:
@@ -52,7 +51,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:

--- a/resources/v1.24.3/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.24.3/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -34,7 +33,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -68,7 +66,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.3/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.24.3/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -28,7 +27,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -51,7 +49,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.3/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.24.3/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.3/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.24.3/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.3/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.24.3/charts/cni/templates/serviceaccount.yaml
@@ -13,7 +13,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.3/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/autoscale.yaml
@@ -10,7 +10,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.3/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/configmap-jwks.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.3/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/configmap.yaml
@@ -84,7 +84,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.24.3/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -40,7 +39,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.24.3/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.24.3/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/mutatingwebhook.yaml
@@ -47,7 +47,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.24.3/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/poddisruptionbudget.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.24.3/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.24.3/charts/istiod/templates/service.yaml
+++ b/resources/v1.24.3/charts/istiod/templates/service.yaml
@@ -11,7 +11,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.24.3/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.24.3/charts/revisiontags/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.24.3/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.24.3/charts/ztunnel/templates/rbac.yaml
@@ -29,7 +29,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:
@@ -52,7 +51,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:

--- a/resources/v1.24.4/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.24.4/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -34,7 +33,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -68,7 +66,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.4/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.24.4/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -28,7 +27,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -51,7 +49,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.4/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.24.4/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.4/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.24.4/charts/cni/templates/daemonset.yaml
@@ -15,7 +15,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.4/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.24.4/charts/cni/templates/serviceaccount.yaml
@@ -13,7 +13,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.4/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/autoscale.yaml
@@ -10,7 +10,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.4/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/configmap-jwks.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.24.4/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/configmap.yaml
@@ -84,7 +84,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.24.4/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -40,7 +39,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.24.4/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.24.4/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/mutatingwebhook.yaml
@@ -47,7 +47,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.24.4/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/poddisruptionbudget.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.24.4/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.24.4/charts/istiod/templates/service.yaml
+++ b/resources/v1.24.4/charts/istiod/templates/service.yaml
@@ -11,7 +11,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.24.4/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.24.4/charts/revisiontags/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.24.4/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.24.4/charts/ztunnel/templates/rbac.yaml
@@ -29,7 +29,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:
@@ -52,7 +51,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:

--- a/resources/v1.25-alpha.c2ac935c/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -34,7 +33,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -68,7 +66,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25-alpha.c2ac935c/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -28,7 +27,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -51,7 +49,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25-alpha.c2ac935c/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25-alpha.c2ac935c/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/cni/templates/daemonset.yaml
@@ -18,7 +18,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25-alpha.c2ac935c/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/cni/templates/serviceaccount.yaml
@@ -13,7 +13,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/autoscale.yaml
@@ -10,7 +10,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/configmap-jwks.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/configmap.yaml
@@ -81,7 +81,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -40,7 +39,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/mutatingwebhook.yaml
@@ -47,7 +47,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/poddisruptionbudget.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/service.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/istiod/templates/service.yaml
@@ -11,7 +11,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.25-alpha.c2ac935c/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/revisiontags/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.25-alpha.c2ac935c/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.25-alpha.c2ac935c/charts/ztunnel/templates/rbac.yaml
@@ -29,7 +29,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ include "ztunnel.release-name" . }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:
@@ -52,7 +51,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ include "ztunnel.release-name" . }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:

--- a/resources/v1.25.1/charts/cni/templates/clusterrole.yaml
+++ b/resources/v1.25.1/charts/cni/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -34,7 +33,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -68,7 +66,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25.1/charts/cni/templates/clusterrolebinding.yaml
+++ b/resources/v1.25.1/charts/cni/templates/clusterrolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -28,7 +27,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
@@ -51,7 +49,6 @@ metadata:
     k8s-app: {{ template "name" . }}-repair
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25.1/charts/cni/templates/configmap-cni.yaml
+++ b/resources/v1.25.1/charts/cni/templates/configmap-cni.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25.1/charts/cni/templates/daemonset.yaml
+++ b/resources/v1.25.1/charts/cni/templates/daemonset.yaml
@@ -20,7 +20,6 @@ metadata:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25.1/charts/cni/templates/serviceaccount.yaml
+++ b/resources/v1.25.1/charts/cni/templates/serviceaccount.yaml
@@ -13,7 +13,6 @@ metadata:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25.1/charts/istiod/templates/autoscale.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/autoscale.yaml
@@ -10,7 +10,6 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25.1/charts/istiod/templates/configmap-jwks.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/configmap-jwks.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}

--- a/resources/v1.25.1/charts/istiod/templates/configmap.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/configmap.yaml
@@ -81,7 +81,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.25.1/charts/istiod/templates/deployment.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
@@ -40,7 +39,6 @@ spec:
       labels:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" | quote }}
-        install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}

--- a/resources/v1.25.1/charts/istiod/templates/istiod-injector-configmap.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/istiod-injector-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"

--- a/resources/v1.25.1/charts/istiod/templates/mutatingwebhook.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/mutatingwebhook.yaml
@@ -47,7 +47,6 @@ metadata:
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}

--- a/resources/v1.25.1/charts/istiod/templates/poddisruptionbudget.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/poddisruptionbudget.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot

--- a/resources/v1.25.1/charts/istiod/templates/revision-tags.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.25.1/charts/istiod/templates/service.yaml
+++ b/resources/v1.25.1/charts/istiod/templates/service.yaml
@@ -11,7 +11,6 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: istiod
     istio: pilot

--- a/resources/v1.25.1/charts/revisiontags/templates/revision-tags.yaml
+++ b/resources/v1.25.1/charts/revisiontags/templates/revision-tags.yaml
@@ -45,7 +45,6 @@ metadata:
   labels:
     istio.io/tag: {{ $tagName }}
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
-    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}

--- a/resources/v1.25.1/charts/ztunnel/templates/rbac.yaml
+++ b/resources/v1.25.1/charts/ztunnel/templates/rbac.yaml
@@ -29,7 +29,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ include "ztunnel.release-name" . }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:
@@ -52,7 +51,6 @@ metadata:
   labels:
     app: ztunnel
     release: {{ include "ztunnel.release-name" . }}
-    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
   annotations:


### PR DESCRIPTION
When charts are deployed via the Sail operator, this label is always set to `unknown`, so there's no point in including it in the resource labels. It's also specific to the upstream operator and is planned for removal (https://github.com/istio/istio/issues/52670).