### PR TITLE
Consolidate multicluster operator deploy/cleanup

### DIFF
--- a/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
+++ b/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
@@ -18,19 +18,16 @@ package multicluster
 
 import (
 	"fmt"
-	"path/filepath"
 	"time"
 
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
-	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
 	"github.com/istio-ecosystem/sail-operator/pkg/version"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
-	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/helm"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/istioctl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -49,35 +46,6 @@ const (
 var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-external"), Ordered, func() {
 	SetDefaultEventuallyTimeout(180 * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
-	debugInfoLogged := false
-	clr1 := cleaner.New(clPrimary, "cluster=primary")
-	clr2 := cleaner.New(clRemote, "cluster=remote")
-
-	BeforeAll(func(ctx SpecContext) {
-		clr1.Record(ctx)
-		clr2.Record(ctx)
-
-		if !skipDeploy {
-			Expect(k1.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Cluster #1")
-			Expect(k2.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Cluster #2")
-
-			Expect(helm.Install("sail-operator", filepath.Join(project.RootDir, "chart"), "--namespace "+namespace, "--set=image="+image, "--kubeconfig "+kubeconfig)).
-				To(Succeed(), "Operator failed to be deployed in Cluster #1")
-
-			Expect(helm.Install("sail-operator", filepath.Join(project.RootDir, "chart"), "--namespace "+namespace, "--set=image="+image, "--kubeconfig "+kubeconfig2)).
-				To(Succeed(), "Operator failed to be deployed in Cluster #2")
-
-			Eventually(common.GetObject).
-				WithArguments(ctx, clPrimary, kube.Key(deploymentName, namespace), &appsv1.Deployment{}).
-				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
-			Success("Operator is deployed in the Cluster #1 namespace and Running")
-
-			Eventually(common.GetObject).
-				WithArguments(ctx, clRemote, kube.Key(deploymentName, namespace), &appsv1.Deployment{}).
-				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
-			Success("Operator is deployed in the Cluster #2 namespace and Running")
-		}
-	})
 
 	Describe("External Control Plane Multi-Network configuration", func() {
 		// Test the External Control Plane Multi-Network configuration for each supported Istio version
@@ -497,23 +465,5 @@ spec:
 				})
 			})
 		}
-	})
-
-	AfterAll(func(ctx SpecContext) {
-		if CurrentSpecReport().Failed() {
-			if !debugInfoLogged {
-				common.LogDebugInfo(common.MultiCluster, k1, k2)
-				debugInfoLogged = true
-			}
-
-			if keepOnFailure {
-				return
-			}
-		}
-
-		c1Deleted := clr1.CleanupNoWait(ctx)
-		c2Deleted := clr2.CleanupNoWait(ctx)
-		clr1.WaitForDeletion(ctx, c1Deleted)
-		clr2.WaitForDeletion(ctx, c2Deleted)
 	})
 })

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -19,19 +19,16 @@ package multicluster
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
-	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/certs"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
-	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/helm"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/istioctl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -44,36 +41,6 @@ import (
 var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-multiprimary"), Ordered, func() {
 	SetDefaultEventuallyTimeout(180 * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
-	debugInfoLogged := false
-	clr1 := cleaner.New(clPrimary, "cluster=primary")
-	clr2 := cleaner.New(clRemote, "cluster=remote")
-
-	BeforeAll(func(ctx SpecContext) {
-		clr1.Record(ctx)
-		clr2.Record(ctx)
-
-		if !skipDeploy {
-			// Deploy the Sail Operator on both clusters
-			Expect(k1.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Cluster #1")
-			Expect(k2.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Cluster #2")
-
-			Expect(helm.Install("sail-operator", filepath.Join(project.RootDir, "chart"), "--namespace "+namespace, "--set=image="+image, "--kubeconfig "+kubeconfig)).
-				To(Succeed(), "Operator failed to be deployed in Cluster #1")
-
-			Expect(helm.Install("sail-operator", filepath.Join(project.RootDir, "chart"), "--namespace "+namespace, "--set=image="+image, "--kubeconfig "+kubeconfig2)).
-				To(Succeed(), "Operator failed to be deployed in Cluster #2")
-
-			Eventually(common.GetObject).
-				WithArguments(ctx, clPrimary, kube.Key(deploymentName, namespace), &appsv1.Deployment{}).
-				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
-			Success("Operator is deployed in the Cluster #1 namespace and Running")
-
-			Eventually(common.GetObject).
-				WithArguments(ctx, clRemote, kube.Key(deploymentName, namespace), &appsv1.Deployment{}).
-				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
-			Success("Operator is deployed in the Cluster #2 namespace and Running")
-		}
-	})
 
 	Describe("Multi-Primary Multi-Network configuration", func() {
 		// Test the Multi-Primary Multi-Network configuration for each supported Istio version
@@ -363,23 +330,5 @@ spec:
 				})
 			})
 		}
-	})
-
-	AfterAll(func(ctx SpecContext) {
-		if CurrentSpecReport().Failed() {
-			if !debugInfoLogged {
-				common.LogDebugInfo(common.MultiCluster, k1, k2)
-				debugInfoLogged = true
-			}
-
-			if keepOnFailure {
-				return
-			}
-		}
-
-		c1Deleted := clr1.CleanupNoWait(ctx)
-		c2Deleted := clr2.CleanupNoWait(ctx)
-		clr1.WaitForDeletion(ctx, c1Deleted)
-		clr2.WaitForDeletion(ctx, c2Deleted)
 	})
 })

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -42,36 +42,6 @@ import (
 var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-primaryremote"), Ordered, func() {
 	SetDefaultEventuallyTimeout(180 * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
-	debugInfoLogged := false
-	clr1 := cleaner.New(clPrimary, "cluster=primary")
-	clr2 := cleaner.New(clRemote, "cluster=remote")
-
-	BeforeAll(func(ctx SpecContext) {
-		clr1.Record(ctx)
-		clr2.Record(ctx)
-
-		if !skipDeploy {
-			// Deploy the Sail Operator on both clusters
-			Expect(k1.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Primary Cluster")
-			Expect(k2.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Remote Cluster")
-
-			Expect(common.InstallOperatorViaHelm("--kubeconfig", kubeconfig)).
-				To(Succeed(), "Operator failed to be deployed in Primary Cluster")
-
-			Expect(common.InstallOperatorViaHelm("--kubeconfig", kubeconfig2)).
-				To(Succeed(), "Operator failed to be deployed in Remote Cluster")
-
-			Eventually(common.GetObject).
-				WithArguments(ctx, clPrimary, kube.Key(deploymentName, namespace), &appsv1.Deployment{}).
-				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
-			Success("Operator is deployed in the Primary namespace and Running")
-
-			Eventually(common.GetObject).
-				WithArguments(ctx, clRemote, kube.Key(deploymentName, namespace), &appsv1.Deployment{}).
-				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
-			Success("Operator is deployed in the Remote namespace and Running")
-		}
-	})
 
 	Describe("Primary-Remote - Multi-Network configuration", func() {
 		// Test the Primary-Remote - Multi-Network configuration for each supported Istio version
@@ -395,23 +365,5 @@ spec:
 				})
 			})
 		}
-	})
-
-	AfterAll(func(ctx SpecContext) {
-		if CurrentSpecReport().Failed() {
-			if !debugInfoLogged {
-				common.LogDebugInfo(common.MultiCluster, k1, k2)
-				debugInfoLogged = true
-			}
-
-			if keepOnFailure {
-				return
-			}
-		}
-
-		c1Deleted := clr1.CleanupNoWait(ctx)
-		c2Deleted := clr2.CleanupNoWait(ctx)
-		clr1.WaitForDeletion(ctx, c1Deleted)
-		clr2.WaitForDeletion(ctx, c2Deleted)
 	})
 })

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -23,11 +23,18 @@ import (
 	"testing"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/env"
+	"github.com/istio-ecosystem/sail-operator/pkg/kube"
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/certs"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,6 +42,7 @@ var (
 	clPrimary                     client.Client
 	clRemote                      client.Client
 	err                           error
+	debugInfoLogged               bool
 	namespace                     = env.Get("NAMESPACE", "sail-operator")
 	deploymentName                = env.Get("DEPLOYMENT_NAME", "sail-operator")
 	controlPlaneNamespace         = env.Get("CONTROL_PLANE_NS", "istio-system")
@@ -42,7 +50,6 @@ var (
 	istioName                     = env.Get("ISTIO_NAME", "default")
 	istioCniNamespace             = env.Get("ISTIOCNI_NAMESPACE", "istio-cni")
 	istioCniName                  = env.Get("ISTIOCNI_NAME", "default")
-	image                         = env.Get("IMAGE", "quay.io/maistra-dev/sail-operator:latest")
 	skipDeploy                    = env.GetBool("SKIP_DEPLOY", false)
 	multicluster                  = env.GetBool("MULTICLUSTER", false)
 	keepOnFailure                 = env.GetBool("KEEP_ON_FAILURE", false)
@@ -59,6 +66,9 @@ var (
 
 	k1 kubectl.Kubectl
 	k2 kubectl.Kubectl
+
+	clr1 cleaner.Cleaner
+	clr2 cleaner.Cleaner
 )
 
 func TestMultiCluster(t *testing.T) {
@@ -105,4 +115,51 @@ func setup(t *testing.T) {
 	// Initialize kubectl utilities, one for each cluster
 	k1 = kubectl.New().WithKubeconfig(kubeconfig)
 	k2 = kubectl.New().WithKubeconfig(kubeconfig2)
+	clr1 = cleaner.New(clPrimary, "cluster=primary")
+	clr2 = cleaner.New(clRemote, "cluster=remote")
 }
+
+var _ = BeforeSuite(func(ctx SpecContext) {
+	clr1.Record(ctx)
+	clr2.Record(ctx)
+
+	if skipDeploy {
+		return
+	}
+
+	Expect(k1.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Primary Cluster")
+	Expect(k2.CreateNamespace(namespace)).To(Succeed(), "Namespace failed to be created on Remote Cluster")
+
+	Expect(common.InstallOperatorViaHelm("--kubeconfig", kubeconfig)).
+		To(Succeed(), "Operator failed to be deployed in Primary Cluster")
+
+	Expect(common.InstallOperatorViaHelm("--kubeconfig", kubeconfig2)).
+		To(Succeed(), "Operator failed to be deployed in Remote Cluster")
+
+	Eventually(common.GetObject).
+		WithArguments(ctx, clPrimary, kube.Key(deploymentName, namespace), &appsv1.Deployment{}).
+		Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
+	Success("Operator is deployed in the Primary namespace and Running")
+
+	Eventually(common.GetObject).
+		WithArguments(ctx, clRemote, kube.Key(deploymentName, namespace), &appsv1.Deployment{}).
+		Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Istio CRD")
+	Success("Operator is deployed in the Remote namespace and Running")
+})
+
+var _ = AfterSuite(func(ctx SpecContext) {
+	if CurrentSpecReport().Failed() {
+		if !debugInfoLogged {
+			common.LogDebugInfo(common.MultiCluster, k1, k2)
+		}
+
+		if keepOnFailure {
+			return
+		}
+	}
+
+	c1Deleted := clr1.CleanupNoWait(ctx)
+	c2Deleted := clr2.CleanupNoWait(ctx)
+	clr1.WaitForDeletion(ctx, c1Deleted)
+	clr2.WaitForDeletion(ctx, c2Deleted)
+})


### PR DESCRIPTION
Now that we have `Cleaner` clean up after each test, it makes sense to run this logic once in the suite, rather than after each test (which cleans up its own resources).

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #666 

#### Additional information:
