### PR TITLE
Add KEEP_ON_FAILURE flag to e2e kind tests

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -90,6 +90,11 @@ DOCKER_BUILD_FLAGS ?= "--platform=$(TARGET_OS)/$(TARGET_ARCH)"
 GOTEST_FLAGS := $(if $(VERBOSE),-v) $(if $(COVERAGE),-coverprofile=$(REPO_ROOT)/out/coverage-unit.out)
 GINKGO_FLAGS ?= $(if $(VERBOSE),-v) $(if $(CI),--no-color) $(if $(COVERAGE),-coverprofile=coverage-integration.out -coverpkg=./... --output-dir=out)
 
+# Fail fast when keeping the environment on failure, to make sure we don't contaminate it with other resources.
+ifeq ($(KEEP_ON_FAILURE),true)
+GINKGO_FLAGS += --fail-fast
+endif
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -234,6 +234,7 @@ The following environment variables define the behavior of the test run:
 * CONTROL_PLANE_NS=istio-system - The namespace where the control plane will be deployed.
 * DEPLOYMENT_NAME=sail-operator - The name of the operator deployment.
 * EXPECTED_REGISTRY=`^docker\.io|^gcr\.io` - Which image registry should the operand images come from. Useful for downstream tests.
+* KEEP_ON_FAILURE - If set to true, when using a local KIND cluster, don't clean it up when the test fails. This allows to debug the failure.
 
 ### Customizing the test run
 

--- a/tests/e2e/ambient/ambient_suite_test.go
+++ b/tests/e2e/ambient/ambient_suite_test.go
@@ -41,6 +41,7 @@ var (
 	skipDeploy            = env.GetBool("SKIP_DEPLOY", false)
 	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
+	keepOnFailure         = env.GetBool("KEEP_ON_FAILURE", false)
 
 	k kubectl.Kubectl
 )

--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -277,6 +277,10 @@ spec:
 					})
 
 					AfterAll(func(ctx SpecContext) {
+						if CurrentSpecReport().Failed() && keepOnFailure {
+							return
+						}
+
 						By("Deleting the pods")
 						Expect(k.DeleteNamespace(common.HttpbinNamespace, common.SleepNamespace)).
 							To(Succeed(), "Failed to delete namespaces")
@@ -334,6 +338,9 @@ spec:
 			if CurrentSpecReport().Failed() {
 				common.LogDebugInfo(common.Ambient, k)
 				debugInfoLogged = true
+				if keepOnFailure {
+					return
+				}
 			}
 
 			By("Cleaning up the Istio namespace")
@@ -348,9 +355,15 @@ spec:
 	})
 
 	AfterAll(func() {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.Ambient, k)
-			debugInfoLogged = true
+		if CurrentSpecReport().Failed() {
+			if !debugInfoLogged {
+				common.LogDebugInfo(common.Ambient, k)
+				debugInfoLogged = true
+			}
+
+			if keepOnFailure {
+				return
+			}
 		}
 
 		if skipDeploy {

--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -46,6 +46,7 @@ var (
 	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io")
 	sampleNamespace       = env.Get("SAMPLE_NAMESPACE", "sample")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
+	keepOnFailure         = env.GetBool("KEEP_ON_FAILURE", false)
 	ipFamily              = env.Get("IP_FAMILY", "ipv4")
 
 	k kubectl.Kubectl

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -240,6 +240,10 @@ spec:
 					})
 
 					AfterAll(func(ctx SpecContext) {
+						if CurrentSpecReport().Failed() && keepOnFailure {
+							return
+						}
+
 						By("Deleting sample")
 						Expect(k.DeleteNamespace(sampleNamespace)).To(Succeed(), "sample namespace failed to be deleted")
 						Success("sample deleted")
@@ -281,6 +285,9 @@ spec:
 			if CurrentSpecReport().Failed() {
 				common.LogDebugInfo(common.ControlPlane, k)
 				debugInfoLogged = true
+				if keepOnFailure {
+					return
+				}
 			}
 
 			By("Cleaning up the Istio namespace")
@@ -294,9 +301,15 @@ spec:
 	})
 
 	AfterAll(func() {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.ControlPlane, k)
-			debugInfoLogged = true
+		if CurrentSpecReport().Failed() {
+			if !debugInfoLogged {
+				common.LogDebugInfo(common.ControlPlane, k)
+				debugInfoLogged = true
+			}
+
+			if keepOnFailure {
+				return
+			}
 		}
 	})
 })

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -304,6 +304,9 @@ spec:
 				if CurrentSpecReport().Failed() {
 					common.LogDebugInfo(common.ControlPlane, k)
 					debugInfoLogged = true
+					if keepOnFailure {
+						return
+					}
 				}
 
 				By("Cleaning up sample namespace")
@@ -324,9 +327,15 @@ spec:
 		})
 
 		AfterAll(func() {
-			if CurrentSpecReport().Failed() && !debugInfoLogged {
-				common.LogDebugInfo(common.ControlPlane, k)
-				debugInfoLogged = true
+			if CurrentSpecReport().Failed() {
+				if !debugInfoLogged {
+					common.LogDebugInfo(common.ControlPlane, k)
+					debugInfoLogged = true
+
+					if keepOnFailure {
+						return
+					}
+				}
 			}
 		})
 	})

--- a/tests/e2e/dualstack/dualstack_suite_test.go
+++ b/tests/e2e/dualstack/dualstack_suite_test.go
@@ -40,6 +40,7 @@ var (
 	skipDeploy            = env.GetBool("SKIP_DEPLOY", false)
 	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
+	keepOnFailure         = env.GetBool("KEEP_ON_FAILURE", false)
 	ipFamily              = env.Get("IP_FAMILY", "ipv4")
 
 	k kubectl.Kubectl

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -230,6 +230,10 @@ spec:
 					})
 
 					AfterAll(func(ctx SpecContext) {
+						if CurrentSpecReport().Failed() && keepOnFailure {
+							return
+						}
+
 						By("Deleting the pods")
 						Expect(k.DeleteNamespace(DualStackNamespace, IPv4Namespace, IPv6Namespace, SleepNamespace)).
 							To(Succeed(), "Failed to delete namespaces")
@@ -272,6 +276,9 @@ spec:
 			if CurrentSpecReport().Failed() {
 				common.LogDebugInfo(common.DualStack, k)
 				debugInfoLogged = true
+				if keepOnFailure {
+					return
+				}
 			}
 
 			By("Cleaning up the Istio namespace")
@@ -285,9 +292,15 @@ spec:
 	})
 
 	AfterAll(func() {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.DualStack, k)
-			debugInfoLogged = true
+		if CurrentSpecReport().Failed() {
+			if !debugInfoLogged {
+				common.LogDebugInfo(common.DualStack, k)
+				debugInfoLogged = true
+			}
+
+			if keepOnFailure {
+				return
+			}
 		}
 
 		if skipDeploy {

--- a/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
+++ b/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
@@ -471,6 +471,9 @@ spec:
 					if CurrentSpecReport().Failed() {
 						common.LogDebugInfo(common.MultiCluster, k1, k2)
 						debugInfoLogged = true
+						if keepOnFailure {
+							return
+						}
 					}
 
 					// Delete namespaces to ensure clean up for new tests iteration
@@ -496,9 +499,15 @@ spec:
 	})
 
 	AfterAll(func(ctx SpecContext) {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.MultiCluster, k1, k2)
-			debugInfoLogged = true
+		if CurrentSpecReport().Failed() {
+			if !debugInfoLogged {
+				common.LogDebugInfo(common.MultiCluster, k1, k2)
+				debugInfoLogged = true
+			}
+
+			if keepOnFailure {
+				return
+			}
 		}
 
 		// Delete the Sail Operator from both clusters

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -337,6 +337,9 @@ spec:
 					if CurrentSpecReport().Failed() {
 						common.LogDebugInfo(common.MultiCluster, k1, k2)
 						debugInfoLogged = true
+						if keepOnFailure {
+							return
+						}
 					}
 
 					// Delete namespaces to ensure clean up for new tests iteration
@@ -362,9 +365,15 @@ spec:
 	})
 
 	AfterAll(func(ctx SpecContext) {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.MultiCluster, k1, k2)
-			debugInfoLogged = true
+		if CurrentSpecReport().Failed() {
+			if !debugInfoLogged {
+				common.LogDebugInfo(common.MultiCluster, k1, k2)
+				debugInfoLogged = true
+			}
+
+			if keepOnFailure {
+				return
+			}
 		}
 
 		// Delete the Sail Operator from both clusters

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -369,6 +369,9 @@ spec:
 					if CurrentSpecReport().Failed() {
 						common.LogDebugInfo(common.MultiCluster, k1, k2)
 						debugInfoLogged = true
+						if keepOnFailure {
+							return
+						}
 					}
 
 					// Delete namespaces to ensure clean up for new tests iteration
@@ -400,9 +403,15 @@ spec:
 	})
 
 	AfterAll(func(ctx SpecContext) {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.MultiCluster, k1, k2)
-			debugInfoLogged = true
+		if CurrentSpecReport().Failed() {
+			if !debugInfoLogged {
+				common.LogDebugInfo(common.MultiCluster, k1, k2)
+				debugInfoLogged = true
+			}
+
+			if keepOnFailure {
+				return
+			}
 		}
 
 		// Delete the Sail Operator from both clusters

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -45,6 +45,7 @@ var (
 	image                         = env.Get("IMAGE", "quay.io/maistra-dev/sail-operator:latest")
 	skipDeploy                    = env.GetBool("SKIP_DEPLOY", false)
 	multicluster                  = env.GetBool("MULTICLUSTER", false)
+	keepOnFailure                 = env.GetBool("KEEP_ON_FAILURE", false)
 	kubeconfig                    = env.Get("KUBECONFIG", "")
 	kubeconfig2                   = env.Get("KUBECONFIG2", "")
 	artifacts                     = env.Get("ARTIFACTS", "/tmp/artifacts")

--- a/tests/e2e/multicontrolplane/multi_control_plane_suite_test.go
+++ b/tests/e2e/multicontrolplane/multi_control_plane_suite_test.go
@@ -47,6 +47,7 @@ var (
 	appNamespace2a         = env.Get("APP_NAMESPACE2A", "app2a")
 	appNamespace2b         = env.Get("APP_NAMESPACE2B", "app2b")
 	multicluster           = env.GetBool("MULTICLUSTER", false)
+	keepOnFailure          = env.GetBool("KEEP_ON_FAILURE", false)
 	ipFamily               = env.Get("IP_FAMILY", "ipv4")
 
 	k kubectl.Kubectl

--- a/tests/e2e/multicontrolplane/multi_control_plane_test.go
+++ b/tests/e2e/multicontrolplane/multi_control_plane_test.go
@@ -170,6 +170,10 @@ spec:
 	})
 
 	AfterAll(func() {
+		if CurrentSpecReport().Failed() && keepOnFailure {
+			return
+		}
+
 		By("Cleaning up the application namespaces")
 		Expect(k.DeleteNamespace(appNamespace1, appNamespace2a, appNamespace2b)).To(Succeed())
 
@@ -188,9 +192,15 @@ spec:
 	})
 
 	AfterAll(func() {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.MultiControlPlane, k)
-			debugInfoLogged = true
+		if CurrentSpecReport().Failed() {
+			if !debugInfoLogged {
+				common.LogDebugInfo(common.MultiControlPlane, k)
+				debugInfoLogged = true
+			}
+
+			if keepOnFailure {
+				return
+			}
 		}
 
 		if skipDeploy {

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -186,6 +186,10 @@ spec:
 		})
 
 		AfterAll(func() {
+			if CurrentSpecReport().Failed() && keepOnFailure {
+				return
+			}
+
 			Expect(k.DeleteNamespace(curlNamespace)).To(Succeed(), "failed to delete curl namespace")
 			exec.Command("kubectl", "delete", "--ignore-not-found", "clusterrolebinding", "metrics-reader-rolebinding").Run()
 
@@ -198,6 +202,9 @@ spec:
 	AfterAll(func() {
 		if CurrentSpecReport().Failed() {
 			common.LogDebugInfo(common.Operator, k)
+			if keepOnFailure {
+				return
+			}
 		}
 
 		if skipDeploy {

--- a/tests/e2e/operator/operator_suite_test.go
+++ b/tests/e2e/operator/operator_suite_test.go
@@ -35,6 +35,7 @@ var (
 	deploymentName     = env.Get("DEPLOYMENT_NAME", "sail-operator")
 	serviceAccountName = deploymentName
 	multicluster       = env.GetBool("MULTICLUSTER", false)
+	keepOnFailure      = env.GetBool("KEEP_ON_FAILURE", false)
 	curlNamespace      = "curl-metrics"
 
 	k kubectl.Kubectl


### PR DESCRIPTION
Using this flag allows debugging the failed test on the environment, instead of destroying it.
The default behavior is still to clean up the cluster when failing.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [x] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #675 

Related Issue/PR #

#### Additional information:
