### PR TITLE
check global hub/tag before setting image digests from configuration

### DIFF
--- a/controllers/istiocni/istiocni_controller.go
+++ b/controllers/istiocni/istiocni_controller.go
@@ -185,6 +185,11 @@ func applyImageDigests(version string, values *v1.CNIValues, config config.Opera
 		return values
 	}
 
+	// if a global hub or tag value is configured by the user, don't set image digests
+	if values != nil && values.Global != nil && (values.Global.Hub != nil || values.Global.Tag != nil) {
+		return values
+	}
+
 	if values == nil {
 		values = &v1.CNIValues{}
 	}

--- a/controllers/istiocni/istiocni_controller_test.go
+++ b/controllers/istiocni/istiocni_controller_test.go
@@ -412,6 +412,56 @@ func TestApplyImageDigests(t *testing.T) {
 			},
 		},
 		{
+			name: "user-supplied-global-hub",
+			config: config.OperatorConfig{
+				ImageDigests: map[string]config.IstioImageConfig{
+					istioversion.Default: {
+						CNIImage: "cni-test",
+					},
+				},
+			},
+			input: &v1.IstioCNI{
+				Spec: v1.IstioCNISpec{
+					Version: istioversion.Default,
+					Values: &v1.CNIValues{
+						Global: &v1.CNIGlobalConfig{
+							Hub: ptr.Of("docker.io/istio"),
+						},
+					},
+				},
+			},
+			expectValues: &v1.CNIValues{
+				Global: &v1.CNIGlobalConfig{
+					Hub: ptr.Of("docker.io/istio"),
+				},
+			},
+		},
+		{
+			name: "user-supplied-global-tag",
+			config: config.OperatorConfig{
+				ImageDigests: map[string]config.IstioImageConfig{
+					istioversion.Default: {
+						CNIImage: "cni-test",
+					},
+				},
+			},
+			input: &v1.IstioCNI{
+				Spec: v1.IstioCNISpec{
+					Version: istioversion.Default,
+					Values: &v1.CNIValues{
+						Global: &v1.CNIGlobalConfig{
+							Tag: ptr.Of("v1.24.0-custom-build"),
+						},
+					},
+				},
+			},
+			expectValues: &v1.CNIValues{
+				Global: &v1.CNIGlobalConfig{
+					Tag: ptr.Of("v1.24.0-custom-build"),
+				},
+			},
+		},
+		{
 			name: "version-without-defaults",
 			config: config.OperatorConfig{
 				ImageDigests: map[string]config.IstioImageConfig{

--- a/controllers/ztunnel/ztunnel_controller.go
+++ b/controllers/ztunnel/ztunnel_controller.go
@@ -183,6 +183,11 @@ func applyImageDigests(version string, values *v1.ZTunnelValues, config config.O
 		return values
 	}
 
+	// if a global hub or tag value is configured by the user, don't set image digests
+	if values != nil && values.Global != nil && (values.Global.Hub != nil || values.Global.Tag != nil) {
+		return values
+	}
+
 	if values == nil {
 		values = &v1.ZTunnelValues{}
 	}

--- a/controllers/ztunnel/ztunnel_controller_test.go
+++ b/controllers/ztunnel/ztunnel_controller_test.go
@@ -440,6 +440,56 @@ func TestApplyImageDigests(t *testing.T) {
 			},
 		},
 		{
+			name: "user-supplied-global-hub",
+			config: config.OperatorConfig{
+				ImageDigests: map[string]config.IstioImageConfig{
+					"v1.24.0": {
+						ZTunnelImage: "ztunnel-test",
+					},
+				},
+			},
+			input: &v1alpha1.ZTunnel{
+				Spec: v1alpha1.ZTunnelSpec{
+					Version: "v1.24.0",
+					Values: &v1.ZTunnelValues{
+						Global: &v1.ZTunnelGlobalConfig{
+							Hub: ptr.Of("docker.io/istio"),
+						},
+					},
+				},
+			},
+			expectValues: &v1.ZTunnelValues{
+				Global: &v1.ZTunnelGlobalConfig{
+					Hub: ptr.Of("docker.io/istio"),
+				},
+			},
+		},
+		{
+			name: "user-supplied-global-tag",
+			config: config.OperatorConfig{
+				ImageDigests: map[string]config.IstioImageConfig{
+					"v1.24.0": {
+						ZTunnelImage: "ztunnel-test",
+					},
+				},
+			},
+			input: &v1alpha1.ZTunnel{
+				Spec: v1alpha1.ZTunnelSpec{
+					Version: "v1.24.0",
+					Values: &v1.ZTunnelValues{
+						Global: &v1.ZTunnelGlobalConfig{
+							Tag: ptr.Of("v1.24.0-custom-build"),
+						},
+					},
+				},
+			},
+			expectValues: &v1.ZTunnelValues{
+				Global: &v1.ZTunnelGlobalConfig{
+					Tag: ptr.Of("v1.24.0-custom-build"),
+				},
+			},
+		},
+		{
 			name: "version-without-defaults",
 			config: config.OperatorConfig{
 				ImageDigests: map[string]config.IstioImageConfig{

--- a/pkg/istiovalues/digests.go
+++ b/pkg/istiovalues/digests.go
@@ -27,6 +27,11 @@ func ApplyDigests(version string, values *v1.Values, config config.OperatorConfi
 		return values
 	}
 
+	// if a global hub or tag value is configured by the user, don't set image digests for any components
+	if values != nil && values.Global != nil && (values.Global.Hub != nil || values.Global.Tag != nil) {
+		return values
+	}
+
 	if values == nil {
 		values = &v1.Values{}
 	}

--- a/pkg/istiovalues/digests_test.go
+++ b/pkg/istiovalues/digests_test.go
@@ -174,6 +174,52 @@ func TestApplyImageDigests(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "user-supplied-global-hub",
+			config: config.OperatorConfig{
+				ImageDigests: map[string]config.IstioImageConfig{
+					"v1.20.0": {
+						IstiodImage:  "istiod-test",
+						ProxyImage:   "proxy-test",
+						ZTunnelImage: "ztunnel-test",
+					},
+				},
+			},
+			version: "v1.20.0",
+			inputValues: &v1.Values{
+				Global: &v1.GlobalConfig{
+					Hub: ptr.Of("docker.io/istio"),
+				},
+			},
+			expectValues: &v1.Values{
+				Global: &v1.GlobalConfig{
+					Hub: ptr.Of("docker.io/istio"),
+				},
+			},
+		},
+		{
+			name: "user-supplied-global-tag",
+			config: config.OperatorConfig{
+				ImageDigests: map[string]config.IstioImageConfig{
+					"v1.20.0": {
+						IstiodImage:  "istiod-test",
+						ProxyImage:   "proxy-test",
+						ZTunnelImage: "ztunnel-test",
+					},
+				},
+			},
+			version: "v1.20.0",
+			inputValues: &v1.Values{
+				Global: &v1.GlobalConfig{
+					Tag: ptr.Of("1.20.0-custom-build"),
+				},
+			},
+			expectValues: &v1.Values{
+				Global: &v1.GlobalConfig{
+					Tag: ptr.Of("1.20.0-custom-build"),
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Fixes a bug where `global.hub` and `global.tag` were being ignored when deciding whether to set component image digests from configuration.

When `global.hub` or `global.tag` are set, they should be used, and image digests from configuration should not be used.

This came up after https://github.com/istio-ecosystem/sail-operator/pull/1001 merged, which added image digest configuration by default. Users who previously had been using `global.hub` are now having that setting be ignored.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #1121.

Related Issue/PR #

#### Additional information:
