### PR TITLE
Skip cleanup if control plane tests fail

### DIFF
--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -90,6 +90,10 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	Success("Operator is deployed in the namespace and Running")
 })
 
-var _ = AfterSuite(func(ctx SpecContext) {
+var _ = ReportAfterSuite("Condiotnal cleanup", func(ctx SpecContext, r Report) {
+	if !r.SuiteSucceeded && keepOnFailure {
+		return
+	}
+
 	clr.Cleanup(ctx)
 })


### PR DESCRIPTION
Seems that this was missed in a recent refactor, so making sure the suite skips cleaning up when it failed and we want to keep the env.

Use `ReportAfterSuite` which recieves a concentrated report and can tell if the suite has passed or failed.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
