### PR TITLE
[release-1.26] Don't do digest pinning by default

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -151,7 +151,7 @@ BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 # It also adds .spec.relatedImages field to generated CSV
 # Note that 'operator-sdk generate bundle' always removes spec.relatedImages field when USE_IMAGE_DIGESTS=false, even if the field already exists in the base CSV
 # Make sure to enable this before creating a release as it's a requirement for disconnected environments.
-USE_IMAGE_DIGESTS ?= true
+USE_IMAGE_DIGESTS ?= false
 ifeq ($(USE_IMAGE_DIGESTS), true)
 	BUNDLE_GEN_FLAGS += --use-image-digests
 endif

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -33,8 +33,8 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
-    containerImage: quay.io/sail-dev/sail-operator@sha256:65abc23ea9de01fdc2eaeb89de933900e01410fe4f1acc2a3715ecc3f930fd3d
-    createdAt: "2025-07-30T07:58:58Z"
+    containerImage: quay.io/sail-dev/sail-operator:1.26.2
+    createdAt: "2025-08-01T09:45:12Z"
     description: The Sail Operator manages the lifecycle of your Istio control plane. It provides custom resources for you to deploy and manage your control plane components.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -688,58 +688,58 @@ spec:
             template:
               metadata:
                 annotations:
-                  images.v1_24_0.cni: gcr.io/istio-release/install-cni@sha256:4b10d810228e553bf34924222b7d62fdfafbce5ed67dc54973d168bda384a4cd
-                  images.v1_24_0.istiod: gcr.io/istio-release/pilot@sha256:e082a6f27001101942d1e2be71764b17ad350ed0d289038020426e7ee603eb56
-                  images.v1_24_0.proxy: gcr.io/istio-release/proxyv2@sha256:ee6565e57319e01b5e45b929335eb9dc3d4b30d531b4652467e6939ae81b41f7
-                  images.v1_24_0.ztunnel: gcr.io/istio-release/ztunnel@sha256:2402a1c71dce11c409b6da171d8ae27dff62c539d58aac41817499e1fcd7beb3
-                  images.v1_24_1.cni: gcr.io/istio-release/install-cni@sha256:d241cd11295b7c7af6c1c7e22096db886b07ab1945b4b7b2fe3d7f95ef41b277
-                  images.v1_24_1.istiod: gcr.io/istio-release/pilot@sha256:c8ac4894f2e667eb439d1c960a47ac7fbc80aad3f0adb98f5fd9330d9c515696
-                  images.v1_24_1.proxy: gcr.io/istio-release/proxyv2@sha256:a5f2c1804ac4397448149b63a67f6cfd1979d304b99a726667a4859d201c6305
-                  images.v1_24_1.ztunnel: gcr.io/istio-release/ztunnel@sha256:74ee23f374ea28b3455ad2eca2bea62da95bc2a23b865b7c8c301139046650d5
-                  images.v1_24_2.cni: gcr.io/istio-release/install-cni@sha256:7b12bcfabd92c5756e4b12bf82e373f4abcdd3ccf81ac0b93fe0aa6f8ccce63c
-                  images.v1_24_2.istiod: gcr.io/istio-release/pilot@sha256:f0bcb10a51dbb2b9e5552e7f82aa7fcc2ff4dd6d0d7d2224986036b1645b855b
-                  images.v1_24_2.proxy: gcr.io/istio-release/proxyv2@sha256:445156b5f4a780242d079a47b7d88199cbbb5959c92358469b721af490eca1ae
-                  images.v1_24_2.ztunnel: gcr.io/istio-release/ztunnel@sha256:56afd26e9384ff41a0244a8c637a0e3aa8654015b8d32b494df8b5023f213ec7
-                  images.v1_24_3.cni: gcr.io/istio-release/install-cni@sha256:3107b1947e755abe698fe2d5c3ed7ba5f228f0b4ff5ff30f484fcc984514b97e
-                  images.v1_24_3.istiod: gcr.io/istio-release/pilot@sha256:7ccda8c22307ee796cb7ba3f4ce224ef533c3c683c063dcc92fd5a244d8a5c9d
-                  images.v1_24_3.proxy: gcr.io/istio-release/proxyv2@sha256:534f7589b085450b5b94e6c955f5106892df88d81676f53ac5e06a0cf5ec45da
-                  images.v1_24_3.ztunnel: gcr.io/istio-release/ztunnel@sha256:eaae7b8ed53a3f18b0291f08db0e3330d7c958d39919fce9dbc43f3027bf2089
-                  images.v1_24_4.cni: gcr.io/istio-release/install-cni@sha256:1d963aca195f1e06459925431c592cf556112d77b824c61e06555fbc31ee415f
-                  images.v1_24_4.istiod: gcr.io/istio-release/pilot@sha256:21b6cdaf12e7eb8bb0ad1d493c32a76e7d34f574a41ece86ded0c79e7191e875
-                  images.v1_24_4.proxy: gcr.io/istio-release/proxyv2@sha256:2edf332e1c7ddd46466e337d009eda091bcd43f827b6f460175b772addc8055a
-                  images.v1_24_4.ztunnel: gcr.io/istio-release/ztunnel@sha256:73b3ad311c9c9a2618e9c2f10259a3bf5414bb4fc6fd407baa6280bdd8d227f0
-                  images.v1_24_5.cni: gcr.io/istio-release/install-cni@sha256:a80a96d9e4e859d1568fe1db1b12525db8c26d153e4bb783ba4efb3c5b16f877
-                  images.v1_24_5.istiod: gcr.io/istio-release/pilot@sha256:29cccf38a413fe81a88d02e0bf924ca84a9cf1d6a3c9ece024c0636b1e3cb029
-                  images.v1_24_5.proxy: gcr.io/istio-release/proxyv2@sha256:2cd83a25202af6c5aef48b432f7fed50b6de460c795ce7c84f80bf630f51ca4d
-                  images.v1_24_5.ztunnel: gcr.io/istio-release/ztunnel@sha256:ca14b3f869aa998da30c6f8f8d14b2e9cd61a40b78b05196b951cac9613d76d8
-                  images.v1_24_6.cni: gcr.io/istio-release/install-cni@sha256:d85b955875b2fbfc2ca8166cf2aa0e4ac3d78dd00f4ec4140a2a22dd17e7deb9
-                  images.v1_24_6.istiod: gcr.io/istio-release/pilot@sha256:93d6b52a61e7e9891fe114e4f7d503b36e8d1566a22e82e5635084a2001eb14a
-                  images.v1_24_6.proxy: gcr.io/istio-release/proxyv2@sha256:91382859f73b1a66ac113631f89ef73dabf9c931d6baf0bd7eb618c0fa958b34
-                  images.v1_24_6.ztunnel: gcr.io/istio-release/ztunnel@sha256:96daeeb4e71a304edbf2ee2d37bc4bd4b88b9da26d7e6cc0c34c94c1cd6e6cca
-                  images.v1_25_1.cni: gcr.io/istio-release/install-cni@sha256:0f27cb9e3423a3ed8a444dd2137ae05f31a03df2bdd549b21ef8f0f3949e3cef
-                  images.v1_25_1.istiod: gcr.io/istio-release/pilot@sha256:4ad6b0c3839a11622e66323a1296c7fc19dcbbb2c371b2e3edd58bd4f763f19f
-                  images.v1_25_1.proxy: gcr.io/istio-release/proxyv2@sha256:640733abb924663df83761e2ec95a2bddca797daf1ca37672ec0b045969cdeb1
-                  images.v1_25_1.ztunnel: gcr.io/istio-release/ztunnel@sha256:45807d4c512e9a0e4855eb1a2535532319b698302ebbf4d4eaccf462997bb374
-                  images.v1_25_2.cni: gcr.io/istio-release/install-cni@sha256:d28af093e5b7f33e8750364e9077c8b2c464145d1904cae8be48227ec0110b04
-                  images.v1_25_2.istiod: gcr.io/istio-release/pilot@sha256:2961bf88463e475f1e53d82a118405841ecbb9d8a6e0b35c73c77bee53bc0c3e
-                  images.v1_25_2.proxy: gcr.io/istio-release/proxyv2@sha256:49ed9dd2c06383c0a847877a707a3563d0968d83779ad8d13a0c022a48c5c407
-                  images.v1_25_2.ztunnel: gcr.io/istio-release/ztunnel@sha256:ae90c4e06a4560898dbf414226e3ea879b8d0b10387af27b0c2907e8488fc5d1
-                  images.v1_25_3.cni: gcr.io/istio-release/install-cni@sha256:313165b70241f65c79b5984797b8e3bc43a264acfeaeda4f33fe3a7f89a2fdb8
-                  images.v1_25_3.istiod: gcr.io/istio-release/pilot@sha256:32d0f6bd6c1259de78dbc79dfd88cf5f4dc8941613560ff2ca7dbabcf04dfd68
-                  images.v1_25_3.proxy: gcr.io/istio-release/proxyv2@sha256:d62cc7585450bce8573338c3d147961f4e1df045ffcf5956abea29841cb5aaa4
-                  images.v1_25_3.ztunnel: gcr.io/istio-release/ztunnel@sha256:0e680a1b33d458e5dfd6f91808c8bd61d00a1103084545ea6a1956c935e7554e
-                  images.v1_26_0.cni: gcr.io/istio-release/install-cni@sha256:313c8b38e89137cb455ee96891c2dc5b69f2907b13af324f0cac8b140897f107
-                  images.v1_26_0.istiod: gcr.io/istio-release/pilot@sha256:0bb4d26e88b61cd2f81d39378111a38a151ec5bf0cb65be49c20d1ef41956299
-                  images.v1_26_0.proxy: gcr.io/istio-release/proxyv2@sha256:bc19e6e0978569a7cc886f3dececc3cb3613cf6e457ddf09e3cb849a2b315231
-                  images.v1_26_0.ztunnel: gcr.io/istio-release/ztunnel@sha256:e3bc4444deb33641b53883a54fff0b11ed4f95c86335dc9af02ab89a9dfe2e46
-                  images.v1_26_1.cni: gcr.io/istio-release/install-cni@sha256:8e782f5077f63c0a15fd4b9a4fa75f8543033c28ccf2457e25afbf1aefb6a72a
-                  images.v1_26_1.istiod: gcr.io/istio-release/pilot@sha256:c4e33921e030bb22d3b8fabc693851d52c07a7af79a9534addc2f50005fa462a
-                  images.v1_26_1.proxy: gcr.io/istio-release/proxyv2@sha256:fd734e6031566b4fb92be38f0f6bb02fdba6c199c45c2db5dc988bbc4fdee026
-                  images.v1_26_1.ztunnel: gcr.io/istio-release/ztunnel@sha256:2d567893e5b452d5c0b9c43a43efd4f8e28e639a344e28d90498f13858f13d46
-                  images.v1_26_2.cni: gcr.io/istio-release/install-cni@sha256:9a0ee38b9b1c6240bc71e58cc1f5a9c6963860a98c3b3655955fc47be9b7cf42
-                  images.v1_26_2.istiod: gcr.io/istio-release/pilot@sha256:1d4fbb7859e515b85b6c2c4787224e4e7cba73aad4573d98e2a83cc028cad392
-                  images.v1_26_2.proxy: gcr.io/istio-release/proxyv2@sha256:921c5ce2c5122facd9a25a7f974aaa4d3679cee38cb3f809e10618384fc3ce7f
-                  images.v1_26_2.ztunnel: gcr.io/istio-release/ztunnel@sha256:fabda07d39993a740b69a54bcb6218eccaaf8fa6b4bcdb733664baf729ec9b21
+                  images.v1_24_0.cni: gcr.io/istio-release/install-cni:1.24.0
+                  images.v1_24_0.istiod: gcr.io/istio-release/pilot:1.24.0
+                  images.v1_24_0.proxy: gcr.io/istio-release/proxyv2:1.24.0
+                  images.v1_24_0.ztunnel: gcr.io/istio-release/ztunnel:1.24.0
+                  images.v1_24_1.cni: gcr.io/istio-release/install-cni:1.24.1
+                  images.v1_24_1.istiod: gcr.io/istio-release/pilot:1.24.1
+                  images.v1_24_1.proxy: gcr.io/istio-release/proxyv2:1.24.1
+                  images.v1_24_1.ztunnel: gcr.io/istio-release/ztunnel:1.24.1
+                  images.v1_24_2.cni: gcr.io/istio-release/install-cni:1.24.2
+                  images.v1_24_2.istiod: gcr.io/istio-release/pilot:1.24.2
+                  images.v1_24_2.proxy: gcr.io/istio-release/proxyv2:1.24.2
+                  images.v1_24_2.ztunnel: gcr.io/istio-release/ztunnel:1.24.2
+                  images.v1_24_3.cni: gcr.io/istio-release/install-cni:1.24.3
+                  images.v1_24_3.istiod: gcr.io/istio-release/pilot:1.24.3
+                  images.v1_24_3.proxy: gcr.io/istio-release/proxyv2:1.24.3
+                  images.v1_24_3.ztunnel: gcr.io/istio-release/ztunnel:1.24.3
+                  images.v1_24_4.cni: gcr.io/istio-release/install-cni:1.24.4
+                  images.v1_24_4.istiod: gcr.io/istio-release/pilot:1.24.4
+                  images.v1_24_4.proxy: gcr.io/istio-release/proxyv2:1.24.4
+                  images.v1_24_4.ztunnel: gcr.io/istio-release/ztunnel:1.24.4
+                  images.v1_24_5.cni: gcr.io/istio-release/install-cni:1.24.5
+                  images.v1_24_5.istiod: gcr.io/istio-release/pilot:1.24.5
+                  images.v1_24_5.proxy: gcr.io/istio-release/proxyv2:1.24.5
+                  images.v1_24_5.ztunnel: gcr.io/istio-release/ztunnel:1.24.5
+                  images.v1_24_6.cni: gcr.io/istio-release/install-cni:1.24.6
+                  images.v1_24_6.istiod: gcr.io/istio-release/pilot:1.24.6
+                  images.v1_24_6.proxy: gcr.io/istio-release/proxyv2:1.24.6
+                  images.v1_24_6.ztunnel: gcr.io/istio-release/ztunnel:1.24.6
+                  images.v1_25_1.cni: gcr.io/istio-release/install-cni:1.25.1
+                  images.v1_25_1.istiod: gcr.io/istio-release/pilot:1.25.1
+                  images.v1_25_1.proxy: gcr.io/istio-release/proxyv2:1.25.1
+                  images.v1_25_1.ztunnel: gcr.io/istio-release/ztunnel:1.25.1
+                  images.v1_25_2.cni: gcr.io/istio-release/install-cni:1.25.2
+                  images.v1_25_2.istiod: gcr.io/istio-release/pilot:1.25.2
+                  images.v1_25_2.proxy: gcr.io/istio-release/proxyv2:1.25.2
+                  images.v1_25_2.ztunnel: gcr.io/istio-release/ztunnel:1.25.2
+                  images.v1_25_3.cni: gcr.io/istio-release/install-cni:1.25.3
+                  images.v1_25_3.istiod: gcr.io/istio-release/pilot:1.25.3
+                  images.v1_25_3.proxy: gcr.io/istio-release/proxyv2:1.25.3
+                  images.v1_25_3.ztunnel: gcr.io/istio-release/ztunnel:1.25.3
+                  images.v1_26_0.cni: gcr.io/istio-release/install-cni:1.26.0
+                  images.v1_26_0.istiod: gcr.io/istio-release/pilot:1.26.0
+                  images.v1_26_0.proxy: gcr.io/istio-release/proxyv2:1.26.0
+                  images.v1_26_0.ztunnel: gcr.io/istio-release/ztunnel:1.26.0
+                  images.v1_26_1.cni: gcr.io/istio-release/install-cni:1.26.1
+                  images.v1_26_1.istiod: gcr.io/istio-release/pilot:1.26.1
+                  images.v1_26_1.proxy: gcr.io/istio-release/proxyv2:1.26.1
+                  images.v1_26_1.ztunnel: gcr.io/istio-release/ztunnel:1.26.1
+                  images.v1_26_2.cni: gcr.io/istio-release/install-cni:1.26.2
+                  images.v1_26_2.istiod: gcr.io/istio-release/pilot:1.26.2
+                  images.v1_26_2.proxy: gcr.io/istio-release/proxyv2:1.26.2
+                  images.v1_26_2.ztunnel: gcr.io/istio-release/ztunnel:1.26.2
                   kubectl.kubernetes.io/default-container: sail-operator
                 labels:
                   app.kubernetes.io/created-by: sailoperator
@@ -769,7 +769,7 @@ spec:
                       - --zap-log-level=info
                     command:
                       - /sail-operator
-                    image: quay.io/sail-dev/sail-operator@sha256:65abc23ea9de01fdc2eaeb89de933900e01410fe4f1acc2a3715ecc3f930fd3d
+                    image: quay.io/sail-dev/sail-operator:1.26.2
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -869,113 +869,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc.
-  relatedImages:
-    - image: gcr.io/istio-release/install-cni@sha256:0f27cb9e3423a3ed8a444dd2137ae05f31a03df2bdd549b21ef8f0f3949e3cef
-      name: install-cni-0f27cb9e3423a3ed8a444dd2137ae05f31a03df2bdd549b21ef8f0f3949e3cef-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:1d963aca195f1e06459925431c592cf556112d77b824c61e06555fbc31ee415f
-      name: install-cni-1d963aca195f1e06459925431c592cf556112d77b824c61e06555fbc31ee415f-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:3107b1947e755abe698fe2d5c3ed7ba5f228f0b4ff5ff30f484fcc984514b97e
-      name: install-cni-3107b1947e755abe698fe2d5c3ed7ba5f228f0b4ff5ff30f484fcc984514b97e-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:313165b70241f65c79b5984797b8e3bc43a264acfeaeda4f33fe3a7f89a2fdb8
-      name: install-cni-313165b70241f65c79b5984797b8e3bc43a264acfeaeda4f33fe3a7f89a2fdb8-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:313c8b38e89137cb455ee96891c2dc5b69f2907b13af324f0cac8b140897f107
-      name: install-cni-313c8b38e89137cb455ee96891c2dc5b69f2907b13af324f0cac8b140897f107-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:4b10d810228e553bf34924222b7d62fdfafbce5ed67dc54973d168bda384a4cd
-      name: install-cni-4b10d810228e553bf34924222b7d62fdfafbce5ed67dc54973d168bda384a4cd-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:7b12bcfabd92c5756e4b12bf82e373f4abcdd3ccf81ac0b93fe0aa6f8ccce63c
-      name: install-cni-7b12bcfabd92c5756e4b12bf82e373f4abcdd3ccf81ac0b93fe0aa6f8ccce63c-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:8e782f5077f63c0a15fd4b9a4fa75f8543033c28ccf2457e25afbf1aefb6a72a
-      name: install-cni-8e782f5077f63c0a15fd4b9a4fa75f8543033c28ccf2457e25afbf1aefb6a72a-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:9a0ee38b9b1c6240bc71e58cc1f5a9c6963860a98c3b3655955fc47be9b7cf42
-      name: install-cni-9a0ee38b9b1c6240bc71e58cc1f5a9c6963860a98c3b3655955fc47be9b7cf42-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:a80a96d9e4e859d1568fe1db1b12525db8c26d153e4bb783ba4efb3c5b16f877
-      name: install-cni-a80a96d9e4e859d1568fe1db1b12525db8c26d153e4bb783ba4efb3c5b16f877-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:d241cd11295b7c7af6c1c7e22096db886b07ab1945b4b7b2fe3d7f95ef41b277
-      name: install-cni-d241cd11295b7c7af6c1c7e22096db886b07ab1945b4b7b2fe3d7f95ef41b277-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:d28af093e5b7f33e8750364e9077c8b2c464145d1904cae8be48227ec0110b04
-      name: install-cni-d28af093e5b7f33e8750364e9077c8b2c464145d1904cae8be48227ec0110b04-annotation
-    - image: gcr.io/istio-release/install-cni@sha256:d85b955875b2fbfc2ca8166cf2aa0e4ac3d78dd00f4ec4140a2a22dd17e7deb9
-      name: install-cni-d85b955875b2fbfc2ca8166cf2aa0e4ac3d78dd00f4ec4140a2a22dd17e7deb9-annotation
-    - image: gcr.io/istio-release/pilot@sha256:0bb4d26e88b61cd2f81d39378111a38a151ec5bf0cb65be49c20d1ef41956299
-      name: pilot-0bb4d26e88b61cd2f81d39378111a38a151ec5bf0cb65be49c20d1ef41956299-annotation
-    - image: gcr.io/istio-release/pilot@sha256:1d4fbb7859e515b85b6c2c4787224e4e7cba73aad4573d98e2a83cc028cad392
-      name: pilot-1d4fbb7859e515b85b6c2c4787224e4e7cba73aad4573d98e2a83cc028cad392-annotation
-    - image: gcr.io/istio-release/pilot@sha256:21b6cdaf12e7eb8bb0ad1d493c32a76e7d34f574a41ece86ded0c79e7191e875
-      name: pilot-21b6cdaf12e7eb8bb0ad1d493c32a76e7d34f574a41ece86ded0c79e7191e875-annotation
-    - image: gcr.io/istio-release/pilot@sha256:2961bf88463e475f1e53d82a118405841ecbb9d8a6e0b35c73c77bee53bc0c3e
-      name: pilot-2961bf88463e475f1e53d82a118405841ecbb9d8a6e0b35c73c77bee53bc0c3e-annotation
-    - image: gcr.io/istio-release/pilot@sha256:29cccf38a413fe81a88d02e0bf924ca84a9cf1d6a3c9ece024c0636b1e3cb029
-      name: pilot-29cccf38a413fe81a88d02e0bf924ca84a9cf1d6a3c9ece024c0636b1e3cb029-annotation
-    - image: gcr.io/istio-release/pilot@sha256:32d0f6bd6c1259de78dbc79dfd88cf5f4dc8941613560ff2ca7dbabcf04dfd68
-      name: pilot-32d0f6bd6c1259de78dbc79dfd88cf5f4dc8941613560ff2ca7dbabcf04dfd68-annotation
-    - image: gcr.io/istio-release/pilot@sha256:4ad6b0c3839a11622e66323a1296c7fc19dcbbb2c371b2e3edd58bd4f763f19f
-      name: pilot-4ad6b0c3839a11622e66323a1296c7fc19dcbbb2c371b2e3edd58bd4f763f19f-annotation
-    - image: gcr.io/istio-release/pilot@sha256:7ccda8c22307ee796cb7ba3f4ce224ef533c3c683c063dcc92fd5a244d8a5c9d
-      name: pilot-7ccda8c22307ee796cb7ba3f4ce224ef533c3c683c063dcc92fd5a244d8a5c9d-annotation
-    - image: gcr.io/istio-release/pilot@sha256:93d6b52a61e7e9891fe114e4f7d503b36e8d1566a22e82e5635084a2001eb14a
-      name: pilot-93d6b52a61e7e9891fe114e4f7d503b36e8d1566a22e82e5635084a2001eb14a-annotation
-    - image: gcr.io/istio-release/pilot@sha256:c4e33921e030bb22d3b8fabc693851d52c07a7af79a9534addc2f50005fa462a
-      name: pilot-c4e33921e030bb22d3b8fabc693851d52c07a7af79a9534addc2f50005fa462a-annotation
-    - image: gcr.io/istio-release/pilot@sha256:c8ac4894f2e667eb439d1c960a47ac7fbc80aad3f0adb98f5fd9330d9c515696
-      name: pilot-c8ac4894f2e667eb439d1c960a47ac7fbc80aad3f0adb98f5fd9330d9c515696-annotation
-    - image: gcr.io/istio-release/pilot@sha256:e082a6f27001101942d1e2be71764b17ad350ed0d289038020426e7ee603eb56
-      name: pilot-e082a6f27001101942d1e2be71764b17ad350ed0d289038020426e7ee603eb56-annotation
-    - image: gcr.io/istio-release/pilot@sha256:f0bcb10a51dbb2b9e5552e7f82aa7fcc2ff4dd6d0d7d2224986036b1645b855b
-      name: pilot-f0bcb10a51dbb2b9e5552e7f82aa7fcc2ff4dd6d0d7d2224986036b1645b855b-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:2cd83a25202af6c5aef48b432f7fed50b6de460c795ce7c84f80bf630f51ca4d
-      name: proxyv2-2cd83a25202af6c5aef48b432f7fed50b6de460c795ce7c84f80bf630f51ca4d-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:2edf332e1c7ddd46466e337d009eda091bcd43f827b6f460175b772addc8055a
-      name: proxyv2-2edf332e1c7ddd46466e337d009eda091bcd43f827b6f460175b772addc8055a-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:445156b5f4a780242d079a47b7d88199cbbb5959c92358469b721af490eca1ae
-      name: proxyv2-445156b5f4a780242d079a47b7d88199cbbb5959c92358469b721af490eca1ae-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:49ed9dd2c06383c0a847877a707a3563d0968d83779ad8d13a0c022a48c5c407
-      name: proxyv2-49ed9dd2c06383c0a847877a707a3563d0968d83779ad8d13a0c022a48c5c407-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:534f7589b085450b5b94e6c955f5106892df88d81676f53ac5e06a0cf5ec45da
-      name: proxyv2-534f7589b085450b5b94e6c955f5106892df88d81676f53ac5e06a0cf5ec45da-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:640733abb924663df83761e2ec95a2bddca797daf1ca37672ec0b045969cdeb1
-      name: proxyv2-640733abb924663df83761e2ec95a2bddca797daf1ca37672ec0b045969cdeb1-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:91382859f73b1a66ac113631f89ef73dabf9c931d6baf0bd7eb618c0fa958b34
-      name: proxyv2-91382859f73b1a66ac113631f89ef73dabf9c931d6baf0bd7eb618c0fa958b34-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:921c5ce2c5122facd9a25a7f974aaa4d3679cee38cb3f809e10618384fc3ce7f
-      name: proxyv2-921c5ce2c5122facd9a25a7f974aaa4d3679cee38cb3f809e10618384fc3ce7f-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:a5f2c1804ac4397448149b63a67f6cfd1979d304b99a726667a4859d201c6305
-      name: proxyv2-a5f2c1804ac4397448149b63a67f6cfd1979d304b99a726667a4859d201c6305-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:bc19e6e0978569a7cc886f3dececc3cb3613cf6e457ddf09e3cb849a2b315231
-      name: proxyv2-bc19e6e0978569a7cc886f3dececc3cb3613cf6e457ddf09e3cb849a2b315231-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:d62cc7585450bce8573338c3d147961f4e1df045ffcf5956abea29841cb5aaa4
-      name: proxyv2-d62cc7585450bce8573338c3d147961f4e1df045ffcf5956abea29841cb5aaa4-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:ee6565e57319e01b5e45b929335eb9dc3d4b30d531b4652467e6939ae81b41f7
-      name: proxyv2-ee6565e57319e01b5e45b929335eb9dc3d4b30d531b4652467e6939ae81b41f7-annotation
-    - image: gcr.io/istio-release/proxyv2@sha256:fd734e6031566b4fb92be38f0f6bb02fdba6c199c45c2db5dc988bbc4fdee026
-      name: proxyv2-fd734e6031566b4fb92be38f0f6bb02fdba6c199c45c2db5dc988bbc4fdee026-annotation
-    - image: quay.io/sail-dev/sail-operator@sha256:65abc23ea9de01fdc2eaeb89de933900e01410fe4f1acc2a3715ecc3f930fd3d
-      name: sail-operator
-    - image: quay.io/sail-dev/sail-operator@sha256:65abc23ea9de01fdc2eaeb89de933900e01410fe4f1acc2a3715ecc3f930fd3d
-      name: sail-operator-65abc23ea9de01fdc2eaeb89de933900e01410fe4f1acc2a3715ecc3f930fd3d-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:0e680a1b33d458e5dfd6f91808c8bd61d00a1103084545ea6a1956c935e7554e
-      name: ztunnel-0e680a1b33d458e5dfd6f91808c8bd61d00a1103084545ea6a1956c935e7554e-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:2402a1c71dce11c409b6da171d8ae27dff62c539d58aac41817499e1fcd7beb3
-      name: ztunnel-2402a1c71dce11c409b6da171d8ae27dff62c539d58aac41817499e1fcd7beb3-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:2d567893e5b452d5c0b9c43a43efd4f8e28e639a344e28d90498f13858f13d46
-      name: ztunnel-2d567893e5b452d5c0b9c43a43efd4f8e28e639a344e28d90498f13858f13d46-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:45807d4c512e9a0e4855eb1a2535532319b698302ebbf4d4eaccf462997bb374
-      name: ztunnel-45807d4c512e9a0e4855eb1a2535532319b698302ebbf4d4eaccf462997bb374-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:56afd26e9384ff41a0244a8c637a0e3aa8654015b8d32b494df8b5023f213ec7
-      name: ztunnel-56afd26e9384ff41a0244a8c637a0e3aa8654015b8d32b494df8b5023f213ec7-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:73b3ad311c9c9a2618e9c2f10259a3bf5414bb4fc6fd407baa6280bdd8d227f0
-      name: ztunnel-73b3ad311c9c9a2618e9c2f10259a3bf5414bb4fc6fd407baa6280bdd8d227f0-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:74ee23f374ea28b3455ad2eca2bea62da95bc2a23b865b7c8c301139046650d5
-      name: ztunnel-74ee23f374ea28b3455ad2eca2bea62da95bc2a23b865b7c8c301139046650d5-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:96daeeb4e71a304edbf2ee2d37bc4bd4b88b9da26d7e6cc0c34c94c1cd6e6cca
-      name: ztunnel-96daeeb4e71a304edbf2ee2d37bc4bd4b88b9da26d7e6cc0c34c94c1cd6e6cca-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:ae90c4e06a4560898dbf414226e3ea879b8d0b10387af27b0c2907e8488fc5d1
-      name: ztunnel-ae90c4e06a4560898dbf414226e3ea879b8d0b10387af27b0c2907e8488fc5d1-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:ca14b3f869aa998da30c6f8f8d14b2e9cd61a40b78b05196b951cac9613d76d8
-      name: ztunnel-ca14b3f869aa998da30c6f8f8d14b2e9cd61a40b78b05196b951cac9613d76d8-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:e3bc4444deb33641b53883a54fff0b11ed4f95c86335dc9af02ab89a9dfe2e46
-      name: ztunnel-e3bc4444deb33641b53883a54fff0b11ed4f95c86335dc9af02ab89a9dfe2e46-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:eaae7b8ed53a3f18b0291f08db0e3330d7c958d39919fce9dbc43f3027bf2089
-      name: ztunnel-eaae7b8ed53a3f18b0291f08db0e3330d7c958d39919fce9dbc43f3027bf2089-annotation
-    - image: gcr.io/istio-release/ztunnel@sha256:fabda07d39993a740b69a54bcb6218eccaaf8fa6b4bcdb733664baf729ec9b21
-      name: ztunnel-fabda07d39993a740b69a54bcb6218eccaaf8fa6b4bcdb733664baf729ec9b21-annotation
   version: 1.26.2


### PR DESCRIPTION
Digest pinning will be done during the release process in the release GH action. It will simplify local development and the release process itself as to make the pinning work, the sail operator image must be already pushed to registry.