### PR TITLE
Add cleaner to operator install test

### DIFF
--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	. "github.com/onsi/ginkgo/v2"
@@ -60,6 +61,11 @@ var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
 	SetDefaultEventuallyPollingInterval(time.Second)
 
 	Describe("installation", func() {
+		clr := cleaner.New(cl)
+		BeforeAll(func(ctx SpecContext) {
+			clr.Record(ctx)
+		})
+
 		It("deploys all the CRDs", func(ctx SpecContext) {
 			Eventually(common.GetList).WithArguments(ctx, cl, &apiextensionsv1.CustomResourceDefinitionList{}).
 				Should(WithTransform(extractCRDNames, ContainElements(sailCRDs)),
@@ -182,6 +188,7 @@ spec:
 			if CurrentSpecReport().Failed() {
 				common.LogDebugInfo(common.Operator, k)
 			}
+			clr.Cleanup(ctx)
 		})
 	})
 


### PR DESCRIPTION
Add a cleaner to clean up resources (`clusterrolebindings metrics-reader-rolebinding` and `job curl-metrics`) which are created in the operator install test. (to be able to run the sail e2e test more times in a row on the same cluster)