### PR TITLE
Fix istiorevision int test for new PDB default behavior

### DIFF
--- a/tests/integration/api/istiorevision_test.go
+++ b/tests/integration/api/istiorevision_test.go
@@ -406,7 +406,8 @@ var _ = Describe("IstioRevision resource", Label("istiorevision"), Ordered, func
 						},
 						Revision: ptr.Of(revName),
 						Pilot: &v1.PilotConfig{
-							Image: ptr.Of(pilotImage),
+							Image:        ptr.Of(pilotImage),
+							AutoscaleMin: ptr.Of(uint32(2)),
 						},
 					},
 				},


### PR DESCRIPTION
After https://github.com/istio/istio/pull/57202 the PDB is not created by default. This change is setting AutoscaleMin to 2 so the PDB is created and the tests is passing
