### PR TITLE
Do not patch values defined by a vendor

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -499,7 +499,7 @@ operator-chart: download-istio-charts # pull the charts first as they are requir
 	       -e "s/^\(  version: \).*$$/\1${VERSION}/g" chart/values.yaml
 	# adding all component images to values
 	# when building the bundle, helm generated base CSV is passed to the operator-sdk. With USE_IMAGE_DIGESTS=true, operator-sdk replaces all pullspecs with tags by digests and adds spec.relatedImages field automatically
-	@hack/patch-values.sh ${HELM_VALUES_FILE}
+	@hack/patch-values.sh chart/values.yaml
 
 .PHONY: update-istio
 update-istio: ## Update the Istio commit hash in the 'latest' entry in versions.yaml to the latest commit in the branch.


### PR DESCRIPTION
We only want to patch default values used by upstream sail operator but we don't want to touch values defined by a vendor as those are edited only manually.

