### PR TITLE
Fix issue 805: update ZTunnel resource logLevel in values

### DIFF
--- a/api/v1/values_types_extra.go
+++ b/api/v1/values_types_extra.go
@@ -90,8 +90,8 @@ type ZTunnelConfig struct {
 	XdsAddress *string `json:"xdsAddress,omitempty"`
 	// Specifies the default namespace for the Istio control plane components.
 	IstioNamespace *string `json:"istioNamespace,omitempty"`
-	// Same as `global.logging.level`, but will override it if set
-	Logging *GlobalLoggingConfig `json:"logging,omitempty"`
+	// Configuration log level of ztunnel binary, default is info. Valid values are: trace, debug, info, warn, error.
+	LogLevel *string `json:"logLevel,omitempty"`
 	// Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.
 	LogAsJSON *bool `json:"logAsJson,omitempty"`
 }

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -5401,10 +5401,10 @@ func (in *ZTunnelConfig) DeepCopyInto(out *ZTunnelConfig) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.Logging != nil {
-		in, out := &in.Logging, &out.Logging
-		*out = new(GlobalLoggingConfig)
-		(*in).DeepCopyInto(*out)
+	if in.LogLevel != nil {
+		in, out := &in.LogLevel, &out.LogLevel
+		*out = new(string)
+		**out = **in
 	}
 	if in.LogAsJSON != nil {
 		in, out := &in.LogAsJSON, &out.LogAsJSON

--- a/bundle/manifests/sailoperator.io_ztunnels.yaml
+++ b/bundle/manifests/sailoperator.io_ztunnels.yaml
@@ -275,17 +275,10 @@ spec:
                           logs in json format by adding --log_as_json argument to
                           each container.
                         type: boolean
-                      logging:
-                        description: Same as `global.logging.level`, but will override
-                          it if set
-                        properties:
-                          level:
-                            description: |-
-                              Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
-                              The control plane has different scopes depending on component, but can configure default log level across all components
-                              If empty, default scope and level will be used as configured in code
-                            type: string
-                        type: object
+                      logLevel:
+                        description: 'Configuration log level of ztunnel binary, default
+                          is info. Valid values are: trace, debug, info, warn, error.'
+                        type: string
                       meshConfig:
                         description: |-
                           meshConfig defines runtime configuration of components.

--- a/chart/crds/sailoperator.io_ztunnels.yaml
+++ b/chart/crds/sailoperator.io_ztunnels.yaml
@@ -275,17 +275,10 @@ spec:
                           logs in json format by adding --log_as_json argument to
                           each container.
                         type: boolean
-                      logging:
-                        description: Same as `global.logging.level`, but will override
-                          it if set
-                        properties:
-                          level:
-                            description: |-
-                              Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
-                              The control plane has different scopes depending on component, but can configure default log level across all components
-                              If empty, default scope and level will be used as configured in code
-                            type: string
-                        type: object
+                      logLevel:
+                        description: 'Configuration log level of ztunnel binary, default
+                          is info. Valid values are: trace, debug, info, warn, error.'
+                        type: string
                       meshConfig:
                         description: |-
                           meshConfig defines runtime configuration of components.

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -453,7 +453,6 @@ _Appears in:_
 - [CNIConfig](#cniconfig)
 - [CNIGlobalConfig](#cniglobalconfig)
 - [GlobalConfig](#globalconfig)
-- [ZTunnelConfig](#ztunnelconfig)
 - [ZTunnelGlobalConfig](#ztunnelglobalconfig)
 
 | Field | Description | Default | Validation |
@@ -3183,7 +3182,7 @@ _Appears in:_
 | `caAddress` _string_ | The address of the CA for CSR. |  |  |
 | `xdsAddress` _string_ | The customized XDS address to retrieve configuration. |  |  |
 | `istioNamespace` _string_ | Specifies the default namespace for the Istio control plane components. |  |  |
-| `logging` _[GlobalLoggingConfig](#globalloggingconfig)_ | Same as `global.logging.level`, but will override it if set |  |  |
+| `logLevel` _string_ | Configuration log level of ztunnel binary, default is info. Valid values are: trace, debug, info, warn, error. |  |  |
 | `logAsJson` _boolean_ | Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container. |  |  |
 
 


### PR DESCRIPTION

- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

This PR is fixing https://github.com/istio-ecosystem/sail-operator/issues/805
Currently, the ZTunnel CR values cannot configure its daemonet logging level correctly. This PR fixes the wrong config field.

How to test this change:
- Deploy this PR sail operator image
- Create a ZTunnel CR with the following spec

```
spec:
  values:
    ztunnel:
      logLevel: debug
```

- Check the ztunnel Daemonset pod logs , it should show the environment variable `RUST_LOG` value is `debug` 
