### PR TITLE
Always use an image from values when generating bundle

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -619,7 +619,7 @@ bundle: gen-all-except-bundle helm operator-sdk ## Generate bundle manifests and
 	if [ "$(OPENSHIFT_PLATFORM)" = "true" ]; then \
 		TEMPL_FLAGS="$$TEMPL_FLAGS --set platform=openshift"; \
 	fi; \
-	$(HELM) template chart chart $$TEMPL_FLAGS --set image='$(IMAGE)' --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(HELM) template chart chart $$TEMPL_FLAGS --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 
 ifeq ($(GENERATE_RELATED_IMAGES), true)
 	@hack/patch-csv.sh bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml


### PR DESCRIPTION
Using values.yaml as a source of truth for bundle generation.

 This allows to easily use `${OSSM_OPERATOR_3_1}` string in https://github.com/openshift-service-mesh/sail-operator/pull/382