### PR TITLE
Add the possibility to attach custom specs to Istio and IstioCNI resources while running e2e test

### DIFF
--- a/tests/e2e/ambient/ambient_suite_test.go
+++ b/tests/e2e/ambient/ambient_suite_test.go
@@ -17,6 +17,7 @@
 package ambient
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/env"
@@ -41,8 +42,12 @@ var (
 	skipDeploy            = env.GetBool("SKIP_DEPLOY", false)
 	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
+	customIstioSpecs      = env.Get("CUSTOM_ISTIO_SPECS", "{}")
+	customIstioCNISpecs   = env.Get("CUSTOM_ISTIO_CNI_SPECS", "{}")
 
-	k kubectl.Kubectl
+	parsedCustomIstioSpecs    map[string]interface{}
+	parsedCustomIstioCNISpecs map[string]interface{}
+	k                         kubectl.Kubectl
 )
 
 func TestAmbient(t *testing.T) {
@@ -63,4 +68,12 @@ func setup() {
 	Expect(err).NotTo(HaveOccurred())
 
 	k = kubectl.New()
+
+	GinkgoWriter.Println("Parsing custom specs")
+	err := json.Unmarshal([]byte(customIstioSpecs), &parsedCustomIstioSpecs)
+	Expect(err).NotTo(HaveOccurred(), "Failed to parse custom Istio specs")
+	err = json.Unmarshal([]byte(customIstioCNISpecs), &parsedCustomIstioCNISpecs)
+	Expect(err).NotTo(HaveOccurred(), "Failed to parse custom Istio CNI specs")
+	GinkgoWriter.Println("Parsed custom Istio specs:", parsedCustomIstioSpecs)
+	GinkgoWriter.Println("Parsed custom Istio CNI specs:", parsedCustomIstioCNISpecs)
 }

--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -90,6 +90,8 @@ spec:
   version: %s
   namespace: %s`
 						cniYAML = fmt.Sprintf(cniYAML, version.Name, istioCniNamespace)
+						cniYAML, err = common.MergeSpecs(cniYAML, parsedCustomIstioCNISpecs)
+						Expect(err).NotTo(HaveOccurred(), "Failed to parse custom Istio CNI specs")
 						Log("IstioCNI YAML:", cniYAML)
 						Expect(k.CreateFromString(cniYAML)).To(Succeed(), "IstioCNI creation failed")
 						Success("IstioCNI created")
@@ -136,6 +138,8 @@ spec:
   version: %s
   namespace: %s`
 						istioYAML = fmt.Sprintf(istioYAML, version.Name, controlPlaneNamespace)
+						istioYAML, err = common.MergeSpecs(istioYAML, parsedCustomIstioSpecs)
+						Expect(err).NotTo(HaveOccurred(), "Failed to parse custom Istio specs")
 						Log("Istio YAML:", istioYAML)
 						Expect(k.CreateFromString(istioYAML)).
 							To(Succeed(), "Istio CR failed to be created")

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -123,6 +123,8 @@ initialize_variables() {
   OPERATOR_SDK=${LOCALBIN}/operator-sdk
   IP_FAMILY=${IP_FAMILY:-ipv4}
   ISTIO_MANIFEST="chart/samples/istio-sample.yaml"
+  CUSTOM_ISTIO_SPECS="${CUSTOM_ISTIO_SPECS:-"{}"}"
+  CUSTOM_ISTIO_CNI_SPECS="${CUSTOM_ISTIO_CNI_SPECS:-"{}"}"
 
   # export to be sure that the variables are available in the subshell
   export IMAGE_BASE="${IMAGE_BASE:-sail-operator}"
@@ -190,7 +192,7 @@ if [ "${OCP}" == "true" ]; then
   HUB="image-registry.openshift-image-registry.svc:5000/sail-operator"
 fi
 
-export SKIP_DEPLOY IP_FAMILY ISTIO_MANIFEST NAMESPACE CONTROL_PLANE_NS DEPLOYMENT_NAME MULTICLUSTER ARTIFACTS ISTIO_NAME COMMAND KUBECONFIG ISTIOCTL_PATH
+export SKIP_DEPLOY IP_FAMILY ISTIO_MANIFEST NAMESPACE CONTROL_PLANE_NS DEPLOYMENT_NAME MULTICLUSTER ARTIFACTS ISTIO_NAME COMMAND KUBECONFIG ISTIOCTL_PATH CUSTOM_ISTIO_SPECS CUSTOM_ISTIO_CNI_SPECS
 
 # shellcheck disable=SC2086
 IMAGE="${HUB}/${IMAGE_BASE}:${TAG}" \

--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -17,6 +17,7 @@
 package controlplane
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/env"
@@ -47,8 +48,12 @@ var (
 	sampleNamespace       = env.Get("SAMPLE_NAMESPACE", "sample")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 	ipFamily              = env.Get("IP_FAMILY", "ipv4")
+	customIstioSpecs      = env.Get("CUSTOM_ISTIO_SPECS", "{}")
+	customIstioCNISpecs   = env.Get("CUSTOM_ISTIO_CNI_SPECS", "{}")
 
-	k kubectl.Kubectl
+	parsedCustomIstioSpecs    map[string]interface{}
+	parsedCustomIstioCNISpecs map[string]interface{}
+	k                         kubectl.Kubectl
 )
 
 func TestControlPlane(t *testing.T) {
@@ -68,6 +73,15 @@ func setup() {
 	Expect(err).NotTo(HaveOccurred())
 
 	k = kubectl.New()
+
+	GinkgoWriter.Println("Parsing custom specs")
+	err := json.Unmarshal([]byte(customIstioSpecs), &parsedCustomIstioSpecs)
+	Expect(err).NotTo(HaveOccurred(), "Failed to parse custom Istio specs")
+	err = json.Unmarshal([]byte(customIstioCNISpecs), &parsedCustomIstioCNISpecs)
+	Expect(err).NotTo(HaveOccurred(), "Failed to parse custom Istio CNI specs")
+	GinkgoWriter.Println("Parsed custom Istio specs:", parsedCustomIstioSpecs)
+	GinkgoWriter.Println("Parsed custom Istio CNI specs:", parsedCustomIstioCNISpecs)
+
 }
 
 var _ = BeforeSuite(func(ctx SpecContext) {

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -114,6 +114,8 @@ spec:
   version: %s
   namespace: %s`
 						yaml = fmt.Sprintf(yaml, version.Name, istioCniNamespace)
+						yaml, err = common.MergeSpecs(yaml, parsedCustomIstioCNISpecs)
+						Expect(err).NotTo(HaveOccurred(), "Error merging IstioCNI specs")
 						Log("IstioCNI YAML:", indent(yaml))
 						Expect(k.CreateFromString(yaml)).To(Succeed(), "IstioCNI creation failed")
 						Success("IstioCNI created")
@@ -164,6 +166,8 @@ spec:
   version: %s
   namespace: %s`
 						istioYAML = fmt.Sprintf(istioYAML, version.Name, controlPlaneNamespace)
+						istioYAML, err = common.MergeSpecs(istioYAML, parsedCustomIstioSpecs)
+						Expect(err).NotTo(HaveOccurred(), "Error merging Istio specs")
 						Log("Istio YAML:", indent(istioYAML))
 						Expect(k.CreateFromString(istioYAML)).
 							To(Succeed(), "Istio CR failed to be created")

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -63,6 +63,8 @@ spec:
   version: %s
   namespace: %s`
 				yaml = fmt.Sprintf(yaml, istioversion.Base, istioCniNamespace)
+				yaml, err = common.MergeSpecs(yaml, parsedCustomIstioCNISpecs)
+				Expect(err).NotTo(HaveOccurred(), "Error merging IstioCNI specs")
 				Log("IstioCNI YAML:", indent(yaml))
 				Expect(k.CreateFromString(yaml)).To(Succeed(), "IstioCNI creation failed")
 				Success("IstioCNI created")
@@ -86,6 +88,8 @@ spec:
     type: RevisionBased
     inactiveRevisionDeletionGracePeriodSeconds: 30`
 					istioYAML = fmt.Sprintf(istioYAML, istioversion.Base, controlPlaneNamespace)
+					istioYAML, err = common.MergeSpecs(istioYAML, parsedCustomIstioSpecs)
+					Expect(err).NotTo(HaveOccurred(), "Error merging Istio specs")
 					Log("Istio YAML:", indent(istioYAML))
 					Expect(k.CreateFromString(istioYAML)).
 						To(Succeed(), "Istio CR failed to be created")

--- a/tests/e2e/multicontrolplane/multi_control_plane_suite_test.go
+++ b/tests/e2e/multicontrolplane/multi_control_plane_suite_test.go
@@ -17,6 +17,7 @@
 package controlplane
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/env"
@@ -48,8 +49,12 @@ var (
 	appNamespace2b         = env.Get("APP_NAMESPACE2B", "app2b")
 	multicluster           = env.GetBool("MULTICLUSTER", false)
 	ipFamily               = env.Get("IP_FAMILY", "ipv4")
+	customIstioSpecs       = env.Get("CUSTOM_ISTIO_SPECS", "{}")
+	customIstioCNISpecs    = env.Get("CUSTOM_ISTIO_CNI_SPECS", "{}")
 
-	k kubectl.Kubectl
+	parsedCustomIstioSpecs    map[string]interface{}
+	parsedCustomIstioCNISpecs map[string]interface{}
+	k                         kubectl.Kubectl
 )
 
 func TestMultiControlPlane(t *testing.T) {
@@ -69,4 +74,12 @@ func setup() {
 	Expect(err).NotTo(HaveOccurred())
 
 	k = kubectl.New()
+
+	GinkgoWriter.Println("Parsing custom specs")
+	err := json.Unmarshal([]byte(customIstioSpecs), &parsedCustomIstioSpecs)
+	Expect(err).NotTo(HaveOccurred(), "Failed to parse custom Istio specs")
+	err = json.Unmarshal([]byte(customIstioCNISpecs), &parsedCustomIstioCNISpecs)
+	Expect(err).NotTo(HaveOccurred(), "Failed to parse custom Istio CNI specs")
+	GinkgoWriter.Println("Parsed custom Istio specs:", parsedCustomIstioSpecs)
+	GinkgoWriter.Println("Parsed custom Istio CNI specs:", parsedCustomIstioCNISpecs)
 }


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
This will allow the user to execute the e2e testing framework against their custom cluster configuration, helping them to attach or override custom configuration for the Istio and IstioCNI resources used in the smoke test. Example of use:
```
GINKGO_FLAGS="-v --label-filter=smoke" CUSTOM_ISTIO_CNI_SPECS="{\"spec.values.cni. cniConfDir\": custom/bin/dir/path}" make test.kind.e2e"
```
This will run the e2e smoke test against their existing cluster, adding a custom cni configuration directory to the spec in the IstioCNI resource

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #838

#### Additional information:
