### PR TITLE
Add label managed-by: sail-operator to all resources the operator deploys

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -58,8 +58,11 @@ const (
 	// KubernetesAppPartOfValue is the KubernetesAppPartOfKey label value the operator sets on all objects it creates
 	KubernetesAppPartOfValue = "istio"
 
-	// KubernetesAppManagedByValue is the KubernetesAppManagedByKey label value the operator sets on all objects it creates
-	KubernetesAppManagedByValue = "sail-operator"
+	// ManagedByLabelKey is the key for the kubernetes resource label indicating the resource is managed by the Sail operator
+	ManagedByLabelKey = "managed-by"
+
+	// ManagedByLabelValue is the ManagedByKey label value the operator sets on all objects it creates
+	ManagedByLabelValue = "sail-operator"
 
 	// WebhookReadinessProbeStatusAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
 	// reports whether the remote control plane is ready or not

--- a/pkg/helm/chartmanager.go
+++ b/pkg/helm/chartmanager.go
@@ -110,7 +110,7 @@ func (h *ChartManager) UpgradeOrInstallChart(
 		log.V(2).Info("Performing helm upgrade", "chartName", chart.Name())
 
 		updateAction := action.NewUpgrade(cfg)
-		updateAction.PostRenderer = NewOwnerReferencePostRenderer(ownerReference, "")
+		updateAction.PostRenderer = NewHelmPostRenderer(ownerReference, "")
 		updateAction.MaxHistory = 1
 		updateAction.SkipCRDs = true
 
@@ -122,7 +122,7 @@ func (h *ChartManager) UpgradeOrInstallChart(
 		log.V(2).Info("Performing helm install", "chartName", chart.Name())
 
 		installAction := action.NewInstall(cfg)
-		installAction.PostRenderer = NewOwnerReferencePostRenderer(ownerReference, "")
+		installAction.PostRenderer = NewHelmPostRenderer(ownerReference, "")
 		installAction.Namespace = namespace
 		installAction.ReleaseName = releaseName
 		installAction.SkipCRDs = true

--- a/pkg/helm/postrenderer_test.go
+++ b/pkg/helm/postrenderer_test.go
@@ -22,8 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestOwnerReferencePostRenderer(t *testing.T) {
-	postRenderer := OwnerReferencePostRenderer{
+func TestHelmPostRenderer(t *testing.T) {
+	postRenderer := HelmPostRenderer{
 		ownerReference: metav1.OwnerReference{
 			APIVersion: "sailoperator.io/v1",
 			Kind:       "Istio",
@@ -50,6 +50,8 @@ kind: Service
 metadata:
   name: service-in-different-namespace
   namespace: other-namespace
+  labels:
+    foo: bar 
 spec:
   ports:
   - port: 80
@@ -58,6 +60,8 @@ spec:
 	expected := `apiVersion: v1
 kind: Deployment
 metadata:
+  labels:
+    managed-by: sail-operator
   name: deployment-in-same-namespace
   namespace: istio-system
   ownerReferences:
@@ -74,6 +78,9 @@ metadata:
   annotations:
     operator-sdk/primary-resource: istio-system/my-istio
     operator-sdk/primary-resource-type: Istio.sailoperator.io
+  labels:
+    foo: bar
+    managed-by: sail-operator
   name: service-in-different-namespace
   namespace: other-namespace
 spec:
@@ -87,6 +94,6 @@ spec:
 	}
 
 	if diff := cmp.Diff(expected, actual.String()); diff != "" {
-		t.Errorf("ownerReference wasn't added properly; diff (-expected, +actual):\n%v", diff)
+		t.Errorf("ownerReference or managed-by label wasn't added properly; diff (-expected, +actual):\n%v", diff)
 	}
 }


### PR DESCRIPTION
We introduce a new label instead of changing the value of the `app.kubernetes.io/managed-by` label, because Helm doesn't allow us to override it. We will be able to override the label only when the operator applies the rendered manifests by itself instead of letting Helm do it. Until then, we need to resort to this additional `managed-by` label.