### PR TITLE
Force push to operator hub fork

### DIFF
--- a/hack/operatorhub/publish-bundle.sh
+++ b/hack/operatorhub/publish-bundle.sh
@@ -145,7 +145,7 @@ fi
 TITLE="operator ${OPERATOR_NAME} (${OPERATOR_VERSION})"
 skipInDryRun git add .
 skipInDryRun git commit -s -m"${TITLE}"
-skipInDryRun git push fork "${BRANCH}"
+skipInDryRun git push -f fork "${BRANCH}"
 
 PAYLOAD="${TMP_DIR}/PAYLOAD"
 


### PR DESCRIPTION
In case the branch already exists from previous failed runs, we need to force push there.
