### PR TITLE
Expose "Profile" parameter in UI for Istio and IstioCNI

### DIFF
--- a/api/v1/istio_types.go
+++ b/api/v1/istio_types.go
@@ -52,8 +52,7 @@ type IstioSpec struct {
 	// The built-in installation configuration profile to use.
 	// The 'default' profile is always applied. On OpenShift, the 'openshift' profile is also applied on top of 'default'.
 	// Must be one of: ambient, default, demo, empty, openshift, openshift-ambient, preview, remote, stable.
-	// +++PROFILES-DROPDOWN-HIDDEN-UNTIL-WE-FULLY-IMPLEMENT-THEM+++operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Profile",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:ambient", "urn:alm:descriptor:com.tectonic.ui:select:default", "urn:alm:descriptor:com.tectonic.ui:select:demo", "urn:alm:descriptor:com.tectonic.ui:select:empty", "urn:alm:descriptor:com.tectonic.ui:select:external", "urn:alm:descriptor:com.tectonic.ui:select:minimal", "urn:alm:descriptor:com.tectonic.ui:select:preview", "urn:alm:descriptor:com.tectonic.ui:select:remote"}
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Profile",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:ambient", "urn:alm:descriptor:com.tectonic.ui:select:default", "urn:alm:descriptor:com.tectonic.ui:select:demo", "urn:alm:descriptor:com.tectonic.ui:select:empty", "urn:alm:descriptor:com.tectonic.ui:select:openshift", "urn:alm:descriptor:com.tectonic.ui:select:openshift-ambient", "urn:alm:descriptor:com.tectonic.ui:select:preview", "urn:alm:descriptor:com.tectonic.ui:select:remote", "urn:alm:descriptor:com.tectonic.ui:select:stable"}
 	// +kubebuilder:validation:Enum=ambient;default;demo;empty;external;openshift;openshift-ambient;preview;remote;stable
 	Profile string `json:"profile,omitempty"`
 

--- a/api/v1/istiocni_types.go
+++ b/api/v1/istiocni_types.go
@@ -38,8 +38,7 @@ type IstioCNISpec struct {
 	// The built-in installation configuration profile to use.
 	// The 'default' profile is always applied. On OpenShift, the 'openshift' profile is also applied on top of 'default'.
 	// Must be one of: ambient, default, demo, empty, openshift, openshift-ambient, preview, remote, stable.
-	// +++PROFILES-DROPDOWN-HIDDEN-UNTIL-WE-FULLY-IMPLEMENT-THEM+++operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Profile",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:ambient", "urn:alm:descriptor:com.tectonic.ui:select:default", "urn:alm:descriptor:com.tectonic.ui:select:demo", "urn:alm:descriptor:com.tectonic.ui:select:empty", "urn:alm:descriptor:com.tectonic.ui:select:external", "urn:alm:descriptor:com.tectonic.ui:select:minimal", "urn:alm:descriptor:com.tectonic.ui:select:preview", "urn:alm:descriptor:com.tectonic.ui:select:remote"}
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Profile",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:General", "urn:alm:descriptor:com.tectonic.ui:select:ambient", "urn:alm:descriptor:com.tectonic.ui:select:default", "urn:alm:descriptor:com.tectonic.ui:select:demo", "urn:alm:descriptor:com.tectonic.ui:select:empty", "urn:alm:descriptor:com.tectonic.ui:select:openshift", "urn:alm:descriptor:com.tectonic.ui:select:openshift-ambient", "urn:alm:descriptor:com.tectonic.ui:select:preview", "urn:alm:descriptor:com.tectonic.ui:select:remote", "urn:alm:descriptor:com.tectonic.ui:select:stable"}
 	// +kubebuilder:validation:Enum=ambient;default;demo;empty;external;openshift;openshift-ambient;preview;remote;stable
 	Profile string `json:"profile,omitempty"`
 

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/sail-dev/sail-operator:1.27-latest
-    createdAt: "2025-05-21T16:54:39Z"
+    createdAt: "2025-06-24T10:01:16Z"
     description: The Sail Operator manages the lifecycle of your Istio control plane.
       It provides custom resources for you to deploy and manage your control plane
       components.
@@ -201,7 +201,16 @@ spec:
         displayName: Profile
         path: profile
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
+        - urn:alm:descriptor:com.tectonic.ui:select:ambient
+        - urn:alm:descriptor:com.tectonic.ui:select:default
+        - urn:alm:descriptor:com.tectonic.ui:select:demo
+        - urn:alm:descriptor:com.tectonic.ui:select:empty
+        - urn:alm:descriptor:com.tectonic.ui:select:openshift
+        - urn:alm:descriptor:com.tectonic.ui:select:openshift-ambient
+        - urn:alm:descriptor:com.tectonic.ui:select:preview
+        - urn:alm:descriptor:com.tectonic.ui:select:remote
+        - urn:alm:descriptor:com.tectonic.ui:select:stable
       - description: Defines the values to be passed to the Helm charts when installing
           Istio CNI.
         displayName: Helm Values
@@ -333,7 +342,16 @@ spec:
         displayName: Profile
         path: profile
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:General
+        - urn:alm:descriptor:com.tectonic.ui:select:ambient
+        - urn:alm:descriptor:com.tectonic.ui:select:default
+        - urn:alm:descriptor:com.tectonic.ui:select:demo
+        - urn:alm:descriptor:com.tectonic.ui:select:empty
+        - urn:alm:descriptor:com.tectonic.ui:select:openshift
+        - urn:alm:descriptor:com.tectonic.ui:select:openshift-ambient
+        - urn:alm:descriptor:com.tectonic.ui:select:preview
+        - urn:alm:descriptor:com.tectonic.ui:select:remote
+        - urn:alm:descriptor:com.tectonic.ui:select:stable
       - description: Defines the update strategy to use when the version in the Istio
           CR is updated.
         displayName: Update Strategy

--- a/hack/update-profiles-list.sh
+++ b/hack/update-profiles-list.sh
@@ -27,11 +27,7 @@ enumValues=""
 
 IFS=',' read -ra elements <<< "${profiles}"
 for element in "${elements[@]}"; do
-  if [[ "$element" != "openshift" ]]; then
-    # skip openshift profile in the drop-down, since it's always applied;
-    # default is also applied, but we preserve it so that users can deselect a profile after they select it
-    selectValues+=', "urn:alm:descriptor:com.tectonic.ui:select:'$element'"'
-  fi
+  selectValues+=', "urn:alm:descriptor:com.tectonic.ui:select:'$element'"'
   enumValues+=$element';'
 done
 


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [X] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
During deployment of Istio in ambient mode, the user should be able to set the "profile: ambient" for Istio and IstioCNI resources. Currently, this parameter is hidden from the UI.
Turn on the visibility of this parameter in the UI.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes https://issues.redhat.com/browse/OSSM-9798

Related Issue/PR #

#### Additional information:
