### PR TITLE
[release-1.26] Increase mem limit of sail operator. (#1104)

### DIFF
--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/sail-dev/sail-operator:1.26.3
-    createdAt: "2025-08-01T11:14:09Z"
+    createdAt: "2025-08-08T06:54:48Z"
     description: The Sail Operator manages the lifecycle of your Istio control plane. It provides custom resources for you to deploy and manage your control plane components.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -795,7 +795,7 @@ spec:
                     resources:
                       limits:
                         cpu: 500m
-                        memory: 512Mi
+                        memory: 1Gi
                       requests:
                         cpu: 10m
                         memory: 64Mi

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -123,7 +123,7 @@ operator:
   resources:
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 1024Mi
     requests:
       cpu: 10m
       memory: 64Mi


### PR DESCRIPTION
With 512Mi it often gets OOMKilled during chart upgrades, leading to other issues.

