### PR TITLE
[release-1.26] cherry-pick of "add postrender logic to not set validating webhook failurePolicy (#1042)"

### DIFF
--- a/pkg/helm/chartmanager.go
+++ b/pkg/helm/chartmanager.go
@@ -112,7 +112,7 @@ func (h *ChartManager) UpgradeOrInstallChart(
 		log.V(2).Info("Performing helm upgrade", "chartName", chart.Name())
 
 		updateAction := action.NewUpgrade(cfg)
-		updateAction.PostRenderer = NewHelmPostRenderer(ownerReference, "")
+		updateAction.PostRenderer = NewHelmPostRenderer(ownerReference, "", true)
 		updateAction.MaxHistory = 1
 		updateAction.SkipCRDs = true
 
@@ -124,7 +124,7 @@ func (h *ChartManager) UpgradeOrInstallChart(
 		log.V(2).Info("Performing helm install", "chartName", chart.Name())
 
 		installAction := action.NewInstall(cfg)
-		installAction.PostRenderer = NewHelmPostRenderer(ownerReference, "")
+		installAction.PostRenderer = NewHelmPostRenderer(ownerReference, "", false)
 		installAction.Namespace = namespace
 		installAction.ReleaseName = releaseName
 		installAction.SkipCRDs = true

--- a/pkg/helm/postrenderer.go
+++ b/pkg/helm/postrenderer.go
@@ -16,12 +16,14 @@ package helm
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/constants"
 	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/postrender"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,16 +37,20 @@ const (
 // NewHelmPostRenderer creates a Helm PostRenderer that adds the following to each rendered manifest:
 // - adds the "managed-by: sail-operator" label
 // - adds the specified OwnerReference
-func NewHelmPostRenderer(ownerReference *metav1.OwnerReference, ownerNamespace string) postrender.PostRenderer {
+// It also removes the failurePolicy field from ValidatingWebhookConfigurations on updates, so
+// the in-cluster setting stays as-is, to prevent clashing with the istiod validation controller.
+func NewHelmPostRenderer(ownerReference *metav1.OwnerReference, ownerNamespace string, isUpdate bool) postrender.PostRenderer {
 	return HelmPostRenderer{
 		ownerReference: ownerReference,
 		ownerNamespace: ownerNamespace,
+		isUpdate:       isUpdate,
 	}
 }
 
 type HelmPostRenderer struct {
 	ownerReference *metav1.OwnerReference
 	ownerNamespace string
+	isUpdate       bool
 }
 
 var _ postrender.PostRenderer = HelmPostRenderer{}
@@ -78,11 +84,56 @@ func (pr HelmPostRenderer) Run(renderedManifests *bytes.Buffer) (modifiedManifes
 			return nil, err
 		}
 
+		// Strip ValidatingWebhookConfiguration webhooks[].failurePolicy field if we're upgrading,
+		// to avoid overwriting the value set in-cluster by the istiod validation controller. On
+		// initial install we still want to set the field per the Helm template.
+		if pr.isUpdate {
+			manifest, err = pr.removeValidatingWebhookFailurePolicy(manifest)
+			if err != nil {
+				return nil, fmt.Errorf("error removing ValidatingWebhookConfiguration failurePolicy: %v", err)
+			}
+		}
+
 		if err := encoder.Encode(manifest); err != nil {
 			return nil, err
 		}
 	}
 	return modifiedManifests, nil
+}
+
+func (pr HelmPostRenderer) removeValidatingWebhookFailurePolicy(manifest map[string]any) (map[string]any, error) {
+	apiVersion, _, _ := unstructured.NestedString(manifest, "apiVersion")
+	if apiVersion != admissionregistrationv1.SchemeGroupVersion.String() {
+		return manifest, nil
+	}
+	kind, _, _ := unstructured.NestedString(manifest, "kind")
+	if kind != "ValidatingWebhookConfiguration" {
+		return manifest, nil
+	}
+
+	webhooksAny, found, err := unstructured.NestedFieldNoCopy(manifest, "webhooks")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return manifest, nil
+	}
+
+	webhooks, ok := webhooksAny.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected webhooks to be []interface{}, got %T", webhooksAny)
+	}
+
+	for _, webhookAny := range webhooks {
+		webhook, ok := webhookAny.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("expected webhook to be map[string]interface{}, got %T", webhookAny)
+		}
+
+		delete(webhook, "failurePolicy")
+	}
+
+	return manifest, nil
 }
 
 func (pr HelmPostRenderer) addOwnerReference(manifest map[string]any) (map[string]any, error) {

--- a/tests/integration/api/istiobase_test.go
+++ b/tests/integration/api/istiobase_test.go
@@ -236,9 +236,14 @@ var _ = Describe("base chart support", Ordered, func() {
 				}, func(obj client.Object) {
 					webhook := obj.(*admissionv1.ValidatingWebhookConfiguration)
 					webhook.Webhooks[0].Name = "xyz.xyz.xyz"
+					webhook.Webhooks[0].FailurePolicy = ptr.Of(admissionv1.Fail)
 				}, func(g Gomega, obj client.Object) {
 					webhook := obj.(*admissionv1.ValidatingWebhookConfiguration)
 					g.Expect(webhook.Webhooks[0].Name).ToNot(Equal("xyz.xyz.xyz"))
+					// FailurePolicy should not be changed because we have a post-render
+					// step to remove it from the Helm generated YAML so it stays as-is
+					// in cluster.
+					g.Expect(webhook.Webhooks[0].FailurePolicy).To(HaveValue(Equal(admissionv1.Fail)))
 				}),
 		)
 

--- a/tests/integration/api/istiorevision_test.go
+++ b/tests/integration/api/istiorevision_test.go
@@ -460,6 +460,23 @@ var _ = Describe("IstioRevision resource", Ordered, func() {
 				hpa := obj.(*autoscalingv2.HorizontalPodAutoscaler)
 				g.Expect(hpa.Spec.MaxReplicas).ToNot(Equal(int32(123)))
 			}),
+		Entry("ValidatingWebhookConfiguration",
+			&admissionv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("istio-validator-%s-%s", revName, istioNamespace),
+				},
+			}, func(obj client.Object) {
+				webhook := obj.(*admissionv1.ValidatingWebhookConfiguration)
+				webhook.Webhooks[0].Name = "xyz.xyz.xyz"
+				webhook.Webhooks[0].FailurePolicy = ptr.Of(admissionv1.Fail)
+			}, func(g Gomega, obj client.Object) {
+				webhook := obj.(*admissionv1.ValidatingWebhookConfiguration)
+				g.Expect(webhook.Webhooks[0].Name).ToNot(Equal("xyz.xyz.xyz"))
+				// FailurePolicy should not be changed because we have a post-render
+				// step to remove it from the Helm generated YAML so it stays as-is
+				// in cluster.
+				g.Expect(webhook.Webhooks[0].FailurePolicy).To(HaveValue(Equal(admissionv1.Fail)))
+			}),
 	)
 
 	DescribeTable("skips reconcile when only the status of the owned resource is updated",


### PR DESCRIPTION
When updating, don't set the validating webhook configuration's failurePolicy, so the in-cluster setting can stay as-is. This prevents conflicts with istiod's validation controller, which sets this field to 'Fail' once the webhook is confirmed to be ready to handle requests.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Manual cherry-pick of #1042 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #1046 

Related Issue/PR #

#### Additional information:
