### PR TITLE
Updates release and nightly-images GH workflows to work with new FBC …

### DIFF
--- a/.github/workflows/nightly-images.yaml
+++ b/.github/workflows/nightly-images.yaml
@@ -3,7 +3,6 @@ name: Nightly image build workflow
 on:
   schedule:
     - cron: "0 3 * * *" # everyday at 3AM UTC - main branch
-    - cron: "0 2 * * *" # everyday at 2AM UTC - release-1.0 branch
 
 run-name: nightly-images
 
@@ -27,11 +26,6 @@ jobs:
       if: github.event.schedule == '0 3 * * *'
       with:
         ref: main
-
-    - uses: actions/checkout@v4
-      if: github.event.schedule == '0 2 * * *'
-      with:
-        ref: release-1.0
 
     - name: Build and push nightly operator image
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,13 +3,6 @@ name: Release workflow
 on:
   workflow_dispatch:
     inputs:
-      release_version:
-        description: "Release version"
-        required: true
-      bundle_channels:
-        description: "Bundle channels"
-        required: true
-        default: dev-1.27
       is_draft_release:
         description: "Draft release"
         type: boolean
@@ -26,7 +19,6 @@ run-name: Release ${{ inputs.release_version }}
 env:
   GIT_USER: ${{ secrets.GIT_USER }}
   GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
-  VERSION: ${{ inputs.release_version }}
 
 jobs:
   release:
@@ -44,22 +36,17 @@ jobs:
 
     - name: Build and push operator image
       run: |
-        make docker-buildx \
-          -e TAG=$VERSION
+        make docker-buildx
 
     - name: Generate bundle metadata
       run: |
-        make bundle \
-         -e CHANNELS=$CHANNELS
-      env:
-        CHANNELS: ${{ inputs.bundle_channels }}
+        make bundle
 
     - name: Publish bundle in operatorhub.io
       run: |
         make bundle-publish \
           -e GIT_CONFIG_USER_NAME="$GIT_CONFIG_USER_NAME" \
           -e GIT_CONFIG_USER_EMAIL="$GIT_CONFIG_USER_EMAIL" \
-          -e OPERATOR_VERSION=$VERSION \
           -e OPERATOR_HUB=community-operators \
           -e OWNER=k8s-operatorhub \
           -e FORK=maistra
@@ -72,7 +59,6 @@ jobs:
         make bundle-publish \
           -e GIT_CONFIG_USER_NAME="$GIT_CONFIG_USER_NAME" \
           -e GIT_CONFIG_USER_EMAIL="$GIT_CONFIG_USER_EMAIL" \
-          -e OPERATOR_VERSION=$VERSION \
           -e OWNER=redhat-openshift-ecosystem \
           -e FORK=maistra
       env:

--- a/hack/operatorhub/publish-bundle.sh
+++ b/hack/operatorhub/publish-bundle.sh
@@ -29,6 +29,8 @@ GIT_CONFIG_USER_EMAIL="${GIT_CONFIG_USER_EMAIL:-}"
 # The OPERATOR_NAME is defined in Makefile
 : "${OPERATOR_NAME:?"Missing OPERATOR_NAME variable"}"
 : "${OPERATOR_VERSION:?"Missing OPERATOR_VERSION variable"}"
+: "${CHANNELS:?"Missing CHANNELS variable"}"
+: "${PREVIOUS_VERSION:?"Missing PREVIOUS_VERSION variable"}"
 
 show_help() {
   echo "publish-bundle - raises PR to Operator Hub"
@@ -98,6 +100,37 @@ OPERATORS_DIR="operators/${OPERATOR_NAME}/${OPERATOR_VERSION}/"
 BUNDLE_DIR="${CUR_DIR}"/../../bundle
 mkdir -p "${OPERATORS_DIR}"
 cp -a "${BUNDLE_DIR}"/. "${OPERATORS_DIR}"
+
+# Generate release-config.yaml which is required to update FBC. FBC is only available in community-operators-prod atm
+if [ "${OPERATOR_HUB}" = "community-operators-prod" ]
+then
+  # when publishing a nightly build, we want to get previous build version automatically
+  if [[ ${OPERATOR_VERSION} == *"nightly"* ]]
+  then
+    # expecting there is only one channel in $CHANNELS when pushing nightly builds
+    LATEST_VERSION=$(yq '.entries[] | select(.schema == "olm.channel" and .name == '\""${CHANNELS}"\"').entries[-1].name' "${OPERATORS_DIR}../catalog-templates/basic.yaml")
+    # there is no entry in the given channel, probably a new channel and first version to be pushed there. Let's use previous nightly channel.
+    if [ -z "${LATEST_VERSION}" ]
+    then
+      PREVIOUS_MINOR=$(echo "${PREVIOUS_VERSION}" | cut -f1,2 -d'.')
+      LATEST_VERSION=$(yq '.entries[] | select(.schema == "olm.channel" and .name == '\""${PREVIOUS_MINOR}-nightly"\"').entries[-1].name' "${OPERATORS_DIR}../catalog-templates/basic.yaml")
+      if [ -z "${LATEST_VERSION}" ]
+      then
+        echo "Unable to find previous nightly version. Exiting."
+        exit 1
+      fi
+    fi
+  else
+    LATEST_VERSION="${OPERATOR_NAME}.v${PREVIOUS_VERSION}"
+  fi
+  cat <<EOF > "${OPERATORS_DIR}/release-config.yaml"
+catalog_templates:
+  - template_name: basic.yaml
+    channels: [${CHANNELS}]
+    replaces: ${LATEST_VERSION}
+    skipRange: '>=1.0.0 <${OPERATOR_VERSION}'
+EOF
+fi
 
 if ! git config --global user.name; then
   skipInDryRun git config --global user.name "${GIT_CONFIG_USER_NAME}"


### PR DESCRIPTION
…used in community-operators-prod

Adds new PREVIOUS_VERSION variable to the Makefile - see the comment for details

Also:
- Disables nightly releases for 1.0 version
- Removes redundant parameters from release GH workflow and github-workflow make target
- Removes extra white spaces in the nightly version string
- Use VERSION as a default value for the bundle-publish make target

This will have to be cherry-picked to release-1.26

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes https://github.com/istio-ecosystem/sail-operator/issues/527
Fixes https://github.com/istio-ecosystem/sail-operator/issues/331

