### PR TITLE
Deterministic solution for name clashes

### DIFF
--- a/api/v1/istiorevision_types.go
+++ b/api/v1/istiorevision_types.go
@@ -148,6 +148,9 @@ const (
 	// IstioRevisionReasonIstiodNotReady indicates that the control plane is fully reconciled, but istiod is not ready.
 	IstioRevisionReasonIstiodNotReady IstioRevisionConditionReason = "IstiodNotReady"
 
+	// IstioRevisionTagNameAlreadyExists indicates that a IstioRevisionTag with the same name as the IstioRevision already exists.
+	IstioRevisionReasonNameAlreadyExists IstioRevisionConditionReason = "NameAlreadyExists"
+
 	// IstioRevisionReasonRemoteIstiodNotReady indicates that the remote istiod is not ready.
 	IstioRevisionReasonRemoteIstiodNotReady IstioRevisionConditionReason = "RemoteIstiodNotReady"
 

--- a/api/v1/istiorevisiontags_types.go
+++ b/api/v1/istiorevisiontags_types.go
@@ -145,7 +145,7 @@ const (
 	// successfully reconciled the resources defined through the CR.
 	IstioRevisionTagConditionReconciled IstioRevisionTagConditionType = "Reconciled"
 
-	// IstioRevisionTagNameAlreadyExists indicates that the a revision with the same name as the IstioRevisionTag already exists.
+	// IstioRevisionTagNameAlreadyExists indicates that an IstioRevision with the same name as the IstioRevisionTag already exists.
 	IstioRevisionTagReasonNameAlreadyExists IstioRevisionTagConditionReason = "NameAlreadyExists"
 
 	// IstioRevisionTagReasonReferenceNotFound indicates that the resource referenced by the tag's TargetRef was not found

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -830,6 +830,7 @@ _Appears in:_
 | --- | --- |
 | `ReconcileError` | IstioRevisionReasonReconcileError indicates that the reconciliation of the resource has failed, but will be retried.  |
 | `IstiodNotReady` | IstioRevisionReasonIstiodNotReady indicates that the control plane is fully reconciled, but istiod is not ready.  |
+| `NameAlreadyExists` | IstioRevisionTagNameAlreadyExists indicates that a IstioRevisionTag with the same name as the IstioRevision already exists.  |
 | `RemoteIstiodNotReady` | IstioRevisionReasonRemoteIstiodNotReady indicates that the remote istiod is not ready.  |
 | `ReadinessCheckFailed` | IstioRevisionReasonReadinessCheckFailed indicates that istiod readiness status could not be ascertained.  |
 | `ReferencedByWorkloads` | IstioRevisionReasonReferencedByWorkloads indicates that the revision is referenced by at least one pod or namespace.  |
@@ -974,7 +975,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `NameAlreadyExists` | IstioRevisionTagNameAlreadyExists indicates that the a revision with the same name as the IstioRevisionTag already exists.  |
+| `NameAlreadyExists` | IstioRevisionTagNameAlreadyExists indicates that an IstioRevision with the same name as the IstioRevisionTag already exists.  |
 | `RefNotFound` | IstioRevisionTagReasonReferenceNotFound indicates that the resource referenced by the tag's TargetRef was not found  |
 | `ReconcileError` | IstioRevisionReasonReconcileError indicates that the reconciliation of the resource has failed, but will be retried.  |
 | `ReferencedByWorkloads` | IstioRevisionReasonReferencedByWorkloads indicates that the revision is referenced by at least one pod or namespace.  |

--- a/pkg/reconciler/errors.go
+++ b/pkg/reconciler/errors.go
@@ -50,3 +50,30 @@ func IsTransientError(err error) bool {
 	e := &TransientError{}
 	return errors.As(err, &e)
 }
+
+type NameAlreadyExistsError struct {
+	Message       string
+	originalError error
+}
+
+func (err NameAlreadyExistsError) Error() string {
+	return err.Message
+}
+
+func (err NameAlreadyExistsError) Unwrap() error {
+	return err.originalError
+}
+
+func NewNameAlreadyExistsError(message string, originalError error) NameAlreadyExistsError {
+	return NameAlreadyExistsError{
+		Message:       message,
+		originalError: originalError,
+	}
+}
+
+func IsNameAlreadyExistsError(err error) bool {
+	if _, ok := err.(NameAlreadyExistsError); ok {
+		return true
+	}
+	return false
+}

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/scheme"
 	"github.com/istio-ecosystem/sail-operator/pkg/test/testtime"
@@ -91,6 +92,70 @@ func TestValidateTargetNamespace(t *testing.T) {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectErr))
 			}
+		})
+	}
+}
+
+func TestResourceTakesPrecedence(t *testing.T) {
+	earlyTimestamp := metav1.Now()
+	lateTimestamp := metav1.NewTime(earlyTimestamp.Add(time.Hour))
+
+	testCases := []struct {
+		name           string
+		object1        *metav1.ObjectMeta
+		object2        *metav1.ObjectMeta
+		expectedResult bool
+	}{
+		{
+			name: "object1 created earlier",
+			object1: &metav1.ObjectMeta{
+				CreationTimestamp: earlyTimestamp,
+			},
+			object2: &metav1.ObjectMeta{
+				CreationTimestamp: lateTimestamp,
+			},
+			expectedResult: true,
+		},
+		{
+			name: "object2 created earlier",
+			object1: &metav1.ObjectMeta{
+				CreationTimestamp: lateTimestamp,
+			},
+			object2: &metav1.ObjectMeta{
+				CreationTimestamp: earlyTimestamp,
+			},
+			expectedResult: false,
+		},
+		{
+			name: "equal timestamp, object1 lower UID",
+			object1: &metav1.ObjectMeta{
+				CreationTimestamp: earlyTimestamp,
+				UID:               "a",
+			},
+			object2: &metav1.ObjectMeta{
+				CreationTimestamp: earlyTimestamp,
+				UID:               "b",
+			},
+			expectedResult: true,
+		},
+		{
+			name: "equal timestamp, object2 lower UID",
+			object1: &metav1.ObjectMeta{
+				CreationTimestamp: earlyTimestamp,
+				UID:               "b",
+			},
+			object2: &metav1.ObjectMeta{
+				CreationTimestamp: earlyTimestamp,
+				UID:               "a",
+			},
+			expectedResult: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := ResourceTakesPrecedence(tc.object1, tc.object2)
+			g.Expect(result).To(Equal(tc.expectedResult))
 		})
 	}
 }


### PR DESCRIPTION
This patch makes sure that if an IstioRevision and an IstioRevisionTag have a name clash, the older one is still reconciled. When CreationDate is equal, object UID will be used as tie-breaker.

Fixes #973