### PR TITLE
docs: remove "$" prefix from shell code blocks in all markdown files

### DIFF
--- a/bundle/README.md
+++ b/bundle/README.md
@@ -89,7 +89,7 @@ web console. For a list of available versions, see the [versions.yaml](../pkg/is
 or use the command:
 
 ```sh
-$ kubectl explain istio.spec.version
+kubectl explain istio.spec.version
 ```
 
 ### Customizing Istio configuration
@@ -132,7 +132,7 @@ For a list of available configuration for the `spec.values` field, run the
 following command:
 
 ```sh
-$ kubectl explain istio.spec.values
+kubectl explain istio.spec.values
 ```
 
 For the `IstioCNI` resource, replace `istio` with `istiocni` in the command above.

--- a/chart/README.md
+++ b/chart/README.md
@@ -17,8 +17,8 @@ OpenShift:
 ## Prepare the Helm charts
 
 ```sh
-$ helm repo add sail-operator https://istio-ecosystem.github.io/sail-operator
-$ helm repo update
+helm repo add sail-operator https://istio-ecosystem.github.io/sail-operator
+helm repo update
 ```
 
 ## Installation steps
@@ -26,7 +26,7 @@ $ helm repo update
 This section describes the procedure to install `Sail Operator` using Helm. The general syntax for helm installation is:
 
 ```sh
-$ helm install <release> <chart> --create-namespace --namespace <namespace> [--set <other_parameters>]
+helm install <release> <chart> --create-namespace --namespace <namespace> [--set <other_parameters>]
 ```
 
 The variables specified in the command are as follows:
@@ -156,7 +156,7 @@ An example configuration:
 For a list of available configuration for the `spec.values` field, run the following command:
 
 ```sh
-$ kubectl explain istio.spec.values
+kubectl explain istio.spec.values
 ```
 
 For the `IstioCNI` resource, replace `istio` with `istiocni` in the command above.
@@ -210,25 +210,25 @@ For installation steps, refer to the following [link](../docs/common/istio-addon
 ### Deleting Istio
 
 ```sh
-$ kubectl -n istio-system delete istio default
+kubectl -n istio-system delete istio default
 ```
 
 ### Deleting IstioCNI (in OpenShift cluster platform)
 
 ```sh
-$ kubectl -n istio-cni delete istiocni default
+kubectl -n istio-cni delete istiocni default
 ```
 
 ### Uninstall the Sail Operator using Helm
 
 ```sh
-$ helm uninstall sail-operator --namespace sail-operator
+helm uninstall sail-operator --namespace sail-operator
 ```
  
 ### Deleting the Project namespaces
 
 ```sh
-$ kubectl delete namespace istio-system
-$ kubectl delete namespace istio-cni
-$ kubectl delete namespace sail-operator
+kubectl delete namespace istio-system
+kubectl delete namespace istio-cni
+kubectl delete namespace sail-operator
 ```

--- a/docs/addons/addons.md
+++ b/docs/addons/addons.md
@@ -64,7 +64,7 @@ EOF
 In our case it is `test` the istio resource name.
 
 ```console
-$ kubectl get istios
+kubectl get istios
 NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
 test      1           1       0        test              Healthy   v1.24.3   8m10s
 ```

--- a/docs/common/create-and-configure-gateways.md
+++ b/docs/common/create-and-configure-gateways.md
@@ -175,7 +175,7 @@ not available by default and must be enabled to be used. This can be done with
 the command:
 
 ```sh
-$ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null ||  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.0.0" | kubectl apply -f -; }
+kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null ||  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.0.0" | kubectl apply -f -; }
 ```
 
 To configure `bookinfo` with a gateway using `Gateway API`:

--- a/docs/common/istio-ambient-mode.md
+++ b/docs/common/istio-ambient-mode.md
@@ -78,8 +78,8 @@ The ZTunnel resource API reference documentation can be found [here](../api-refe
 2. Create the `istio-system` namespace and add a label `istio-discovery=enabled`.
 
 ```bash
-$ kubectl create namespace istio-system
-$ kubectl label namespace istio-system istio-discovery=enabled
+kubectl create namespace istio-system
+kubectl label namespace istio-system istio-discovery=enabled
 ```
 
 3. Create the `Istio` resource. 
@@ -87,7 +87,7 @@ $ kubectl label namespace istio-system istio-discovery=enabled
 > The Istio resource `.spec.values.pilot.trustedZtunnelNamespace` value should match the namespace that we will install a `ZTunnel` resource at. 
 
 ```bash
-$ cat <<EOF | kubectl apply -f-
+cat <<EOF | kubectl apply -f-
 apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
@@ -111,7 +111,7 @@ EOF
 4. Confirm the installation and version of the control plane.
 
 ```console
-$ kubectl get istio -n istio-system
+kubectl get istio -n istio-system
     NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
     default   1           1       0        default           Healthy   v1.24.0   23s
 ```
@@ -120,13 +120,13 @@ $ kubectl get istio -n istio-system
 5. Create the `istio-cni` namespace.
 
 ```bash
-$ kubectl create namespace istio-cni
+kubectl create namespace istio-cni
 ```
 
 6. Create the `IstioCNI` resource.
 
 ```bash
-$ cat <<EOF | kubectl apply -f-
+cat <<EOF | kubectl apply -f-
 apiVersion: sailoperator.io/v1
 kind: IstioCNI
 metadata:
@@ -143,14 +143,14 @@ EOF
 > We need to label both the `Istio` resource's namespace e.g. `istio-system` and the `ZTunnel` resource's namespace when using a `discoverySelectors` mesh config. Those two labels should be added before installing a `ZTunnel` instance. This approach is used to avoid a [TLS signing error](https://github.com/istio/istio/issues/52057).
 
 ```bash
-$ kubectl create namespace ztunnel
-$ kubectl label namespace ztunnel istio-discovery=enabled
+kubectl create namespace ztunnel
+kubectl label namespace ztunnel istio-discovery=enabled
 ```
 
 8. Create the `ZTunnel` resource.
 
 ```bash
-$ cat <<EOF | kubectl apply -f-
+cat <<EOF | kubectl apply -f-
 apiVersion: sailoperator.io/v1alpha1
 kind: ZTunnel
 metadata:
@@ -165,7 +165,7 @@ EOF
 9. Confirm the installation and version of the `ztunnel`.
 
 ```console
-$ kubectl get ztunnel -n istio-system
+kubectl get ztunnel -n istio-system
     NAME      READY   STATUS    VERSION   AGE
     default   True    Healthy   v1.24.0   16s
 ```
@@ -179,21 +179,21 @@ To explore Istio's ambient mode, let's install the sample `Bookinfo application`
 1. Create the `bookinfo` namespace and add a label `istio-discovery=enabled`.
 
 ```bash
-$ kubectl create ns bookinfo
-$ kubectl label namespace bookinfo istio-discovery=enabled
+kubectl create ns bookinfo
+kubectl label namespace bookinfo istio-discovery=enabled
 ```
 
 2. Deploy the application.
 
 ```bash
-$ kubectl apply -n bookinfo -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/platform/kube/bookinfo.yaml
-$ kubectl apply -n bookinfo -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/platform/kube/bookinfo-versions.yaml
+kubectl apply -n bookinfo -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/platform/kube/bookinfo.yaml
+kubectl apply -n bookinfo -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/platform/kube/bookinfo-versions.yaml
 ```
 
 3. Verify that the application is running.
 
 ```console
-$ kubectl get -n bookinfo pods
+kubectl get -n bookinfo pods
 
     NAME                             READY   STATUS    RESTARTS   AGE
     details-v1-cf74bb974-nw94k       1/1     Running   0          42s
@@ -207,18 +207,18 @@ $ kubectl get -n bookinfo pods
 4. Deploy and configure the ingress gateway using the Kubernetes Gateway API.
 
 ```bash
-$ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \ 
+kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
 { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml; }
-$ kubectl apply -n bookinfo -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/gateway-api/bookinfo-gateway.yaml
+kubectl apply -n bookinfo -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/gateway-api/bookinfo-gateway.yaml
 ```
     
 Wait for the `bookinfo-gateway` pod to enter running state and then get the `productpage` service URL. The wait time depends on your cluster cloud provider. It takes me about one minute from an AWS ELB to be able to access it.
 
 ```bash
-$ export INGRESS_HOST=$(kubectl get -n bookinfo gtw bookinfo-gateway -o jsonpath='{.status.addresses[0].value}')
-$ export INGRESS_PORT=$(kubectl get -n bookinfo gtw bookinfo-gateway -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
-$ export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
-$ echo "http://${GATEWAY_URL}/productpage"
+export INGRESS_HOST=$(kubectl get -n bookinfo gtw bookinfo-gateway -o jsonpath='{.status.addresses[0].value}')
+export INGRESS_PORT=$(kubectl get -n bookinfo gtw bookinfo-gateway -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
+export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
+echo "http://${GATEWAY_URL}/productpage"
 ```
 
 5. Access the application.
@@ -229,7 +229,7 @@ If you refresh the page, you should see the display of the book ratings changing
 6. Add Bookinfo to the Ambient mesh.
 
 ```bash
-$ kubectl label namespace bookinfo istio.io/dataplane-mode=ambient
+kubectl label namespace bookinfo istio.io/dataplane-mode=ambient
 ```
 
 > **Note**:
@@ -241,7 +241,7 @@ If you refresh the previous browser page, you should see the same display.
 7. To confirm that `ztunnel` successfully opened listening sockets inside the pod network ns, use the following command.
 
 ```console
-$ kubectl debug -it -n bookinfo "$(kubectl get pod -n bookinfo -l app=productpage -o name)" --image quay.io/curl/curl -- netstat -tulpn
+kubectl debug -it -n bookinfo "$(kubectl get pod -n bookinfo -l app=productpage -o name)" --image quay.io/curl/curl -- netstat -tulpn
 Active Internet connections (only servers)
 Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
 tcp        0      0 127.0.0.1:15053         0.0.0.0:*               LISTEN      -
@@ -260,7 +260,7 @@ Using Kiali dashboard and Prometheus metrics engine, you can visualize the Booki
 Deploy Prometheus in `istio-system` namespace.
 
 ```bash
-$ kubectl apply -n istio-system -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/prometheus.yaml
+kubectl apply -n istio-system -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/prometheus.yaml
 ```
 
 > **NOTE**:
@@ -269,7 +269,7 @@ $ kubectl apply -n istio-system -f https://raw.githubusercontent.com/istio/istio
 Deploy a Kiali dashboard using a community Kiali operator on OpenShift.
 
 ```bash
-$ cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -282,11 +282,11 @@ spec:
   source: community-operators
   sourceNamespace: openshift-marketplace
 EOF
-$ kubectl wait --for condition=established --timeout=60s crd "kialis.kiali.io"
+kubectl wait --for condition=established --timeout=60s crd "kialis.kiali.io"
 
 customresourcedefinition.apiextensions.k8s.io/kialis.kiali.io condition met
 
-$ cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: kiali.io/v1alpha1
 kind: Kiali
 metadata:
@@ -298,7 +298,7 @@ EOF
 To access the Kiali dashboard, let's get the URL.
 
 ```bash
-$ kubectl get route -n istio-system -l app.kubernetes.io/name=kiali -o jsonpath='https://{..spec.host}/'
+kubectl get route -n istio-system -l app.kubernetes.io/name=kiali -o jsonpath='https://{..spec.host}/'
 ```
 
 ![kiali-dashboard](images/kiali-dashboard.png "Kiali Dashboard")
@@ -322,7 +322,7 @@ Users can download an `istioctl` binary and run those diagnostic commands. We re
 Before adding Bookinfo to the Ambient mesh, you would see the PROTOCOL field as TCP for all the workloads.
 
 ```console
-$ istioctl -n ztunnel ztunnel-config workloads
+istioctl -n ztunnel ztunnel-config workloads
     NAMESPACE    POD NAME                        ADDRESS      NODE                       WAYPOINT PROTOCOL
     bookinfo     details-v1-6cd6d9df6b-mddv2     10.129.0.43  ip-10-0-0-241.ec2.internal None     TCP
     bookinfo     productpage-v1-57ffb6658c-vmb6z 10.129.0.48  ip-10-0-0-241.ec2.internal None     TCP
@@ -336,7 +336,7 @@ $ istioctl -n ztunnel ztunnel-config workloads
 After adding `bookinfo` namespace to the Ambient mesh, you would see HBONE protocol.
 
 ```console
-$ istioctl -n ztunnel ztunnel-config workloads
+istioctl -n ztunnel ztunnel-config workloads
     NAMESPACE    POD NAME                        ADDRESS      NODE                       WAYPOINT PROTOCOL
     bookinfo     details-v1-6cd6d9df6b-mddv2     10.129.0.43  ip-10-0-0-241.ec2.internal None     HBONE
     bookinfo     productpage-v1-57ffb6658c-vmb6z 10.129.0.48  ip-10-0-0-241.ec2.internal None     HBONE
@@ -352,7 +352,7 @@ $ istioctl -n ztunnel ztunnel-config workloads
 You can also validate mTLS from ztunnel logs to confirm mTLS is enabled.
 
 ```console
-$ kubectl -n ztunnel logs -l app=ztunnel | grep -E "inbound|outbound"
+kubectl -n ztunnel logs -l app=ztunnel | grep -E "inbound|outbound"
 
 2025-01-23T05:07:25.806642Z	info	access	connection complete	src.addr=10.129.0.48:40978 src.workload="productpage-v1-57ffb6658c-vmb6z" src.namespace="bookinfo" src.identity="spiffe://cluster.local/ns/bookinfo/sa/bookinfo-productpage" dst.addr=10.129.0.43:15008 dst.hbone_addr=10.129.0.43:9080 dst.service="details.bookinfo.svc.cluster.local" dst.workload="details-v1-6cd6d9df6b-mddv2" dst.namespace="bookinfo" dst.identity="spiffe://cluster.local/ns/bookinfo/sa/bookinfo-details" direction="outbound" bytes_sent=283 bytes_recv=358 duration="2ms"
 ```

--- a/docs/deployment-models/multiple-mesh.md
+++ b/docs/deployment-models/multiple-mesh.md
@@ -240,7 +240,7 @@ Use the `istioctl ps` command to confirm that the application pods are connected
 The `curl` and `httpbin` pods in namespace `app1` should be connected to the control plane in namespace `istio-system1`, as shown in the following example (note the `.app1` suffix in the `NAME` column):
 
 ```console
-$ istioctl ps -i istio-system1
+istioctl ps -i istio-system1
 NAME                              CLUSTER        CDS                LDS                EDS                RDS                ECDS        ISTIOD                            VERSION
 curl-5b549b49b8-mg7nl.app1        Kubernetes     SYNCED (4m40s)     SYNCED (4m40s)     SYNCED (4m31s)     SYNCED (4m40s)     IGNORED     istiod-mesh1-5df45b97dd-tf2wl     1.24.0
 httpbin-7b549f7859-h6hnk.app1     Kubernetes     SYNCED (4m31s)     SYNCED (4m31s)     SYNCED (4m31s)     SYNCED (4m31s)     IGNORED     istiod-mesh1-5df45b97dd-tf2wl     1.24.0
@@ -249,7 +249,7 @@ httpbin-7b549f7859-h6hnk.app1     Kubernetes     SYNCED (4m31s)     SYNCED (4m31
 The pods in namespaces `app2a` and `app2b` should be connected to the control plane in namespace `istio-system2`:
 
 ```console
-$ istioctl ps -i istio-system2
+istioctl ps -i istio-system2
 NAME                               CLUSTER        CDS                LDS                EDS                RDS                ECDS        ISTIOD                            VERSION
 curl-5b549b49b8-2hlvm.app2a        Kubernetes     SYNCED (4m37s)     SYNCED (4m37s)     SYNCED (4m31s)     SYNCED (4m37s)     IGNORED     istiod-mesh2-59f6b874fb-mzxqw     1.24.0
 curl-5b549b49b8-xnzzk.app2b        Kubernetes     SYNCED (4m37s)     SYNCED (4m37s)     SYNCED (4m31s)     SYNCED (4m37s)     IGNORED     istiod-mesh2-59f6b874fb-mzxqw     1.24.0
@@ -268,7 +268,7 @@ As both meshes are configured to use the `STRICT` mTLS peer authentication mode,
 To test whether the `curl` pod in namespace `app2a` can connect to the `httpbin` service in namespace `app1`, run the following commands:
 
 ```console
-$ kubectl -n app2a exec deploy/curl -c curl -- curl -sIL http://httpbin.app1:8000
+kubectl -n app2a exec deploy/curl -c curl -- curl -sIL http://httpbin.app1:8000
 HTTP/1.1 503 Service Unavailable
 content-length: 95
 content-type: text/plain
@@ -291,7 +291,7 @@ As expected, the response indicates that the connection was not successful.
 In contrast, the same pod should be able to connect to the `httpbin` service in namespace `app2b`, because they are part of the same mesh:
 
 ```console
-$ kubectl -n app2a exec deploy/curl -c curl -- curl -sIL http://httpbin.app2b:8000
+kubectl -n app2a exec deploy/curl -c curl -- curl -sIL http://httpbin.app2b:8000
 HTTP/1.1 200 OK
 access-control-allow-credentials: true
 access-control-allow-origin: *

--- a/docs/general/plugin-ca.md
+++ b/docs/general/plugin-ca.md
@@ -9,7 +9,7 @@ By default the Istio CA generates a self-signed root certificate and key and use
 ### Cause of the traffic disruptions
 We can simply add a new `cacerts` secret with our certificates but what does it mean for service to service mTLS traffic? Consider `sleep` and `httpbin` demo applications. Both are sharing the same root of trust which is the Istio CA generated self-signed root certificate:
 ```bash
-$ istioctl proxy-config secret deployment/sleep -n sleep -o json | jq -r '.dynamicActiveSecrets[1].secret.validationContext.trustedCa.inlineBytes' | base64 --decode | openssl x509 -text -noout
+istioctl proxy-config secret deployment/sleep -n sleep -o json | jq -r '.dynamicActiveSecrets[1].secret.validationContext.trustedCa.inlineBytes' | base64 --decode | openssl x509 -text -noout
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -22,7 +22,7 @@ Certificate:
             Not After : Jun 17 12:39:46 2035 GMT
         Subject: O=cluster.local
         ...
-$ istioctl proxy-config secret deployment/httpbin -n httpbin -o json | jq -r '.dynamicActiveSecrets[1].secret.validationContext.trustedCa.inlineBytes' | base64 --decode | openssl x509 -text -noout
+istioctl proxy-config secret deployment/httpbin -n httpbin -o json | jq -r '.dynamicActiveSecrets[1].secret.validationContext.trustedCa.inlineBytes' | base64 --decode | openssl x509 -text -noout
 Certificate:
     Data:
         Version: 3 (0x2)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -210,12 +210,12 @@ Specifically for OCP:
 
 * To run the end-to-end tests in OCP cluster, use the following command:
 ```
-$ make test.e2e.ocp
+make test.e2e.ocp
 ```
 
 * To run the end-to-end tests in KinD cluster, use the following command:
 ```
-$ make test.e2e.kind
+make test.e2e.kind
 ```
 
 Both targets will run setup first by using `integ-suite-ocp.sh` and `integ-suite-kind.sh` scripts respectively, and then run the end-to-end tests using the `common-operator-integ-suite` script setting different flags for OCP and KinD.
@@ -226,7 +226,7 @@ Note: By default, the test runs inside a container because the env var `BUILD_WI
 To run a specific subset of tests, you can use the `GINKGO_FLAGS` environment variable. For example, to run only the `smoke` tests, you can use the following command:
 
 ```
-$ GINKGO_FLAGS="-v --label-filter=smoke" make test.e2e.kind
+GINKGO_FLAGS="-v --label-filter=smoke" make test.e2e.kind
 ```
 Note: `-v` is to add verbosity to the output. The `--label-filter` flag is used to filter the tests by label. You can use multiple labels separated by commas. Please take a look at the topic [Settings for end to end test execution](#settings-for-end-to-end-test-execution) to see how you can set more customizations for the test run.
 
@@ -235,11 +235,11 @@ Note: `-v` is to add verbosity to the output. The `--label-filter` flag is used 
 To run the end-to-end tests without a container, use the following command:
 
 ```
-$ make BUILD_WITH_CONTAINER=0 test.e2e.kind
+make BUILD_WITH_CONTAINER=0 test.e2e.kind
 ```
 or
 ```
-$ make BUILD_WITH_CONTAINER=0 test.e2e.ocp
+make BUILD_WITH_CONTAINER=0 test.e2e.ocp
 ```
 
 Note: if you are running the test against a cluster that has a different architecture than the one you are running the test, you will need to set the `TARGET_ARCH` environment variable to the architecture of the cluster. For example, if you are running the test against an ARM64 cluster, you can use the following command:
@@ -271,7 +271,7 @@ The test run can be customized by setting the following environment variables:
 To change all the sample files used in the test, you can use the following environment variable:
 * `SAMPLES_PATH=<path-to-kustomize-sample-base-folder>`. We use kustomize to patch the upstream sample yaml files to use images located in the `quay.io/sail-dev` registry. This is useful when you want to use your own sample files or when you want to use a different version of the sample files. The path should point to the folder where the kustomize files are located. For example, if you have your own sample files in the `tests/e2e/samples/custom` folder, you can set the environment variable as follows:
 ```
-$ CUSTOM_SAMPLES_PATH=tests/e2e/samples/custom
+CUSTOM_SAMPLES_PATH=tests/e2e/samples/custom
 ```
 
 Note: when setting this environment variable, make sure that the folder contains the kustomize files with the same structure as the upstream sample files. This means that the folder should contain:
@@ -318,12 +318,12 @@ To run the test group, you can use the following command:
 * Run the following command to run the smoke tests:
 For running on kind:
 ```
-$ SKIP_BUILD=true SKIP_DEPLOY=true GINKGO_FLAGS="-v --label-filter=smoke" make test.e2e.kind
+SKIP_BUILD=true SKIP_DEPLOY=true GINKGO_FLAGS="-v --label-filter=smoke" make test.e2e.kind
 ```
 
 For running on OCP:
 ```
-$ SKIP_BUILD=true SKIP_DEPLOY=true GINKGO_FLAGS="-v --label-filter=smoke" make test.e2e.ocp
+SKIP_BUILD=true SKIP_DEPLOY=true GINKGO_FLAGS="-v --label-filter=smoke" make test.e2e.ocp
 ```
 
 #### Running with specific configuration for the Istio and IstioCNI resource
@@ -364,7 +364,7 @@ versions:
 
 * To run the test framework against a specific Istio version, you can use the following command:
 ```
-$ VERSIONS_YAML_FILE=custom_versions.yaml SKIP_BUILD=true SKIP_DEPLOY=true GINKGO_FLAGS="-v --label-filter=smoke" make test.e2e.kind
+VERSIONS_YAML_FILE=custom_versions.yaml SKIP_BUILD=true SKIP_DEPLOY=true GINKGO_FLAGS="-v --label-filter=smoke" make test.e2e.kind
 ```
 Note: The `custom_versions.yaml` file must be placed in the `pkg/istioversion` directory. The test framework uses this file to run tests against the specific Istio versions it defines.
 
@@ -401,7 +401,7 @@ Test Suite Failed
 The end-to-end test suite is defined in the `tests/e2e/operator` directory. If you want to check the test definition without running the test, you can use the following make target:
 
 ```
-$ make test.e2e.describe
+make test.e2e.describe
 ```
 
 When you run this target, the test definitions will be printed to the console with format `indent`. For example:


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [X] Documentation Update

#### What this PR does / why we need it:

Shell commands with "$" prefix can't be just copied and executed in a terminal.