### PR TITLE
Stabilize e2e dual-stack test

### DIFF
--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -34,6 +34,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -256,19 +257,17 @@ spec:
 						Expect(k.Label("namespace", common.HttpbinNamespace, "istio.io/dataplane-mode", "ambient")).To(Succeed(), "Error labeling httpbin namespace")
 
 						// Deploy the test pods.
-						Expect(k.WithNamespace(common.SleepNamespace).Apply(common.GetSampleYAML(version, "sleep"))).To(Succeed(), "error deploying sleep pod")
-						Expect(k.WithNamespace(common.HttpbinNamespace).Apply(common.GetSampleYAML(version, "httpbin"))).To(Succeed(), "error deploying httpbin pod")
+						Expect(k.WithNamespace(common.SleepNamespace).Apply(common.GetSampleYAML(version, "sleep"))).To(Succeed(), "Error deploying sleep pod")
+						Expect(k.WithNamespace(common.HttpbinNamespace).Apply(common.GetSampleYAML(version, "httpbin"))).To(Succeed(), "Error deploying httpbin pod")
 
 						Success("Ambient validation pods deployed")
 					})
 
 					sleepPod := &corev1.PodList{}
 					It("updates the status of pods to Running", func(ctx SpecContext) {
-						sleepPod, err = common.CheckPodsReady(ctx, cl, common.SleepNamespace)
-						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error checking status of sleep pod: %v", err))
-
-						_, err = common.CheckPodsReady(ctx, cl, common.HttpbinNamespace)
-						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error checking status of httpbin pod: %v", err))
+						Eventually(common.CheckPodsReady).WithArguments(ctx, cl, common.SleepNamespace).Should(Succeed(), "Error checking status of sleep pod")
+						Eventually(common.CheckPodsReady).WithArguments(ctx, cl, common.HttpbinNamespace).Should(Succeed(), "Error checking status of httpbin pod")
+						Expect(cl.List(ctx, sleepPod, client.InNamespace(common.SleepNamespace))).To(Succeed(), "Error getting the pod in sleep namespace")
 
 						Success("Pods are ready")
 					})

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -215,21 +215,10 @@ spec:
 					})
 
 					samplePods := &corev1.PodList{}
-
 					It("updates the pods status to Running", func(ctx SpecContext) {
-						Eventually(func() bool {
-							// Wait until the sample pod exists. Is wraped inside a function to avoid failure on the first iteration
-							Expect(cl.List(ctx, samplePods, client.InNamespace(sampleNamespace))).To(Succeed())
-							return len(samplePods.Items) > 0
-						}).Should(BeTrue(), "No sample pods found")
+						Eventually(common.CheckPodsReady).WithArguments(ctx, cl, sampleNamespace).Should(Succeed(), "Error checking status of sample pods")
+						Expect(cl.List(ctx, samplePods, client.InNamespace(sampleNamespace))).To(Succeed(), "Error getting the pods in sample namespace")
 
-						Expect(cl.List(ctx, samplePods, client.InNamespace(sampleNamespace))).To(Succeed())
-						Expect(samplePods.Items).ToNot(BeEmpty(), "No pods found in sample namespace")
-
-						for _, pod := range samplePods.Items {
-							Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(pod.Name, sampleNamespace), &corev1.Pod{}).
-								Should(HaveConditionStatus(corev1.PodReady, metav1.ConditionTrue), "Pod is not Ready")
-						}
 						Success("sample pods are ready")
 					})
 

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -146,16 +146,9 @@ spec:
 					Success("sample deployed")
 
 					samplePods := &corev1.PodList{}
+					Eventually(common.CheckPodsReady).WithArguments(ctx, cl, sampleNamespace).Should(Succeed(), "Error checking status of sample pods")
+					Expect(cl.List(ctx, samplePods, client.InNamespace(sampleNamespace))).To(Succeed(), "Error getting the pods in sample namespace")
 
-					Eventually(func() bool {
-						Expect(cl.List(ctx, samplePods, client.InNamespace(sampleNamespace))).To(Succeed())
-						return len(samplePods.Items) > 0
-					}).Should(BeTrue(), "No sample pods found")
-
-					for _, pod := range samplePods.Items {
-						Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(pod.Name, sampleNamespace), &corev1.Pod{}).
-							Should(HaveConditionStatus(corev1.PodReady, metav1.ConditionTrue), "Pod is not Ready")
-					}
 					Success("sample pods are ready")
 
 					for _, pod := range samplePods.Items {

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -34,6 +34,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -207,17 +208,11 @@ spec:
 
 					sleepPod := &corev1.PodList{}
 					It("updates the status of pods to Running", func(ctx SpecContext) {
-						_, err = common.CheckPodsReady(ctx, cl, DualStackNamespace)
-						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error checking status of dual-stack pods: %v", err))
-
-						_, err = common.CheckPodsReady(ctx, cl, IPv4Namespace)
-						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error checking status of ipv4 pods: %v", err))
-
-						_, err = common.CheckPodsReady(ctx, cl, IPv6Namespace)
-						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error checking status of ipv6 pods: %v", err))
-
-						sleepPod, err = common.CheckPodsReady(ctx, cl, SleepNamespace)
-						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error checking status of sleep pods: %v", err))
+						Eventually(common.CheckPodsReady).WithArguments(ctx, cl, DualStackNamespace).Should(Succeed(), "Error checking status of dual-stack pod")
+						Eventually(common.CheckPodsReady).WithArguments(ctx, cl, IPv4Namespace).Should(Succeed(), "Error checking status of ipv4 pod")
+						Eventually(common.CheckPodsReady).WithArguments(ctx, cl, IPv6Namespace).Should(Succeed(), "Error checking status of ipv6 pod")
+						Eventually(common.CheckPodsReady).WithArguments(ctx, cl, SleepNamespace).Should(Succeed(), "Error checking status of sleep pod")
+						Expect(cl.List(ctx, sleepPod, client.InNamespace(SleepNamespace))).To(Succeed(), "Error getting the pod in sleep namespace")
 
 						Success("Pods are ready")
 					})


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

Allows wait inside CheckPodsReady func till pods will be ready (avoid errors during dual-stack tests like 

```
[38;5;9m[FAILED] No pods found in dual-stack namespace
  Expected
      <[]v1.Pod | len:0, cap:0>: nil
  not to be empty[0m
```

Same principle as used here: https://github.com/istio-ecosystem/sail-operator/blob/main/tests/e2e/controlplane/control_plane_test.go#L221

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
