### PR TITLE
Use istioctl for getting proxy version

### DIFF
--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -17,8 +17,11 @@
 package controlplane
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
@@ -26,6 +29,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/istioctl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -198,7 +202,7 @@ metadata:
 
 					It("has sidecars with the correct istio version", func(ctx SpecContext) {
 						for _, pod := range samplePods.Items {
-							sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
+							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
 							Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
 							Expect(sidecarVersion).To(Equal(version.Version), "Sidecar Istio version does not match the expected version")
 						}
@@ -269,4 +273,27 @@ func HaveContainersThat(matcher types.GomegaMatcher) types.GomegaMatcher {
 
 func ImageFromRegistry(regexp string) types.GomegaMatcher {
 	return HaveField("Image", MatchRegexp(regexp))
+}
+
+func getProxyVersion(podName, namespace string) (*semver.Version, error) {
+	proxyStatus, err := istioctl.GetProxyStatus("--namespace " + namespace)
+	if err != nil {
+		return nil, fmt.Errorf("error getting sidecar version: %w", err)
+	}
+
+	lines := strings.Split(proxyStatus, "\n")
+	var versionStr string
+	for _, line := range lines {
+		if strings.Contains(line, podName+"."+namespace) {
+			values := strings.Fields(line)
+			versionStr = values[len(values)-1]
+			break
+		}
+	}
+
+	version, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return version, fmt.Errorf("error parsing sidecar version %q: %w", versionStr, err)
+	}
+	return version, err
 }

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -130,7 +130,7 @@ spec:
 					Success("sample pods are ready")
 
 					for _, pod := range samplePods.Items {
-						sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
+						sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
 						Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
 						Expect(sidecarVersion).To(Equal(istioversion.Map[istioversion.Base].Version), "Sidecar Istio version does not match the expected version")
 					}
@@ -203,7 +203,7 @@ spec:
 
 					for _, pod := range samplePods.Items {
 						Eventually(func() *semver.Version {
-							sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
+							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
 							Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
 							return sidecarVersion
 						}).Should(Equal(istioversion.Map[istioversion.Base].Version), "Sidecar Istio version does not match the expected version")
@@ -241,7 +241,7 @@ spec:
 						}
 
 						for _, pod := range samplePods.Items {
-							sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
+							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
 							if err != nil || !sidecarVersion.Equal(istioversion.Map[istioversion.New].Version) {
 								return false
 							}

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -288,29 +288,6 @@ func GetVersionFromIstiod() (*semver.Version, error) {
 	return nil, fmt.Errorf("error getting version from istiod: version not found in output: %s", output)
 }
 
-func GetProxyVersion(podName, namespace string) (*semver.Version, error) {
-	proxyStatus, err := istioctl.GetProxyStatus()
-	if err != nil {
-		return nil, fmt.Errorf("error getting sidecar version: %w", err)
-	}
-
-	lines := strings.Split(proxyStatus, "\n")
-	var versionStr string
-	for _, line := range lines {
-		if strings.Contains(line, podName+"."+namespace) {
-			values := strings.Fields(line)
-			versionStr = values[len(values)-1]
-			break
-		}
-	}
-
-	version, err := semver.NewVersion(versionStr)
-	if err != nil {
-		return version, fmt.Errorf("error parsing sidecar version %q: %w", versionStr, err)
-	}
-	return version, err
-}
-
 func isPodReady(pod *corev1.Pod) bool {
 	for _, cond := range pod.Status.Conditions {
 		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

This is for using `istioctl proxy-status` output to get the proxy version instead of execute a curl command.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #671 

#### Additional information:
