### PR TITLE
Modify MultiControlPlane Test to run for all supported versions (#972)

### DIFF
--- a/tests/e2e/multicontrolplane/multi_control_plane_suite_test.go
+++ b/tests/e2e/multicontrolplane/multi_control_plane_suite_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/env"
-	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
 	. "github.com/onsi/ginkgo/v2"
@@ -32,7 +31,6 @@ var (
 	cl  client.Client
 	err error
 	// version will be the first version in the list, this version is the newest Istio version in the versions.yaml file
-	version                = istioversion.New
 	controlPlaneNamespace1 = env.Get("CONTROL_PLANE_NS1", "istio-system1")
 	controlPlaneNamespace2 = env.Get("CONTROL_PLANE_NS2", "istio-system2")
 	istioName1             = env.Get("ISTIO_NAME1", "mesh1")

--- a/tests/e2e/multicontrolplane/multi_control_plane_test.go
+++ b/tests/e2e/multicontrolplane/multi_control_plane_test.go
@@ -10,7 +10,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR Condition OF ANY KIND, either express or implied.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
@@ -24,6 +24,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	. "github.com/onsi/ginkgo/v2"
@@ -36,118 +37,152 @@ var _ = Describe("Multi control plane deployment model", Label("smoke", "multico
 	SetDefaultEventuallyTimeout(180 * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false
+	latestVersion := istioversion.GetLatestPatchVersions()[0]
 
-	Describe("Installation", func() {
-		It("Sets up namespaces", func(ctx SpecContext) {
-			Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
-			Expect(k.CreateNamespace(controlPlaneNamespace1)).To(Succeed(), "Istio namespace failed to be created")
-			Expect(k.CreateNamespace(controlPlaneNamespace2)).To(Succeed(), "Istio namespace failed to be created")
+	Describe("for supported versions", func() {
+		for _, version := range istioversion.GetLatestPatchVersions() {
+			Context(fmt.Sprintf("Istio version %s", version.Version), func() {
+				clr := cleaner.New(cl)
 
-			Expect(k.Label("namespace", controlPlaneNamespace1, "mesh", istioName1)).To(Succeed(), "Failed to label namespace")
-			Expect(k.Label("namespace", controlPlaneNamespace2, "mesh", istioName2)).To(Succeed(), "Failed to label namespace")
-		})
+				BeforeAll(func(ctx SpecContext) {
+					clr.Record(ctx)
+				})
 
-		It("Installs IstioCNI", func(ctx SpecContext) {
-			common.CreateIstioCNI(k, version)
+				Describe("Installation", func() {
+					It("Sets up namespaces", func(ctx SpecContext) {
+						Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
+						Expect(k.CreateNamespace(controlPlaneNamespace1)).To(Succeed(), "Istio namespace failed to be created")
+						Expect(k.CreateNamespace(controlPlaneNamespace2)).To(Succeed(), "Istio namespace failed to be created")
 
-			Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(istioCniName), &v1.IstioCNI{}).
-				Should(HaveConditionStatus(v1.IstioCNIConditionReady, metav1.ConditionTrue), "IstioCNI is not Ready; unexpected Condition")
-			Success("IstioCNI is Ready")
-		})
+						Expect(k.Label("namespace", controlPlaneNamespace1, "mesh", istioName1)).To(Succeed(), "Failed to label namespace")
+						Expect(k.Label("namespace", controlPlaneNamespace2, "mesh", istioName2)).To(Succeed(), "Failed to label namespace")
+					})
 
-		DescribeTable("Installs Istios",
-			Entry("Mesh 1", istioName1, controlPlaneNamespace1),
-			Entry("Mesh 2", istioName2, controlPlaneNamespace2),
-			func(ctx SpecContext, name, ns string) {
-				Expect(k.CreateFromString(`
+					It("Installs IstioCNI", func(ctx SpecContext) {
+						common.CreateIstioCNI(k, latestVersion.Name)
+
+						Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(istioCniName), &v1.IstioCNI{}).
+							Should(HaveConditionStatus(v1.IstioCNIConditionReady, metav1.ConditionTrue), "IstioCNI is not Ready; unexpected Condition")
+						Success("IstioCNI is Ready")
+					})
+
+					DescribeTable("Installs Istios",
+						Entry("Mesh 1", istioName1, controlPlaneNamespace1, latestVersion.Name),
+						Entry("Mesh 2", istioName2, controlPlaneNamespace2, version.Name),
+						func(ctx SpecContext, name, ns, version string) {
+							Expect(k.CreateFromString(fmt.Sprintf(`
 apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
-  name: `+name+`
+  name: %s
 spec:
-  version: `+version+`
-  namespace: `+ns+`
+  version: %s
+  namespace: %s
   values:
     meshConfig:
       discoverySelectors:
-      - matchLabels:
-          mesh: `+name)).To(Succeed(), "failed to create Istio CR")
+        - matchLabels:
+            mesh: %s`, name, version, ns, name))).To(Succeed(), "failed to create Istio CR")
 
-				Expect(k.CreateFromString(`
+							Expect(k.CreateFromString(fmt.Sprintf(`
 apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
-  namespace: `+ns+`
+  namespace: %s
 spec:
   mtls:
-    mode: STRICT`)).To(Succeed(), "failed to create PeerAuthentication")
+    mode: STRICT`, ns))).To(Succeed(), "failed to create PeerAuthentication")
+						},
+					)
+
+					DescribeTable("Waits for Istios",
+						Entry("Mesh 1", istioName1),
+						Entry("Mesh 2", istioName2),
+						func(ctx SpecContext, name string) {
+							Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(name), &v1.Istio{}).
+								Should(
+									And(
+										HaveConditionStatus(v1.IstioConditionReconciled, metav1.ConditionTrue),
+										HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue),
+									), "Istio is not Reconciled and Ready; unexpected Condition")
+							Success(fmt.Sprintf("Istio %s ready", name))
+						})
+
+					DescribeTable("Deploys applications",
+						Entry("App 1", appNamespace1, istioName1),
+						Entry("App 2a", appNamespace2a, istioName2),
+						Entry("App 2b", appNamespace2b, istioName2),
+						func(ns, mesh string) {
+							var ver string
+							if mesh == istioName1 {
+								ver = latestVersion.Name
+							} else {
+								ver = version.Name
+							}
+
+							Expect(k.CreateNamespace(ns)).To(Succeed(), "Failed to create namespace")
+							Expect(k.Label("namespace", ns, "mesh", mesh)).To(Succeed(), "Failed to label namespace")
+							Expect(k.Label("namespace", ns, "istio.io/rev", mesh)).To(Succeed(), "Failed to label namespace")
+
+							for _, appName := range []string{"sleep", "httpbin"} {
+								Expect(k.WithNamespace(ns).
+									Apply(common.GetSampleYAML(istioversion.Map[ver], appName))).
+									To(Succeed(), "Failed to deploy application")
+							}
+
+							Success(fmt.Sprintf("Applications in namespace %s deployed", ns))
+						},
+					)
+
+					DescribeTable("Waits for apps to be ready",
+						Entry("App 1", appNamespace1),
+						Entry("App 2a", appNamespace2a),
+						Entry("App 2b", appNamespace2b),
+						func(ctx SpecContext, ns string) {
+							for _, deployment := range []string{"sleep", "httpbin"} {
+								Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(deployment, ns), &appsv1.Deployment{}).
+									Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error waiting for deployment to be available")
+							}
+							Success(fmt.Sprintf("Applications in namespace %s ready", ns))
+						})
+				})
+
+				Describe("Verification", func() {
+					It("Verifies app2a cannot connect to app1", func(ctx SpecContext) {
+						output, err := k.WithNamespace(appNamespace2a).
+							Exec("deploy/sleep", "sleep", fmt.Sprintf("curl -sIL http://httpbin.%s:8000", appNamespace1))
+						Expect(err).NotTo(HaveOccurred(), "error running curl in sleep pod")
+						Expect(output).To(ContainSubstring("503 Service Unavailable"), fmt.Sprintf("Unexpected response from sleep pod in namespace %s", appNamespace1))
+						Success("As expected, app2a in mesh2 is not allowed to communicate with app1 in mesh1")
+					})
+
+					It("Verifies app2a can connect to app2b", func(ctx SpecContext) {
+						output, err := k.WithNamespace(appNamespace2a).
+							Exec("deploy/sleep", "sleep", fmt.Sprintf("curl -sIL http://httpbin.%s:8000", appNamespace2b))
+						Expect(err).NotTo(HaveOccurred(), "error running curl in sleep pod")
+						Expect(output).To(ContainSubstring("200 OK"), fmt.Sprintf("Unexpected response from sleep pod in namespace %s", appNamespace2b))
+						Success("As expected, app2a in mesh2 can communicate with app2b in the same mesh")
+					})
+				})
+
+				AfterAll(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.ControlPlane, k)
+						debugInfoLogged = true
+					}
+					clr.Cleanup(ctx)
+				})
 			})
-
-		DescribeTable("Waits for Istios",
-			Entry("Mesh 1", istioName1),
-			Entry("Mesh 2", istioName2),
-			func(ctx SpecContext, name string) {
-				Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(name), &v1.Istio{}).
-					Should(
-						And(
-							HaveConditionStatus(v1.IstioConditionReconciled, metav1.ConditionTrue),
-							HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue),
-						), "Istio is not Reconciled and Ready; unexpected Condition")
-				Success(fmt.Sprintf("Istio %s ready", name))
-			})
-
-		DescribeTable("Deploys applications",
-			Entry("App 1", appNamespace1, istioName1),
-			Entry("App 2a", appNamespace2a, istioName2),
-			Entry("App 2b", appNamespace2b, istioName2),
-			func(ns, mesh string) {
-				Expect(k.CreateNamespace(ns)).To(Succeed(), "Failed to create namespace")
-				Expect(k.Label("namespace", ns, "mesh", mesh)).To(Succeed(), "Failed to label namespace")
-				Expect(k.Label("namespace", ns, "istio.io/rev", mesh)).To(Succeed(), "Failed to label namespace")
-				for _, appName := range []string{"sleep", "httpbin"} {
-					Expect(k.WithNamespace(ns).
-						Apply(common.GetSampleYAML(istioversion.Map[version], appName))).
-						To(Succeed(), "Failed to deploy application")
-				}
-				Success(fmt.Sprintf("Applications in namespace %s deployed", ns))
-			})
-
-		DescribeTable("Waits for apps to be ready",
-			Entry("App 1", appNamespace1),
-			Entry("App 2a", appNamespace2a),
-			Entry("App 2b", appNamespace2b),
-			func(ctx SpecContext, ns string) {
-				for _, deployment := range []string{"sleep", "httpbin"} {
-					Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(deployment, ns), &appsv1.Deployment{}).
-						Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error waiting for deployment to be available")
-				}
-				Success(fmt.Sprintf("Applications in namespace %s ready", ns))
-			})
-	})
-
-	Describe("Verification", func() {
-		It("Verifies app2a cannot connect to app1", func(ctx SpecContext) {
-			output, err := k.WithNamespace(appNamespace2a).
-				Exec("deploy/sleep", "sleep", fmt.Sprintf("curl -sIL http://httpbin.%s:8000", appNamespace1))
-			Expect(err).NotTo(HaveOccurred(), "error running curl in sleep pod")
-			Expect(output).To(ContainSubstring("503 Service Unavailable"), fmt.Sprintf("Unexpected response from sleep pod in namespace %s", appNamespace1))
-			Success("As expected, app2a in mesh2 is not allowed to communicate with app1 in mesh1")
-		})
-
-		It("Verifies app2a can connect to app2b", func(ctx SpecContext) {
-			output, err := k.WithNamespace(appNamespace2a).
-				Exec("deploy/sleep", "sleep", fmt.Sprintf("curl -sIL http://httpbin.%s:8000", appNamespace2b))
-			Expect(err).NotTo(HaveOccurred(), "error running curl in sleep pod")
-			Expect(output).To(ContainSubstring("200 OK"), fmt.Sprintf("Unexpected response from sleep pod in namespace %s", appNamespace2b))
-			Success("As expected, app2a in mesh2 can communicate with app2b in the same mesh")
-		})
-	})
-
-	AfterAll(func(ctx SpecContext) {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.MultiControlPlane, k)
-			debugInfoLogged = true
 		}
+
+		AfterAll(func(ctx SpecContext) {
+			if CurrentSpecReport().Failed() {
+				if !debugInfoLogged {
+					common.LogDebugInfo(common.MultiControlPlane, k)
+					debugInfoLogged = true
+				}
+			}
+		})
 	})
 })


### PR DESCRIPTION
This PR https://github.com/istio-ecosystem/sail-operator/pull/972 was not automatically backported to release-3.1 branch

Resolves https://github.com/istio-ecosystem/sail-operator/issues/986