### PR TITLE
Cleaner improvements

### DIFF
--- a/tests/e2e/util/cleaner/cleaner.go
+++ b/tests/e2e/util/cleaner/cleaner.go
@@ -271,7 +271,8 @@ func (c *Cleaner) WaitForDeletion(ctx context.Context, deleted []client.Object) 
 
 	By(fmt.Sprintf("Waiting for resources to be deleted%s", s))
 	for _, obj := range deleted {
-		Expect(c.waitForDeletion(ctx, obj)).To(Succeed())
+		Expect(c.waitForDeletion(ctx, obj)).To(Succeed(),
+			fmt.Sprintf("Failed while waiting for %s to delete", obj.GetName()))
 	}
 
 	Success(fmt.Sprintf("Finished cleaning up resources%s", s))


### PR DESCRIPTION
PR to introduce some improvements to the `Cleaner`:

    Print sensible error when failing to wait
    
    Right now the error is not clear enough, adding the context of which
    resource we fail to wait for should make it much easier to debug cleaner
    failures.
---
    Make sure Record is called before cleaning up
    
    Prevent misuse of the cleaner when trying to call the cleanup functions
    without calling the `Record` function first.
    
    Otherwise, the cleaner will attempt to remove all the resources it
    tracks from the cluster.
