### PR TITLE
Simplify logic when using `KEEP_ON_FAILURE`

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -90,9 +90,10 @@ DOCKER_BUILD_FLAGS ?= "--platform=$(TARGET_OS)/$(TARGET_ARCH)"
 GOTEST_FLAGS := $(if $(VERBOSE),-v) $(if $(COVERAGE),-coverprofile=$(REPO_ROOT)/out/coverage-unit.out)
 GINKGO_FLAGS ?= $(if $(VERBOSE),-v) $(if $(CI),--no-color) $(if $(COVERAGE),-coverprofile=coverage-integration.out -coverpkg=./... --output-dir=out)
 
-# Fail fast when keeping the environment on failure, to make sure we don't contaminate it with other resources.
+# Fail fast when keeping the environment on failure, to make sure we don't contaminate it with other resources. Also make sure to skip cleanup so it won't be deleted.
 ifeq ($(KEEP_ON_FAILURE),true)
 GINKGO_FLAGS += --fail-fast
+SKIP_CLEANUP = true
 endif
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/tests/e2e/integ-suite-kind.sh
+++ b/tests/e2e/integ-suite-kind.sh
@@ -24,7 +24,6 @@ export MULTICLUSTER="${MULTICLUSTER:-false}"
 export IP_FAMILY="${IP_FAMILY:-ipv4}"
 export ISTIOCTL="${ISTIOCTL:-${ROOT}/bin/istioctl}"
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-operator-integration-tests}"
-export KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-}"
 
 function check_prerequisites() {
   if ! command -v "${ISTIOCTL}" &> /dev/null; then
@@ -42,22 +41,6 @@ function run_integration_tests() {
   fi
 }
 
-function keep_on_failure() {
-  if [ $? -eq 0 ]; then
-    original_trap="${original_trap#*\'}"
-    eval "${original_trap%\'*}"
-    exit 0
-  fi
-
-  KUBECONFIG="${ARTIFACTS}/config"
-  if [ "${MULTICLUSTER}" == "true" ]; then
-    printf -v KUBECONFIG '%s:' "${KUBECONFIGS[@]}"
-  fi
-
-  echo "The kind cluster has been kept due to a test failure."
-  echo "To access it use \`export KUBECONFIG=${KUBECONFIG%:}\`"
-}
-
 check_prerequisites
 
 source "${ROOT}/tests/e2e/setup/setup-kind.sh"
@@ -66,10 +49,5 @@ source "${ROOT}/tests/e2e/setup/setup-kind.sh"
 export HUB="${KIND_REGISTRY}"
 # Workaround make inside make: ovewrite this variable so it is not recomputed in Makefile.core.mk
 export IMAGE="${HUB}/${IMAGE_BASE:-sail-operator}:${TAG:-latest}"
-
-if [ "${KEEP_ON_FAILURE}" == "true" ]; then
-  original_trap="$(trap -p EXIT)"
-  trap keep_on_failure EXIT
-fi
 
 run_integration_tests


### PR DESCRIPTION
When using `KEEP_ON_FAILURE=true` also set `SKIP_CLEANUP=true`. This keeps the cluster running after the tests, without a need to defined our own trap logic.

The downside is that the cluster will keep running even if the tests passed, but seeing as using the `KEEP_ON_FAILURE` flag is excpected mainly when there are failures, it seems that it's resonable to do.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [x] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #832 

#### Additional information:
