### PR TITLE
Enchance debug information when e2e fails: add istioctl proxy status

### DIFF
--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/helm"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/istioctl"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -217,6 +218,10 @@ func logIstioDebugInfo(k kubectl.Kubectl) {
 
 	events, err := k.WithNamespace(controlPlaneNamespace).GetEvents()
 	logDebugElement("=====Events in "+controlPlaneNamespace+"=====", events, err)
+
+	// Running istioctl proxy-status to get the status of the proxies.
+	proxyStatus, err := istioctl.GetProxyStatus()
+	logDebugElement("=====Istioctl Proxy Status=====", proxyStatus, err)
 }
 
 func logCNIDebugInfo(k kubectl.Kubectl) {

--- a/tests/e2e/util/istioctl/istioctl.go
+++ b/tests/e2e/util/istioctl/istioctl.go
@@ -58,3 +58,13 @@ func CreateRemoteSecret(remoteKubeconfig, namespace, secretName, internalIP stri
 
 	return yaml, err
 }
+
+// GetProxyStatus runs istioctl proxy-status command and return the output
+func GetProxyStatus() (string, error) {
+	cmd := istioctl("proxy-status")
+	status, err := shell.ExecuteCommand(cmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to get proxy status: %w", err)
+	}
+	return status, nil
+}


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Adding the print of istioctl proxy status when control plane related test fails, this will help debugging errors like proxy version mistmatch, errors pod not found, etc. It will print something like this:
```
  =====Istioctl Proxy Status=====:
    NAME                                      CLUSTER        CDS             LDS             EDS             RDS             ECDS        ISTIOD                                      VERSION
    helloworld-v1-6bcd6bdf6f-5rw6b.sample     Kubernetes     SYNCED (1s)     SYNCED (1s)     SYNCED (1s)     SYNCED (1s)     IGNORED     istiod-default-v1-25-3-6d4f4bcd99-8r74g     1.25.3
  =========================================================
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
