### PR TITLE
Make a yaml linter in the community-operators-prod happy

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -665,7 +665,7 @@ bundle-publish: ## Create a PR for publishing in OperatorHub.
 	export GITHUB_TOKEN=$(GITHUB_TOKEN); \
 	export OPERATOR_VERSION=$(VERSION); \
 	export OPERATOR_NAME=$(OPERATOR_NAME); \
-	export CHANNELS=$(CHANNELS); \
+	export CHANNELS="$(CHANNELS)"; \
 	export PREVIOUS_VERSION=$(PREVIOUS_VERSION); \
 	./hack/operatorhub/publish-bundle.sh
 

--- a/hack/operatorhub/publish-bundle.sh
+++ b/hack/operatorhub/publish-bundle.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC2001
 
 # Copyright Istio Authors
 #
@@ -123,10 +123,12 @@ then
   else
     LATEST_VERSION="${OPERATOR_NAME}.v${PREVIOUS_VERSION}"
   fi
+  # yaml linter in community-operators-prod CI is expecting a space after a comma
+  CHANNELS_SANITIZED=$(echo "${CHANNELS}" | sed 's/, */, /g')
   cat <<EOF > "${OPERATORS_DIR}/release-config.yaml"
 catalog_templates:
   - template_name: basic.yaml
-    channels: [${CHANNELS}]
+    channels: [${CHANNELS_SANITIZED}]
     replaces: ${LATEST_VERSION}
     skipRange: '>=1.0.0 <${OPERATOR_VERSION}'
 EOF


### PR DESCRIPTION
Yaml linter in community-operators-prod CI is expecting a space after a comma in release-config.yaml
