### PR TITLE
Fix issue 851: wrong behaviour in ApplyVendorDefaults

### DIFF
--- a/pkg/istiovalues/vendor_defaults.go
+++ b/pkg/istiovalues/vendor_defaults.go
@@ -45,6 +45,6 @@ func ApplyVendorDefaults(version string, values *v1.Values) (*v1.Values, error) 
 	if len(vendorDefaults) == 0 {
 		return values, nil
 	}
-	mergedValues := helm.Values(mergeOverwrite(helm.FromValues(values), vendorDefaults[version]))
+	mergedValues := helm.Values(mergeOverwrite(vendorDefaults[version], helm.FromValues(values)))
 	return helm.ToValues(mergedValues, &v1.Values{})
 }

--- a/pkg/istiovalues/vendor_defaults_test.go
+++ b/pkg/istiovalues/vendor_defaults_test.go
@@ -24,6 +24,7 @@ import (
 
 func TestApplyVendorDefaults(t *testing.T) {
 	testcases := []struct {
+		name           string
 		vendorDefaults string
 		version        string
 		preValues      *v1.Values
@@ -31,6 +32,7 @@ func TestApplyVendorDefaults(t *testing.T) {
 		err            error
 	}{
 		{
+			name: "no user values",
 			vendorDefaults: `
 v1.24.2:
   pilot:
@@ -46,6 +48,32 @@ v1.24.2:
 					},
 				},
 			},
+			err: nil,
+		},
+		{
+			name: "user values override vendor defaults",
+			vendorDefaults: `
+v1.24.2:
+  pilot:
+    env:
+      someEnvVar: "true"
+`,
+			version: "v1.24.2",
+			preValues: &v1.Values{
+				Pilot: &v1.PilotConfig{
+					Env: map[string]string{
+						"someEnvVar": "false",
+					},
+				},
+			},
+			postValues: &v1.Values{
+				Pilot: &v1.PilotConfig{
+					Env: map[string]string{
+						"someEnvVar": "false", // user value overrides vendor default
+					},
+				},
+			},
+			err: nil,
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
In `ApplyVendorDefaults`, the expected behaviour is to take default vendor values and override them with user-given values. To achieve this in the `mergeOverwrite` call, we need to invert the position of the parameters: the base is the default vendor values, and the override is the user-given values

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #851

Related Issue/PR #

#### Additional information:
