### PR TITLE
API transformer: map MeshConfigServiceScopeConfigs fields

### DIFF
--- a/hack/api_transformer/transform.yaml
+++ b/hack/api_transformer/transform.yaml
@@ -162,6 +162,8 @@ inputFiles:
       MeshConfig.DiscoverySelectors: "[]*metav1.LabelSelector"
       ConfigSource.TlsSettings: "*ClientTLSSettings"
       MeshConfig_CA.TlsSettings: "*ClientTLSSettings"
+      MeshConfig_ServiceScopeConfigs.NamespaceSelector: "*metav1.LabelSelector"
+      MeshConfig_ServiceScopeConfigs.ServicesSelector: "*metav1.LabelSelector"
     removeTypes:
     - LabelSelector
     - LabelSelectorRequirement


### PR DESCRIPTION
Maps NamespaceSelector and ServicesSelector to *metav1.LabelSelector.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Adds type mappings for the fields named above, to fix API code generation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Related Issue/PR #1016 

#### Additional information:
ref. https://github.com/istio-ecosystem/sail-operator/actions/runs/16284568700/job/45980697680#step:5:465 for the Automator error log about this.