### PR TITLE
Improve e2e test cleanup by recording & cleaning up

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -170,6 +170,28 @@ var _ = Describe("Operator", func() {
 * Use `Success` helper to print Success message in the test output.
 * Use `kubectl` and `helm` utils to make all the necessary operations in the test that are going to be done by a user. This means that the test should simulate the user behavior when using the operator.
 * Use `client` to interact with the Kubernetes API. This is useful when you need to interact with the Kubernetes API directly and not through `kubectl`. This needs to be used to make all the assertions if is possible. We use the client to make the assertions over `kubectl` because it is more reliable and faster, it will not need any complex parsing of the output.
+* Use `cleaner` to clean up any resources your tests create after they finish. The cleaner records a "snapshot" of the cluster, and removes any resources that weren't recorded. The best way to use it is by adding call in `BeforeAll` and `AfterAll` blocks. For example:
+```go
+import "github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
+
+var _ = Describe("Testing with cleanup", Ordered, func() {
+    clr := cleaner.New(cl)
+
+    BeforeAll(func(ctx SpecContext) {
+        clr.Record(ctx)
+        // Any additional set up goes here
+    })
+
+    // Tests go here
+
+    AfterAll(func(ctx SpecContext) {
+        // Any finalizing logic goes here
+        clr.Cleanup(ctx)
+    })
+})
+```
+    * You can use multiple cleaners, each with its own state. This is useful if the test does some global set up, e.g. sets up the operator, and then specific tests create further resources which you want cleaned.
+    * To clean resources without waiting, and waiting for them later, use `CleanupNoWait` followed by `WaitForDeletion`. This is particularly useful when working with more than one cluster.
 
 ## Running the test
 The end-to-end test can be run in two different environments: OCP (OpenShift Container Platform) and KinD (Kubernetes in Docker).

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	. "github.com/onsi/ginkgo/v2"
@@ -98,7 +99,9 @@ metadata:
 	Describe("given Istio version", func() {
 		for _, version := range istioversion.GetLatestPatchVersions() {
 			Context(version.Name, func() {
-				BeforeAll(func() {
+				clr := cleaner.New(cl)
+				BeforeAll(func(ctx SpecContext) {
+					clr.Record(ctx)
 					Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
 					Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
 				})
@@ -202,7 +205,7 @@ spec:
 				})
 
 				When("sample pod is deployed", func() {
-					BeforeAll(func() {
+					BeforeAll(func(ctx SpecContext) {
 						Expect(k.CreateNamespace(sampleNamespace)).To(Succeed(), "Sample namespace failed to be created")
 						Expect(k.Label("namespace", sampleNamespace, "istio-injection", "enabled")).To(Succeed(), "Error labeling sample namespace")
 						Expect(k.WithNamespace(sampleNamespace).
@@ -238,16 +241,6 @@ spec:
 						}
 						Success("Istio sidecar version matches the expected Istio version")
 					})
-
-					AfterAll(func(ctx SpecContext) {
-						if CurrentSpecReport().Failed() && keepOnFailure {
-							return
-						}
-
-						By("Deleting sample")
-						Expect(k.DeleteNamespace(sampleNamespace)).To(Succeed(), "sample namespace failed to be deleted")
-						Success("sample deleted")
-					})
 				})
 
 				When("the Istio CR is deleted", func() {
@@ -278,6 +271,14 @@ spec:
 						Success("CNI namespace is empty")
 					})
 				})
+
+				AfterAll(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() && keepOnFailure {
+						return
+					}
+
+					clr.Cleanup(ctx)
+				})
 			})
 		}
 
@@ -285,18 +286,7 @@ spec:
 			if CurrentSpecReport().Failed() {
 				common.LogDebugInfo(common.ControlPlane, k)
 				debugInfoLogged = true
-				if keepOnFailure {
-					return
-				}
 			}
-
-			By("Cleaning up the Istio namespace")
-			Expect(k.DeleteNamespace(controlPlaneNamespace)).To(Succeed(), "Istio Namespace failed to be deleted")
-
-			By("Cleaning up the IstioCNI namespace")
-			Expect(k.DeleteNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI Namespace failed to be deleted")
-
-			Success("Cleanup done")
 		})
 	})
 
@@ -305,10 +295,6 @@ spec:
 			if !debugInfoLogged {
 				common.LogDebugInfo(common.ControlPlane, k)
 				debugInfoLogged = true
-			}
-
-			if keepOnFailure {
-				return
 			}
 		}
 	})

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	. "github.com/onsi/ginkgo/v2"
@@ -46,11 +47,14 @@ var _ = Describe("Control Plane updates", Label("control-plane", "slow"), Ordere
 		}
 
 		Context(istioversion.Base, func() {
+			clr := cleaner.New(cl)
+
 			BeforeAll(func(ctx SpecContext) {
 				if len(istioversion.List) < 2 {
 					Skip("Skipping update tests because there are not enough versions in versions.yaml")
 				}
 
+				clr.Record(ctx)
 				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
 				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
 
@@ -309,20 +313,12 @@ spec:
 					}
 				}
 
-				By("Cleaning up sample namespace")
-				Expect(k.DeleteNamespace(sampleNamespace)).To(Succeed(), "Sample Namespace failed to be deleted")
-
-				By("Cleaning up the Istio namespace")
+				clr.Cleanup(ctx)
 				Expect(k.Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
-				Expect(k.DeleteNamespace(controlPlaneNamespace)).To(Succeed(), "Istio Namespace failed to be deleted")
-
-				By("Cleaning up the IstioCNI namespace")
 				Expect(k.Delete("istiocni", istioCniName)).To(Succeed(), "IstioCNI CR failed to be deleted")
-				Expect(k.DeleteNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI Namespace failed to be deleted")
 
 				By("Deleting the IstioRevisionTag")
 				Expect(k.Delete("istiorevisiontag", "default")).To(Succeed(), "IstioRevisionTag failed to be deleted")
-				Success("Cleanup done")
 			})
 		})
 

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -314,11 +314,6 @@ spec:
 				}
 
 				clr.Cleanup(ctx)
-				Expect(k.Delete("istio", istioName)).To(Succeed(), "Istio CR failed to be deleted")
-				Expect(k.Delete("istiocni", istioCniName)).To(Succeed(), "IstioCNI CR failed to be deleted")
-
-				By("Deleting the IstioRevisionTag")
-				Expect(k.Delete("istiorevisiontag", "default")).To(Succeed(), "IstioRevisionTag failed to be deleted")
 			})
 		})
 

--- a/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
+++ b/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
 	"github.com/istio-ecosystem/sail-operator/pkg/version"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/helm"
@@ -49,6 +50,8 @@ var _ = Describe("Multicluster deployment models", Label("multicluster", "multic
 	SetDefaultEventuallyTimeout(180 * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false
+	clr1 := cleaner.New(clPrimary, "cluster=primary")
+	clr2 := cleaner.New(clRemote, "cluster=remote")
 
 	BeforeAll(func(ctx SpecContext) {
 		if !skipDeploy {
@@ -71,6 +74,9 @@ var _ = Describe("Multicluster deployment models", Label("multicluster", "multic
 				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
 			Success("Operator is deployed in the Cluster #2 namespace and Running")
 		}
+
+		clr1.Record(ctx)
+		clr2.Record(ctx)
 	})
 
 	Describe("External Control Plane Multi-Network configuration", func() {
@@ -476,23 +482,10 @@ spec:
 						}
 					}
 
-					// Delete namespaces to ensure clean up for new tests iteration
-					Expect(k1.DeleteNamespaceNoWait(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-					Expect(k1.DeleteNamespaceNoWait(externalControlPlaneNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-					Expect(k1.DeleteNamespaceNoWait(istioCniNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-					Expect(k2.DeleteNamespaceNoWait(externalControlPlaneNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #2")
-					Expect(k2.DeleteNamespaceNoWait(sampleNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #2")
-					Expect(k2.DeleteNamespaceNoWait(istioCniNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #2")
-
-					Expect(k1.WaitNamespaceDeleted(controlPlaneNamespace)).To(Succeed())
-					Expect(k1.WaitNamespaceDeleted(externalControlPlaneNamespace)).To(Succeed())
-					Expect(k2.WaitNamespaceDeleted(externalControlPlaneNamespace)).To(Succeed())
-					Expect(k1.WaitNamespaceDeleted(istioCniNamespace)).To(Succeed())
-					Expect(k2.WaitNamespaceDeleted(istioCniNamespace)).To(Succeed())
-					Success("ControlPlane Namespaces are empty")
-
-					Expect(k2.WaitNamespaceDeleted(sampleNamespace)).To(Succeed())
-					Success("Sample app is deleted in Cluster #2")
+					c1Deleted := clr1.CleanupNoWait(ctx)
+					c2Deleted := clr2.CleanupNoWait(ctx)
+					clr1.WaitForDeletion(ctx, c1Deleted)
+					clr2.WaitForDeletion(ctx, c2Deleted)
 				})
 			})
 		}

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/certs"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/helm"
@@ -44,6 +45,8 @@ var _ = Describe("Multicluster deployment models", Label("multicluster", "multic
 	SetDefaultEventuallyTimeout(180 * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false
+	clr1 := cleaner.New(clPrimary, "cluster=primary")
+	clr2 := cleaner.New(clRemote, "cluster=remote")
 
 	BeforeAll(func(ctx SpecContext) {
 		if !skipDeploy {
@@ -67,6 +70,9 @@ var _ = Describe("Multicluster deployment models", Label("multicluster", "multic
 				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
 			Success("Operator is deployed in the Cluster #2 namespace and Running")
 		}
+
+		clr1.Record(ctx)
+		clr2.Record(ctx)
 	})
 
 	Describe("Multi-Primary Multi-Network configuration", func() {
@@ -342,23 +348,10 @@ spec:
 						}
 					}
 
-					// Delete namespaces to ensure clean up for new tests iteration
-					Expect(k1.DeleteNamespaceNoWait(istioCniNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-					Expect(k2.DeleteNamespaceNoWait(istioCniNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #2")
-					Expect(k1.DeleteNamespaceNoWait(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-					Expect(k2.DeleteNamespaceNoWait(controlPlaneNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #2")
-					Expect(k1.DeleteNamespaceNoWait(sampleNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #1")
-					Expect(k2.DeleteNamespaceNoWait(sampleNamespace)).To(Succeed(), "Namespace failed to be deleted on Cluster #2")
-
-					Expect(k1.WaitNamespaceDeleted(istioCniNamespace)).To(Succeed())
-					Expect(k2.WaitNamespaceDeleted(istioCniNamespace)).To(Succeed())
-					Expect(k1.WaitNamespaceDeleted(controlPlaneNamespace)).To(Succeed())
-					Expect(k2.WaitNamespaceDeleted(controlPlaneNamespace)).To(Succeed())
-					Success("ControlPlane and CNI Namespaces are empty")
-
-					Expect(k1.WaitNamespaceDeleted(sampleNamespace)).To(Succeed())
-					Expect(k2.WaitNamespaceDeleted(sampleNamespace)).To(Succeed())
-					Success("Sample app is deleted in both clusters")
+					c1Deleted := clr1.CleanupNoWait(ctx)
+					c2Deleted := clr2.CleanupNoWait(ctx)
+					clr1.WaitForDeletion(ctx, c1Deleted)
+					clr2.WaitForDeletion(ctx, c2Deleted)
 				})
 			})
 		}

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -384,12 +384,6 @@ spec:
 					c2Deleted := clr2.CleanupNoWait(ctx)
 					clr1.WaitForDeletion(ctx, c1Deleted)
 					clr2.WaitForDeletion(ctx, c2Deleted)
-
-					// Delete the resources created by istioctl create-remote-secret
-					Expect(k2.Delete("ClusterRoleBinding", "istiod-clusterrole-istio-system")).To(Succeed())
-					Expect(k2.Delete("ClusterRole", "istiod-clusterrole-istio-system")).To(Succeed())
-					Expect(k2.Delete("ClusterRoleBinding", "istiod-gateway-controller-istio-system")).To(Succeed())
-					Expect(k2.Delete("ClusterRole", "istiod-gateway-controller-istio-system")).To(Succeed())
 				})
 			})
 		}

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -47,6 +47,9 @@ var _ = Describe("Multicluster deployment models", Label("multicluster", "multic
 	clr2 := cleaner.New(clRemote, "cluster=remote")
 
 	BeforeAll(func(ctx SpecContext) {
+		clr1.Record(ctx)
+		clr2.Record(ctx)
+
 		if !skipDeploy {
 			// Deploy the Sail Operator on both clusters
 			Expect(k1.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Primary Cluster")
@@ -68,9 +71,6 @@ var _ = Describe("Multicluster deployment models", Label("multicluster", "multic
 				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
 			Success("Operator is deployed in the Remote namespace and Running")
 		}
-
-		clr1.Record(ctx)
-		clr2.Record(ctx)
 	})
 
 	Describe("Primary-Remote - Multi-Network configuration", func() {
@@ -83,6 +83,14 @@ var _ = Describe("Multicluster deployment models", Label("multicluster", "multic
 			}
 
 			Context(fmt.Sprintf("Istio version %s", v.Version), func() {
+				clr1 := cleaner.New(clPrimary, "cluster=primary")
+				clr2 := cleaner.New(clRemote, "cluster=remote")
+
+				BeforeAll(func(ctx SpecContext) {
+					clr1.Record(ctx)
+					clr2.Record(ctx)
+				})
+
 				When("Istio and IstioCNI resources are created in both clusters", func() {
 					BeforeAll(func(ctx SpecContext) {
 						Expect(k1.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
@@ -401,10 +409,9 @@ spec:
 			}
 		}
 
-		// Delete the Sail Operator from both clusters
-		Expect(k1.DeleteNamespaceNoWait(namespace)).To(Succeed(), "Namespace failed to be deleted on Primary Cluster")
-		Expect(k2.DeleteNamespaceNoWait(namespace)).To(Succeed(), "Namespace failed to be deleted on Remote Cluster")
-		Expect(k1.WaitNamespaceDeleted(namespace)).To(Succeed())
-		Expect(k2.WaitNamespaceDeleted(namespace)).To(Succeed())
+		c1Deleted := clr1.CleanupNoWait(ctx)
+		c2Deleted := clr2.CleanupNoWait(ctx)
+		clr1.WaitForDeletion(ctx, c1Deleted)
+		clr2.WaitForDeletion(ctx, c2Deleted)
 	})
 })

--- a/tests/e2e/multicontrolplane/multi_control_plane_test.go
+++ b/tests/e2e/multicontrolplane/multi_control_plane_test.go
@@ -179,11 +179,6 @@ spec:
 		}
 
 		clr.Cleanup(ctx)
-		By("Deleting any left-over Istio and IstioRevision resources")
-		Expect(k.Delete("istio", istioName1)).To(Succeed(), "Failed to delete Istio")
-		Expect(k.Delete("istio", istioName2)).To(Succeed(), "Failed to delete Istio")
-		Expect(k.Delete("istiocni", istioCniName)).To(Succeed(), "Failed to delete IstioCNI")
-		Success("Istio Resources deleted")
 	})
 
 	AfterAll(func() {

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -195,7 +195,6 @@ spec:
 			}
 
 			clr.Cleanup(ctx)
-			exec.Command("kubectl", "delete", "--ignore-not-found", "clusterrolebinding", "metrics-reader-rolebinding").Run()
 
 			if CurrentSpecReport().Failed() {
 				common.LogDebugInfo(common.Operator, k)

--- a/tests/e2e/util/cleaner/cleaner.go
+++ b/tests/e2e/util/cleaner/cleaner.go
@@ -1,0 +1,164 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR Condition OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleaner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Cleaner records resources to keep, and cleans up any resources it didn't record.
+type Cleaner struct {
+	cl         client.Client
+	ctx        []string
+	namespaces map[string]struct{}
+}
+
+// New returns a Cleaner which can record resources to keep, and clean up any resources it didn't record.
+// It needs an initialized client, and has optional (string) context which can be used to distinguish it's output.
+func New(cl client.Client, ctx ...string) Cleaner {
+	return Cleaner{
+		cl:         cl,
+		ctx:        ctx,
+		namespaces: make(map[string]struct{}),
+	}
+}
+
+// Record will save the state of all resources it wants to keep in the cluster, so they won't be cleaned up.
+func (c *Cleaner) Record(ctx context.Context) {
+	// Save all namespaces that exist so that we can skip them when cleaning
+	namespaceList := &corev1.NamespaceList{}
+	Expect(c.cl.List(ctx, namespaceList)).To(Succeed())
+	for _, ns := range namespaceList.Items {
+		c.namespaces[ns.Name] = struct{}{}
+	}
+}
+
+// CleanupNoWait will cleanup any resources not recorded, while not waiting for their deletion to complete.
+// Use Cleaner.WaitForDeletion to wait for their deletion at a later point.
+func (c *Cleaner) CleanupNoWait(ctx context.Context) (deleted []client.Object) {
+	return c.cleanup(ctx)
+}
+
+// Cleanup will cleanup any resources not recorded, and wait for their deletion.
+func (c *Cleaner) Cleanup(ctx context.Context) {
+	c.WaitForDeletion(ctx, c.cleanup(ctx))
+}
+
+func (c *Cleaner) cleanup(ctx context.Context) (deleted []client.Object) {
+	// Clean up all namespaces that didn't exist before the tests
+	namespaceList := &corev1.NamespaceList{}
+	Expect(c.cl.List(ctx, namespaceList)).To(Succeed())
+	for _, ns := range namespaceList.Items {
+		if mapHasKey(c.namespaces, ns.Name) {
+			continue
+		}
+
+		By(c.cleaningUpThe(&ns, "namespace"), func() {
+			Expect(c.delete(ctx, &ns)).To(Succeed())
+			deleted = append(deleted, &ns)
+		})
+	}
+
+	return
+}
+
+func mapHasKey[V any](m map[string]V, k string) bool {
+	_, exists := m[k]
+	return exists
+}
+
+func (c *Cleaner) delete(ctx context.Context, obj client.Object) error {
+	if err := c.cl.Delete(ctx, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (c *Cleaner) cleaningUpThe(obj client.Object, kind string) (s string) {
+	ctx := []string{}
+	ns := obj.GetNamespace()
+	if ns != "" {
+		ctx = append(ctx, fmt.Sprintf("namespace=%s", ns))
+	}
+
+	ctx = append(ctx, c.ctx...)
+	s = strings.Join(ctx, ", ")
+	if s != "" {
+		s = fmt.Sprintf(" on %s", s)
+	}
+
+	return fmt.Sprintf("Cleaning up the %s %s%s", obj.GetName(), kind, s)
+}
+
+// WaitForDeletion receives a slice of resources marked for deletion, and waits until they're all delete.
+// It will fail the test suite if any resource hasn't been deleted in sufficient time.
+func (c *Cleaner) WaitForDeletion(ctx context.Context, deleted []client.Object) {
+	if len(deleted) == 0 {
+		return
+	}
+
+	s := strings.Join(c.ctx, ", ")
+	if s != "" {
+		s = fmt.Sprintf("on %s", s)
+	}
+
+	By(fmt.Sprintf("Waiting for resources to be deleted%s", s))
+	for _, obj := range deleted {
+		Expect(c.waitForDeletion(ctx, obj)).To(Succeed())
+	}
+
+	Success(fmt.Sprintf("Finished cleaning up resources%s", s))
+}
+
+func (c *Cleaner) waitForDeletion(ctx context.Context, obj client.Object) error {
+	objKey := client.ObjectKeyFromObject(obj)
+
+	err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+		gotObj := obj.DeepCopyObject().(client.Object)
+
+		if err := c.cl.Get(ctx, objKey, gotObj); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+
+			return false, err
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -320,10 +320,6 @@ func InstallOperatorViaHelm(extraArgs ...string) error {
 	return helm.Install("sail-operator", filepath.Join(project.RootDir, "chart"), args...)
 }
 
-func UninstallOperator() error {
-	return helm.Uninstall("sail-operator", "--namespace", OperatorNamespace)
-}
-
 // GetSampleYAML returns the URL of the yaml file for the testing app.
 // args:
 // version: the version of the Istio to get the yaml file from.

--- a/tests/e2e/util/helm/helm.go
+++ b/tests/e2e/util/helm/helm.go
@@ -37,18 +37,3 @@ func Install(name string, chart string, args ...string) error {
 	g.Success("Helm install executed successfully")
 	return nil
 }
-
-// Uninstall runs helm uninstall in the given directory with params
-// name: name of the helm release
-// args: additional helm args, for example "--namespace sail-operator"
-func Uninstall(name string, args ...string) error {
-	argsStr := strings.Join(args, " ")
-	command := fmt.Sprintf("helm uninstall %s %s", name, argsStr)
-	output, err := shell.ExecuteCommand(command)
-	if err != nil {
-		return fmt.Errorf("error running Helm uninstall: %w. Output: %s", err, output)
-	}
-
-	g.Success("Helm uninstall executed successfully")
-	return nil
-}

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -17,7 +17,6 @@ package kubectl
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -117,38 +116,6 @@ func (k Kubectl) CreateFromString(yamlString string) error {
 	return nil
 }
 
-// DeleteCRDs deletes the CRDs by given list of crds names
-func (k Kubectl) DeleteCRDs(crds []string) error {
-	for _, crd := range crds {
-		cmd := k.build(" delete crd " + crd)
-		_, err := shell.ExecuteCommand(cmd)
-		if err != nil {
-			return fmt.Errorf("error deleting crd %s: %w", crd, err)
-		}
-	}
-
-	return nil
-}
-
-// DeleteNamespaceNoWait deletes a namespace and returns immediately (without waiting for the namespace to be removed).
-func (k Kubectl) DeleteNamespaceNoWait(namespaces ...string) error {
-	return k.deleteNamespace(namespaces, false)
-}
-
-// DeleteNamespace deletes a namespace and waits for it to be removed completely.
-func (k Kubectl) DeleteNamespace(namespaces ...string) error {
-	return k.deleteNamespace(namespaces, true)
-}
-
-func (k Kubectl) deleteNamespace(namespaces []string, wait bool) error {
-	cmd := k.build(" delete namespace " + strings.Join(namespaces, " ") + " --wait=" + strconv.FormatBool(wait))
-	_, err := k.executeCommand(cmd)
-	if err != nil {
-		return fmt.Errorf("error deleting namespace: %w", err)
-	}
-	return nil
-}
-
 // ApplyString applies the given yaml string to the cluster
 func (k Kubectl) ApplyString(yamlString string) error {
 	cmd := k.build(" apply --server-side -f -")
@@ -197,13 +164,6 @@ func (k Kubectl) Delete(kind, name string) error {
 	}
 
 	return nil
-}
-
-// Wait waits for a specific condition on one or many resources
-func (k Kubectl) Wait(waitFor, resource string, timeout time.Duration) error {
-	cmd := k.build(fmt.Sprintf("wait --for %s %s --timeout %s", waitFor, resource, timeout.String()))
-	_, err := k.executeCommand(cmd)
-	return err
 }
 
 // Patch patches a resource
@@ -329,11 +289,6 @@ func (k Kubectl) Label(kind, name, labelKey, labelValue string) error {
 // executeCommand handles running the command and then resets the namespace automatically
 func (k Kubectl) executeCommand(cmd string) (string, error) {
 	return shell.ExecuteCommand(cmd)
-}
-
-// WaitNamespaceDeleted waits for a namespace to be deleted
-func (k Kubectl) WaitNamespaceDeleted(ns string) error {
-	return k.Wait("delete", "namespace/"+ns, 2*time.Minute)
 }
 
 func sinceFlag(since *time.Duration) string {


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [x] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
This set of commits adds a `Cleaner` type which can record the cluster state and revert to that state by removing resources added via tests.

Currently only pertinent resources are tracked for the sake of simplicity, but this can be further expanded and generalized if necessary.

Cleaning up the operator is handled automatically, and when the operator is deployed externally if would be skipped (as it's recorded at the start of the test).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #833 

Related Issue/PR #

#### Additional information:
