### PR TITLE
Use `Eventually` in remote secret generation

### DIFF
--- a/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
+++ b/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
@@ -224,16 +224,20 @@ metadata:
 						Expect(apiURLCluster2).NotTo(BeEmpty(), "API URL is empty for the Cluster #2")
 						Expect(err).NotTo(HaveOccurred())
 
-						secret, err := istioctl.CreateRemoteSecret(
-							kubeconfig2,
-							externalControlPlaneNamespace,
-							"cluster2",
-							apiURLCluster2,
-							"--type=config",
-							"--service-account=istiod-"+externalIstioName,
-							"--create-service-account=false",
-						)
-						Expect(err).NotTo(HaveOccurred())
+						var secret string
+						Eventually(func() error {
+							secret, err = istioctl.CreateRemoteSecret(
+								kubeconfig2,
+								externalControlPlaneNamespace,
+								"cluster2",
+								apiURLCluster2,
+								"--type=config",
+								"--service-account=istiod-"+externalIstioName,
+								"--create-service-account=false",
+							)
+
+							return err
+						}).ShouldNot(HaveOccurred(), "Remote secret generation failed")
 						Expect(k1.ApplyString(secret)).To(Succeed(), "Remote secret creation failed on Cluster #1")
 					})
 


### PR DESCRIPTION
In this test the secret generation sometimes is attempted before everything is ready, leading to flaky, hard to debug, failures.

Using `Eventually` to generate the secret avoids these failures.

Fixes: https://github.com/istio-ecosystem/sail-operator/issues/866
