### PR TITLE
Fix log message for cleaner when waiting

### DIFF
--- a/tests/e2e/util/cleaner/cleaner.go
+++ b/tests/e2e/util/cleaner/cleaner.go
@@ -266,7 +266,7 @@ func (c *Cleaner) WaitForDeletion(ctx context.Context, deleted []client.Object) 
 
 	s := strings.Join(c.ctx, ", ")
 	if s != "" {
-		s = fmt.Sprintf("on %s", s)
+		s = fmt.Sprintf(" on %s", s)
 	}
 
 	By(fmt.Sprintf("Waiting for resources to be deleted%s", s))


### PR DESCRIPTION
Message example before fix:
`STEP: Waiting for resources to be deletedon cluster=primary`