### PR TITLE
Check if IstioRevisionTag references a remote IstioRevision

### DIFF
--- a/controllers/istiorevisiontag/istiorevisiontag_controller.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller.go
@@ -106,6 +106,10 @@ func (r *Reconciler) doReconcile(ctx context.Context, tag *v1.IstioRevisionTag) 
 		return nil, err
 	}
 
+	if revision.IsUsingRemoteControlPlane(rev) {
+		return nil, reconciler.NewValidationError("IstioRevisionTag cannot reference a remote IstioRevision")
+	}
+
 	log.Info("Installing Helm chart")
 	return rev, r.installHelmCharts(ctx, tag, rev)
 }


### PR DESCRIPTION
The istiorevisiontag controller doesn't render anything when the reference IstioRevision has the `istiodRemote.enabled` value set to `true`, leaving users confused why the MutatingWebhookConfiguration isn't there. Instead of quietly rendering nothing, the controller will now return a validation error, clearly signalling to the user what's wrong.