### PR TITLE
Container: only use required packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
-FROM registry.access.redhat.com/ubi10/ubi-micro:latest 
-
+FROM registry.access.redhat.com/ubi10/ubi:latest AS packager
 ARG TARGETOS TARGETARCH
+
+RUN dnf -y --setopt=install_weak_deps=0 --nodocs \
+    --installroot /output install \
+    setup \
+ && dnf clean all --installroot /output
+RUN [ -d /usr/share/buildinfo ] && cp -a /usr/share/buildinfo /output/usr/share/buildinfo ||:
+RUN [ -d /root/buildinfo ] && cp -a /root/buildinfo /output/root/buildinfo ||:
+
+FROM scratch
+ARG TARGETOS TARGETARCH
+
+COPY --from=packager /output /
 
 ADD out/${TARGETOS:-linux}_${TARGETARCH:-amd64}/sail-operator /sail-operator
 ADD resources /var/lib/sail-operator/resources


### PR DESCRIPTION
#### What type of PR is this?
- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

This uses a two-stage build to produce a UBI-based image with only the required packages, in this case only the setup package. buildinfo is copied so that Clair has enough information to accurately scan the image for vulnerable UBI packages.

The result is a minimal image with only the operator as the attack surface (no shell etc.).

#### Which issue(s) this PR fixes:
Fixes #

Related Issue/PR #

#### Additional information:
