### PR TITLE
chartmanager: disable OpenAPI validation during install

### DIFF
--- a/pkg/helm/chartmanager.go
+++ b/pkg/helm/chartmanager.go
@@ -127,6 +127,7 @@ func (h *ChartManager) UpgradeOrInstallChart(
 		updateAction.PostRenderer = NewHelmPostRenderer(ownerReference, "", true)
 		updateAction.MaxHistory = 1
 		updateAction.SkipCRDs = true
+		updateAction.DisableOpenAPIValidation = true
 
 		rel, err = updateAction.RunWithContext(ctx, releaseName, chart, values)
 		if err != nil {
@@ -140,6 +141,7 @@ func (h *ChartManager) UpgradeOrInstallChart(
 		installAction.Namespace = namespace
 		installAction.ReleaseName = releaseName
 		installAction.SkipCRDs = true
+		installAction.DisableOpenAPIValidation = true
 
 		rel, err = installAction.RunWithContext(ctx, chart, values)
 		if err != nil {


### PR DESCRIPTION
Turning this off reduces our memory allocations during integration tests from 58GB to less than 18GB. There's no need to constantly perform OpenAPI validations - we're working with pre-vetted charts, and the API server will validate for us again anyway.

```
$ go tool pprof -top mem.prof | head -n 5 # with OpenAPI validation
File: api.test
Build ID: f4f47ff2a60a6f8652f8b5dc22a0d37d724a2411
Type: alloc_space
Time: 2025-08-18 11:16:19 CEST
Showing nodes accounting for 52660.68MB, 90.66% of 58083.88MB total
$ go tool pprof -top mem2.prof | head -n 5 # without OpenAPI validation
File: api.test
Build ID: 6ed54fc7a03c659300ff038a57ab89dc79a26993
Type: alloc_space
Time: 2025-08-18 11:31:04 CEST
Showing nodes accounting for 14685.12MB, 85.42% of 17192.63MB total
```