### PR TITLE
Fix macOS compatibility for update_deps.sh and update macOS specific dev docs

### DIFF
--- a/docs/macos/develop-on-macos.md
+++ b/docs/macos/develop-on-macos.md
@@ -76,5 +76,20 @@ Note: the default image used by the kind script from upstream does not work on m
 
     You can also set the `DOCKER_GID` environment variable in your shell configuration file or terminal session.
 
+- **Shell compatibility errors with `update-common` target:**
+
+    When running `CONTAINER_CLI=podman make update-common`, you may encounter shell compatibility errors like:
+
+    ```
+    /bin/sh: 1: [: unexpected operator
+    ```
+
+    This occurs because the `update-common` target runs inside containers by default, but it needs to modify local files and has shell compatibility issues between macOS/bash and the container's `/bin/sh`. To resolve this, run the target directly from the common Makefile:
+
+    ```bash
+    make -f common/Makefile.common.mk update-common
+    ```
+
+    This bypasses the container logic entirely and runs the target on the host system, which is necessary for file modification operations.
 
 **Note**: Please submit a PR to this document if you find any issues or have additional tips for developing on macOS with the Sail Operator project.

--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -43,7 +43,7 @@ make update-common
 
 # update build container used in github actions
 NEW_IMAGE_MASTER=$(grep IMAGE_VERSION= < common/scripts/setup_env.sh | cut -d= -f2)
-sed -i -e "s|\(gcr.io/istio-testing/build-tools\):master.*|\1:$NEW_IMAGE_MASTER|" .github/workflows/update-deps.yaml
+sed -i '' -e "s|\(gcr.io/istio-testing/build-tools\):master.*|\1:$NEW_IMAGE_MASTER|" .github/workflows/update-deps.yaml
 
 # Update go dependencies
 export GO111MODULE=on
@@ -53,16 +53,16 @@ go mod tidy
 
 # Update operator-sdk
 OPERATOR_SDK_LATEST_VERSION=$(getLatestVersion operator-framework/operator-sdk)
-sed -i "s|OPERATOR_SDK_VERSION ?= .*|OPERATOR_SDK_VERSION ?= ${OPERATOR_SDK_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
-find "${ROOTDIR}/chart/templates/olm/scorecard.yaml" -type f -exec sed -i "s|quay.io/operator-framework/scorecard-test:.*|quay.io/operator-framework/scorecard-test:${OPERATOR_SDK_LATEST_VERSION}|" {} +
+sed -i '' "s|OPERATOR_SDK_VERSION ?= .*|OPERATOR_SDK_VERSION ?= ${OPERATOR_SDK_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+find "${ROOTDIR}/chart/templates/olm/scorecard.yaml" -type f -exec sed -i '' "s|quay.io/operator-framework/scorecard-test:.*|quay.io/operator-framework/scorecard-test:${OPERATOR_SDK_LATEST_VERSION}|" {} +
 
 # Update helm
 HELM_LATEST_VERSION=$(getLatestVersion helm/helm | cut -d/ -f2)
-sed -i "s|HELM_VERSION ?= .*|HELM_VERSION ?= ${HELM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+sed -i '' "s|HELM_VERSION ?= .*|HELM_VERSION ?= ${HELM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update controller-tools
 CONTROLLER_TOOLS_LATEST_VERSION=$(getLatestVersion kubernetes-sigs/controller-tools)
-sed -i "s|CONTROLLER_TOOLS_VERSION ?= .*|CONTROLLER_TOOLS_VERSION ?= ${CONTROLLER_TOOLS_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+sed -i '' "s|CONTROLLER_TOOLS_VERSION ?= .*|CONTROLLER_TOOLS_VERSION ?= ${CONTROLLER_TOOLS_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update controller-runtime
 CONTROLLER_RUNTIME_LATEST_VERSION=$(getLatestVersion kubernetes-sigs/controller-runtime)
@@ -70,41 +70,41 @@ CONTROLLER_RUNTIME_LATEST_VERSION=$(getLatestVersion kubernetes-sigs/controller-
 # go get -u "sigs.k8s.io/controller-runtime@${CONTROLLER_RUNTIME_LATEST_VERSION}"
 go get "sigs.k8s.io/controller-runtime@${CONTROLLER_RUNTIME_LATEST_VERSION}"
 CONTROLLER_RUNTIME_BRANCH=$(getReleaseBranch "${CONTROLLER_RUNTIME_LATEST_VERSION}")
-sed -i "s|CONTROLLER_RUNTIME_BRANCH ?= .*|CONTROLLER_RUNTIME_BRANCH ?= ${CONTROLLER_RUNTIME_BRANCH}|" "${ROOTDIR}/Makefile.core.mk"
+sed -i '' "s|CONTROLLER_RUNTIME_BRANCH ?= .*|CONTROLLER_RUNTIME_BRANCH ?= ${CONTROLLER_RUNTIME_BRANCH}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update opm
 OPM_LATEST_VERSION=$(getLatestVersion operator-framework/operator-registry)
-sed -i "s|OPM_VERSION ?= .*|OPM_VERSION ?= ${OPM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+sed -i '' "s|OPM_VERSION ?= .*|OPM_VERSION ?= ${OPM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update olm
 OLM_LATEST_VERSION=$(getLatestVersion operator-framework/operator-lifecycle-manager)
-sed -i "s|OLM_VERSION ?= .*|OLM_VERSION ?= ${OLM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+sed -i '' "s|OLM_VERSION ?= .*|OLM_VERSION ?= ${OLM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update kube-rbac-proxy
 RBAC_PROXY_LATEST_VERSION=$(getLatestVersion brancz/kube-rbac-proxy | cut -d/ -f1)
 # Only update it if the newer image is available in the registry
 if docker manifest inspect "gcr.io/kubebuilder/kube-rbac-proxy:${RBAC_PROXY_LATEST_VERSION}" >/dev/null 2>/dev/null; then
-  sed -i "s|gcr.io/kubebuilder/kube-rbac-proxy:.*|gcr.io/kubebuilder/kube-rbac-proxy:${RBAC_PROXY_LATEST_VERSION}|" "${ROOTDIR}/chart/values.yaml"
+  sed -i '' "s|gcr.io/kubebuilder/kube-rbac-proxy:.*|gcr.io/kubebuilder/kube-rbac-proxy:${RBAC_PROXY_LATEST_VERSION}|" "${ROOTDIR}/chart/values.yaml"
 fi
 
 # Update gitleaks
 GITLEAKS_VERSION=$(getLatestVersion gitleaks/gitleaks)
-sed -i "s|GITLEAKS_VERSION ?= .*|GITLEAKS_VERSION ?= ${GITLEAKS_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+sed -i '' "s|GITLEAKS_VERSION ?= .*|GITLEAKS_VERSION ?= ${GITLEAKS_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update runme
 RUNME_LATEST_VERSION=$(getLatestVersion runmedev/runme)
 # Remove the leading "v" from the version string
 RUNME_LATEST_VERSION=${RUNME_LATEST_VERSION#v}
-sed -i "s|RUNME_VERSION ?= .*|RUNME_VERSION ?= ${RUNME_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+sed -i '' "s|RUNME_VERSION ?= .*|RUNME_VERSION ?= ${RUNME_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update misspell
 MISSPELL_LATEST_VERSION=$(getLatestVersion client9/misspell)
-sed -i "s|MISSPELL_VERSION ?= .*|MISSPELL_VERSION ?= ${MISSPELL_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+sed -i '' "s|MISSPELL_VERSION ?= .*|MISSPELL_VERSION ?= ${MISSPELL_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update KIND_IMAGE. Look for KIND_IMAGE := docker.io in the make file and look on docker.io/kindest/node for the latest version.
 KIND_LATEST_VERSION=$(getLatestVersionFromDockerHub kindest/node)
 if [[ -n "${KIND_LATEST_VERSION}" ]]; then
-  sed -i "s|KIND_IMAGE := docker.io/kindest/node:.*|KIND_IMAGE := docker.io/kindest/node:${KIND_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+  sed -i '' "s|KIND_IMAGE := docker.io/kindest/node:.*|KIND_IMAGE := docker.io/kindest/node:${KIND_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 else
   echo "No latest version found for kindest/node on Docker Hub. Keeping the existing KIND_IMAGE."
 fi


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [x] Documentation Update

#### What this PR does / why we need it:
This PR adds:
  - Update macOS documentation with workaround for `update-common` shell errors. On macOS, you may find some issues while running locally the update-common target
  - Fix `sed -i` commands in `update_deps.sh` to work on both BSD (macOS) and GNU (Linux) sed

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
