### PR TITLE
Try to uninstall releases in `uninstalling` status

### DIFF
--- a/pkg/helm/chartmanager.go
+++ b/pkg/helm/chartmanager.go
@@ -94,8 +94,10 @@ func (h *ChartManager) UpgradeOrInstallChart(
 			return nil, fmt.Errorf("failed to roll back helm release %s: %w", releaseName, err)
 		}
 		releaseExists = true
-	} else if rel.Info.Status == release.StatusPendingInstall || (rel.Info.Status == release.StatusFailed && rel.Version <= 1) {
-		log.V(2).Info("Performing helm uninstall", "release", releaseName)
+	} else if rel.Info.Status == release.StatusPendingInstall ||
+		rel.Info.Status == release.StatusUninstalling ||
+		(rel.Info.Status == release.StatusFailed && rel.Version <= 1) {
+		log.V(2).Info("Performing helm uninstall", "release", releaseName, "status", rel.Info.Status)
 		if _, err := action.NewUninstall(cfg).Run(releaseName); err != nil {
 			return nil, fmt.Errorf("failed to uninstall failed helm release %s: %w", releaseName, err)
 		}

--- a/pkg/helm/chartmanager_test.go
+++ b/pkg/helm/chartmanager_test.go
@@ -93,6 +93,13 @@ var (
 			},
 		},
 		{
+			name: "release in uninstalling state",
+			setup: func(g *WithT, cl client.Client, helm *ChartManager, ns string) {
+				install(g, helm, chartDir, ns, relName, owner)
+				setReleaseStatus(g, helm, ns, relName, release.StatusUninstalling)
+			},
+		},
+		{
 			name: "release in uninstalled state",
 			setup: func(g *WithT, cl client.Client, helm *ChartManager, ns string) {
 				install(g, helm, chartDir, ns, relName, owner)
@@ -100,14 +107,6 @@ var (
 			},
 			wantErrOnInstall:  true,
 			skipUninstallTest: true, // If the release is marked as Uninstalled, helm doesn't uninstall it
-		},
-		{
-			name: "release in uninstalling state",
-			setup: func(g *WithT, cl client.Client, helm *ChartManager, ns string) {
-				install(g, helm, chartDir, ns, relName, owner)
-				setReleaseStatus(g, helm, ns, relName, release.StatusUninstalling)
-			},
-			wantErrOnInstall: true,
 		},
 		{
 			name: "release in unknown state",


### PR DESCRIPTION
When installing with helm, sometimes the intallation fails and the operator issues an uninstall which can also fail.
In such a case, the release will get stuck perpetually in `uninstalling` status.

It should be safe to retry uninstalling it in such a case.

Fixes: https://github.com/istio-ecosystem/sail-operator/issues/920
