### PR TITLE
docs: remove remaining "$" prefixes from code blocks

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -46,7 +46,7 @@ Default configuration values can be changed using one or more `--set <parameter>
 1. Create the namespace, `sail-operator`, for the Sail Operator components:
 
     ```sh
-    $ kubectl create namespace sail-operator
+    kubectl create namespace sail-operator
     ```
 
 **Note** - This step could be skipped by using the `--create-namespace` argument in step 2.
@@ -54,13 +54,13 @@ Default configuration values can be changed using one or more `--set <parameter>
 2. Install the Sail Operator base charts which will manage all the Custom Resource Definitions(CRDs) to be able to deploy the Istio control plane:
 
     ```sh
-    $ helm install sail-operator sail-operator/sail-operator --version 1.26.3 --namespace sail-operator
+    helm install sail-operator sail-operator/sail-operator --version 1.26.3 --namespace sail-operator
     ```
 
 3. Validate the CRD installation with the `helm ls` command:
 
     ```sh
-    $ helm ls -n sail-operator
+    helm ls -n sail-operator
 
     NAME  	      NAMESPACE    	REVISION	UPDATED                                	STATUS  	CHART               	APP VERSION
     sail-operator	sail-operator	1       	2025-08-20 16:14:12.210759174 +0300 IDT	deployed	sail-operator-1.26.3	1.26.3
@@ -69,7 +69,7 @@ Default configuration values can be changed using one or more `--set <parameter>
 4. Get the status of the installed helm chart to ensure it is deployed:
 
     ```bash
-    $ helm status sail-operator -n sail-operator
+    helm status sail-operator -n sail-operator
 
     NAME: sail-operator
     LAST DEPLOYED: Wed Aug 20 16:14:12 2025
@@ -82,12 +82,12 @@ Default configuration values can be changed using one or more `--set <parameter>
 5. Check `sail-operator` deployment is successfully installed and its pods are running:
 
     ```sh
-    $ kubectl -n sail-operator get deployment --output wide
+    kubectl -n sail-operator get deployment --output wide
 
     NAME            READY   UP-TO-DATE   AVAILABLE   AGE     CONTAINERS      IMAGES                                  SELECTOR
     sail-operator   1/1     1            1           4h37m   sail-operator   quay.io/sail-dev/sail-operator:1.26.3   app.kubernetes.io/created-by=sailoperator,app.kubernetes.io/part-of=sailoperator,control-plane=sail-operator
 
-    $ kubectl -n sail-operator get pods -o wide
+    kubectl -n sail-operator get pods -o wide
 
     NAME                             READY   STATUS    RESTARTS   AGE     IP           NODE                                       NOMINATED NODE   READINESS GATES
     sail-operator-79c7d9ffb9-bwfdf   1/1     Running   0          4h38m   10.244.0.5   operator-integration-tests-control-plane   <none>           <none>

--- a/docs/README.md
+++ b/docs/README.md
@@ -204,10 +204,10 @@ with_retries resource_version_equal "istiocni" "default" "v1.24.2"
 -->
 2. Confirm the installation and version of the CNI plugin.
     ```console
-    $ kubectl get istiocni -n istio-cni
+    kubectl get istiocni -n istio-cni
     NAME      READY   STATUS    VERSION   AGE
     default   True    Healthy   v1.24.2   91m
-    $ kubectl get pods -n istio-cni
+    kubectl get pods -n istio-cni
     NAME                   READY   STATUS    RESTARTS   AGE
     istio-cni-node-hd9zf   1/1     Running   0          90m
     ```
@@ -234,10 +234,10 @@ wait_cni_ready "istio-cni"
 4. Confirm the CNI plugin version was updated.
 
     ```console
-    $ kubectl get istiocni -n istio-cni
+    kubectl get istiocni -n istio-cni
     NAME      READY   STATUS    VERSION   AGE
     default   True    Healthy   v1.24.3   93m
-    $ kubectl get pods -n istio-cni
+    kubectl get pods -n istio-cni
     NAME                   READY   STATUS    RESTARTS   AGE
     istio-cni-node-jz4lg   1/1     Running   0          44s
     ```

--- a/docs/addons/observability.md
+++ b/docs/addons/observability.md
@@ -158,7 +158,7 @@ If you followed [Scraping metrics using the OpenShift monitoring stack](#scrapin
 1. Find out the revision name of your Istio instance. In our case it is `test`.
     
     ```console
-    $ kubectl get istiorevisions.sailoperator.io 
+    kubectl get istiorevisions.sailoperator.io
     NAME   READY   STATUS    IN USE   VERSION   AGE
     test   True    Healthy   True     v1.21.0   119m
     ```

--- a/docs/common/create-and-configure-gateways.md
+++ b/docs/common/create-and-configure-gateways.md
@@ -31,26 +31,26 @@ where the application is installed:
 1. Create the `istio-ingressgateway` deployment and service:
 
     ```sh
-    $ kubectl apply -f ingress-gateway.yaml
+    kubectl apply -f ingress-gateway.yaml
     ```
 
 2. Configure the `bookinfo` application with the new gateway:
 
     ```sh
-    $ kubectl apply -f https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/networking/bookinfo-gateway.yaml
+    kubectl apply -f https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/networking/bookinfo-gateway.yaml
     ```
 
 3. On OpenShift, you can use a [Route](https://docs.openshift.com/container-platform/4.13/networking/routes/route-configuration.html) to expose the gateway externally: 
 
     ```sh
-    $ kubectl expose service istio-ingressgateway
+    kubectl expose service istio-ingressgateway
     ```
 
 4. Finally, obtain the gateway host name and the URL of the product page:
 
     ```sh
-    $ HOST=$(kubectl get route istio-ingressgateway -o jsonpath='{.spec.host}')
-    $ echo http://$HOST/productpage
+    HOST=$(kubectl get route istio-ingressgateway -o jsonpath='{.spec.host}')
+    echo http://$HOST/productpage
     ```
 
 Verify that the `productpage` is accessible from a web browser. 
@@ -62,13 +62,13 @@ An egress gateway allows you to control outbound traffic from the service mesh, 
 1. Create the `istio-egressgateway` namespace:
 
     ```sh
-    $ kubectl create namespace istio-egressgateway
+    kubectl create namespace istio-egressgateway
     ```
 
 2. Create the `istio-egressgateway` deployment and service using the provided [sample egress gateway configuration](../../chart/samples/egress-gateway.yaml?raw=1):
 
     ```sh
-    $ kubectl apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/chart/samples/egress-gateway.yaml -n istio-egressgateway
+    kubectl apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/chart/samples/egress-gateway.yaml -n istio-egressgateway
     ```
 
 3. Configure traffic routing to use the egress gateway by creating these resources in the `istio-egressgateway` namespace. For example, to route traffic to `httpbin.org` through the egress gateway:
@@ -153,13 +153,13 @@ An egress gateway allows you to control outbound traffic from the service mesh, 
    Apply this configuration:
 
     ```sh
-    $ kubectl apply -f egress-gateway-config.yaml
+    kubectl apply -f egress-gateway-config.yaml
     ```
 
 4. Test the egress gateway by making a request from a pod in the mesh (EG: using a bookinfo pod within the mesh):
 
     ```sh
-    $ kubectl exec -it $(kubectl get pod -l app=productpage -o jsonpath='{.items[0].metadata.name}') -c productpage -- curl -v http://httpbin.org/get
+    kubectl exec -it $(kubectl get pod -l app=productpage -o jsonpath='{.items[0].metadata.name}') -c productpage -- curl -v http://httpbin.org/get
     ```
 
 **Note:** With gateway injection, the gateway proxy automatically handles the routing configuration for the injected workload. The VirtualService above directs mesh traffic to the egress gateway service, and the gateway proxy forwards it to the external destination. This approach provides centralized egress traffic monitoring, policy enforcement, and security controls for outbound traffic.
@@ -183,21 +183,21 @@ To configure `bookinfo` with a gateway using `Gateway API`:
 1. Create and configure a gateway using a `Gateway` and `HTTPRoute` resource:
 
     ```sh
-    $ kubectl apply -f https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/gateway-api/bookinfo-gateway.yaml
+    kubectl apply -f https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/gateway-api/bookinfo-gateway.yaml
     ```
 
 2. Retrieve the host, port and gateway URL:
 
     ```sh
-    $ export INGRESS_HOST=$(kubectl get gtw bookinfo-gateway -o jsonpath='{.status.addresses[0].value}')
-    $ export INGRESS_PORT=$(kubectl get gtw bookinfo-gateway -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
-    $ export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
+    export INGRESS_HOST=$(kubectl get gtw bookinfo-gateway -o jsonpath='{.status.addresses[0].value}')
+    export INGRESS_PORT=$(kubectl get gtw bookinfo-gateway -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
+    export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
     ```
 
 3. Obtain the `productpage` URL and check that you can visit it from a browser:
 
    ```sh
-    $ echo "http://${GATEWAY_URL}/productpage"
+    echo "http://${GATEWAY_URL}/productpage"
     ```
 
 ### Deploying an Egress Gateway with Kubernetes Gateway API
@@ -211,8 +211,8 @@ To deploy an egress gateway using the Gateway API, follow these steps:
 1. **Create the egress gateway namespace:**
 
     ```sh
-    $ kubectl create namespace egress-gateway
-    $ kubectl label namespace egress-gateway istio-injection=enabled
+    kubectl create namespace egress-gateway
+    kubectl label namespace egress-gateway istio-injection=enabled
     ```
 
 2. **Apply the sample egress gateway configuration:**
@@ -220,7 +220,7 @@ To deploy an egress gateway using the Gateway API, follow these steps:
     We provide a sample manifest that includes a `ServiceEntry`, `Gateway`, and `HTTPRoute`s for egress to `httpbin.org` [here](../../chart/samples/egress-gateway-gw-api.yaml?raw=1):
 
     ```sh
-    $ kubectl apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/chart/samples/egress-gateway-gw-api.yaml -n egress-gateway
+    kubectl apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/chart/samples/egress-gateway-gw-api.yaml -n egress-gateway
     ```
 
     This will:

--- a/docs/common/install-istioctl-tool.md
+++ b/docs/common/install-istioctl-tool.md
@@ -24,27 +24,27 @@ releases, including Beta releases.
 the following command at the terminal:
 
     ```sh
-    $ istioctl version
+    istioctl version
     ```
 
 2. Confirm the version of Istio you are using by running the following command 
 at the terminal:
 
     ```sh
-    $ oc get istio
+    oc get istio
     ```
 
 3. Install `istioctl` by running the following command at the terminal: 
 
     ```sh
-    $ curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=<version> sh -
+    curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=<version> sh -
     ```
     Replace `<version>` with the version of Istio you are using.
 
 4. Put the `istioctl` directory on path by running the following command at the terminal:
   
     ```sh
-    $ export PATH=$HOME/.istioctl/bin:$PATH
+    export PATH=$HOME/.istioctl/bin:$PATH
     ```
 
 5. Confirm that the `istioctl` client version and the Istio control plane 
@@ -52,7 +52,7 @@ version now match (or are within one version) by running the following command
 at the terminal:
 
     ```sh
-    $ istioctl version
+    istioctl version
     ```
 For more information on usage, see the [Istioctl documentation](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/).
 

--- a/docs/common/istio-addons-integrations.md
+++ b/docs/common/istio-addons-integrations.md
@@ -27,19 +27,19 @@ To install Prometheus, perform the following steps:
 1. Deploy `Prometheus`:
 
     ```sh
-    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/prometheus.yaml
+    oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/prometheus.yaml
     ```
 2. Access to `Prometheus`console:
 
     * Expose the `Prometheus` service externally:
     
     ```sh
-    $ oc expose service prometheus -n istio-system
+    oc expose service prometheus -n istio-system
     ```
     * Get the route of the service and open the URL in the web browser
     
     ```sh
-    $ oc get route prometheus -o jsonpath='{.spec.host}' -n istio-system
+    oc get route prometheus -o jsonpath='{.spec.host}' -n istio-system
     ```
 
 
@@ -54,7 +54,7 @@ To install Grafana, perform the following steps:
 1. Deploy `Grafana`:
     
     ```sh
-    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/grafana.yaml
+    oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/grafana.yaml
     ```
 
 2. Access to `Grafana`console:
@@ -62,12 +62,12 @@ To install Grafana, perform the following steps:
     * Expose the `Grafana` service externally
     
     ```sh
-    $ oc expose service grafana -n istio-system
+    oc expose service grafana -n istio-system
     ```
     * Get the route of the service and open the URL in the web browser
     
     ```sh
-    $ oc get route grafana -o jsonpath='{.spec.host}' -n istio-system
+    oc get route grafana -o jsonpath='{.spec.host}' -n istio-system
     ```
 
 
@@ -82,20 +82,20 @@ To install Jaeger, perform the following steps:
 1. Deploy `Jaeger`:
     
     ```sh
-    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/jaeger.yaml
+    oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/jaeger.yaml
     ```
 2. Access to `Jaeger` console:
 
     * Expose the `Jaeger` service externally:
 
         ```sh
-        $ oc expose svc/tracing -n istio-system
+        oc expose svc/tracing -n istio-system
         ```
 
     * Get the route of the service and open the URL in the web browser
 
         ```sh
-        $ oc get route tracing -o jsonpath='{.spec.host}' -n istio-system
+        oc get route tracing -o jsonpath='{.spec.host}' -n istio-system
         ```
 *Note*: if you want to see some traces you can refresh several times the product 
 page of bookinfo app to start generating traces.
@@ -111,7 +111,7 @@ To install Kiali, perform the following steps:
 1. Deploy `Kiali`:
     
     ```sh
-    $ oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/kiali.yaml
+    oc apply -f https://raw.githubusercontent.com/istio/istio/master/samples/addons/kiali.yaml
     ```
 
 2. Access to `Kiali` console:
@@ -119,11 +119,11 @@ To install Kiali, perform the following steps:
     * Expose the `Kiali` service externally:
 
         ```sh
-        $ oc expose service kiali -n istio-system
+        oc expose service kiali -n istio-system
         ```
 
     * Get the route of the service and open the URL in the web browser
 
         ```sh
-        $ oc get route kiali -o jsonpath='{.spec.host}' -n istio-system
+        oc get route kiali -o jsonpath='{.spec.host}' -n istio-system
         ```

--- a/docs/deployment-models/multiple-mesh.md
+++ b/docs/deployment-models/multiple-mesh.md
@@ -122,7 +122,7 @@ Because each mesh will use its own root certificate authority and configured to 
 
 1. Check the labels on the control plane namespaces:
    ```console
-   $ kubectl get ns -l mesh -L mesh
+   kubectl get ns -l mesh -L mesh
    NAME            STATUS   AGE    MESH
    istio-system1   Active   106s   mesh1
    istio-system2   Active   105s   mesh2
@@ -136,7 +136,7 @@ Because each mesh will use its own root certificate authority and configured to 
 -->
 2. Check the control planes are `Healthy`:
    ```console
-   $ kubectl get istios
+   kubectl get istios
    NAME    REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
    mesh1   1           1       0        mesh1             Healthy   v1.24.0   84s
    mesh2   1           1       0        mesh2             Healthy   v1.24.0   77s
@@ -148,12 +148,12 @@ Because each mesh will use its own root certificate authority and configured to 
 -->
 3. Confirm that the validation and mutation webhook configurations exist for both meshes:
    ```console
-   $ kubectl get validatingwebhookconfigurations
+   kubectl get validatingwebhookconfigurations
    NAME                                  WEBHOOKS   AGE
    istio-validator-mesh1-istio-system1   1          2m45s
    istio-validator-mesh2-istio-system2   1          2m38s
 
-   $ kubectl get mutatingwebhookconfigurations
+   kubectl get mutatingwebhookconfigurations
    NAME                                         WEBHOOKS   AGE
    istio-sidecar-injector-mesh1-istio-system1   2          5m55s
    istio-sidecar-injector-mesh2-istio-system2   2          5m48s
@@ -215,17 +215,17 @@ Because each mesh will use its own root certificate authority and configured to 
 -->
 5. Confirm that a sidecar has been injected into each of the application pods. The value `2/2` should be displayed in the `READY` column for each pod, as in the following example:
    ```console
-   $ kubectl get pods -n app1
+   kubectl get pods -n app1
    NAME                       READY   STATUS    RESTARTS   AGE
    curl-5b549b49b8-mg7nl      2/2     Running   0          102s
    httpbin-7b549f7859-h6hnk   2/2     Running   0          89s
 
-   $ kubectl get pods -n app2a
+   kubectl get pods -n app2a
    NAME                       READY   STATUS    RESTARTS   AGE
    curl-5b549b49b8-2hlvm      2/2     Running   0          2m3s
    httpbin-7b549f7859-bgblg   2/2     Running   0          110s
 
-   $ kubectl get pods -n app2b
+   kubectl get pods -n app2b
    NAME                       READY   STATUS    RESTARTS   AGE
    curl-5b549b49b8-xnzzk      2/2     Running   0          2m9s
    httpbin-7b549f7859-7k5gf   2/2     Running   0          118s

--- a/docs/dual-stack/dual-stack.md
+++ b/docs/dual-stack/dual-stack.md
@@ -127,7 +127,7 @@ Note: If you installed the KinD cluster using the command above, install the [Sa
 
 4. Ensure that the tcp-echo service in the dual-stack namespace is configured with `ipFamilyPolicy` of RequireDualStack.
    ```console
-   $ kubectl get service tcp-echo -n dual-stack -o=jsonpath='{.spec.ipFamilyPolicy}'
+   kubectl get service tcp-echo -n dual-stack -o=jsonpath='{.spec.ipFamilyPolicy}'
    RequireDualStack
    ```
 <!-- ```bash { name=validation-ipfamilypolicy tag=dual-stack}
@@ -142,7 +142,7 @@ Note: If you installed the KinD cluster using the command above, install the [Sa
 ``` -->
 5. Verify that sleep pod is able to reach the dual-stack pods.
    ```console
-   $ kubectl exec -n sleep "$(kubectl get pod -n sleep -l app=sleep -o jsonpath='{.items[0].metadata.name}')" -- sh -c "echo dualstack | nc tcp-echo.dual-stack 9000"
+   kubectl exec -n sleep "$(kubectl get pod -n sleep -l app=sleep -o jsonpath='{.items[0].metadata.name}')" -- sh -c "echo dualstack | nc tcp-echo.dual-stack 9000"
    hello dualstack
    ```
 <!-- ```bash { name=validation-sleep-reach-dual-stack tag=dual-stack}
@@ -157,7 +157,7 @@ Note: If you installed the KinD cluster using the command above, install the [Sa
 ``` -->
 6. Similarly verify that sleep pod is able to reach both ipv4 pods as well as ipv6 pods.
    ```console
-   $ kubectl exec -n sleep "$(kubectl get pod -n sleep -l app=sleep -o jsonpath='{.items[0].metadata.name}')" -- sh -c "echo ipv4 | nc tcp-echo.ipv4 9000"
+   kubectl exec -n sleep "$(kubectl get pod -n sleep -l app=sleep -o jsonpath='{.items[0].metadata.name}')" -- sh -c "echo ipv4 | nc tcp-echo.ipv4 9000"
    hello ipv4
    ```
 <!-- ```bash { name=validation-sleep-reach-ipv4-pod tag=dual-stack}
@@ -171,7 +171,7 @@ Note: If you installed the KinD cluster using the command above, install the [Sa
     fi
 ``` -->
    ```console
-   $ kubectl exec -n sleep "$(kubectl get pod -n sleep -l app=sleep -o jsonpath='{.items[0].metadata.name}')" -- sh -c "echo ipv6 | nc tcp-echo.ipv6 9000"
+   kubectl exec -n sleep "$(kubectl get pod -n sleep -l app=sleep -o jsonpath='{.items[0].metadata.name}')" -- sh -c "echo ipv6 | nc tcp-echo.ipv6 9000"
    hello ipv6
    ```
 <!-- ```bash { name=validation-sleep-reach-ipv4-pod tag=dual-stack}

--- a/docs/general/getting-started.md
+++ b/docs/general/getting-started.md
@@ -73,7 +73,7 @@ is installed. `Succeeded` should appear in the **Status** column.
 1. Verify that the installation succeeded by inspecting the CSV status.
 
     ```console
-    $ kubectl get csv -n openshift-operators
+    kubectl get csv -n openshift-operators
     NAME                                     DISPLAY         VERSION                    REPLACES                                 PHASE
     sailoperator.v0.1.0-nightly-2024-06-25   Sail Operator   0.1.0-nightly-2024-06-25   sailoperator.v0.1.0-nightly-2024-06-21   Succeeded
     ```

--- a/docs/update-strategy/update-strategy.md
+++ b/docs/update-strategy/update-strategy.md
@@ -55,7 +55,7 @@ Steps:
 3. Confirm the installation and version of the control plane.
 
     ```console
-    $ kubectl get istio -n istio-system
+    kubectl get istio -n istio-system
     NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
     default   1           1       0        default           Healthy   v1.25.3   23s
     ```
@@ -81,7 +81,7 @@ Steps:
 5. Review the `Istio` resource after application deployment.
 
    ```console
-   $ kubectl get istio -n istio-system
+   kubectl get istio -n istio-system
    NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
    default   1           1       1        default           Healthy   v1.25.3   115s
    ```
@@ -106,7 +106,7 @@ Steps:
 7. Confirm the `Istio` resource version was updated.
 
     ```console
-    $ kubectl get istio -n istio-system
+    kubectl get istio -n istio-system
     NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
     default   1           1       1        default           Healthy   v1.26.0   4m50s
     ```
@@ -190,7 +190,7 @@ Steps:
 3. Confirm the control plane is installed and is using the desired version.
 
     ```console
-    $ kubectl get istio -n istio-system
+    kubectl get istio -n istio-system
     NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
     default   1           1       0        default-v1-25-3   Healthy   v1.25.3   52s
     ```
@@ -199,7 +199,7 @@ Steps:
 4. Get the `IstioRevision` name.
 
     ```console
-    $ kubectl get istiorevision -n istio-system
+    kubectl get istiorevision -n istio-system
     NAME              TYPE    READY   STATUS    IN USE   VERSION   AGE
     default-v1-25-3   Local   True    Healthy   False    v1.25.3   3m4s
     ```
@@ -234,7 +234,7 @@ Steps:
 7. Review the `Istio` resource after application deployment.
 
     ```console
-    $ kubectl get istio -n istio-system
+    kubectl get istio -n istio-system
     NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
     default   1           1       1        default-v1-25-3   Healthy   v1.25.3   5m13s
     ```
@@ -269,11 +269,11 @@ Steps:
 10. Verify the `Istio` and `IstioRevision` resources. There will be a new revision created with the new version.
 
     ```console
-    $ kubectl get istio
+    kubectl get istio
     NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
     default   2           2       1        default-v1-26-0   Healthy   v1.26.0   9m23s
 
-    $ kubectl get istiorevision
+    kubectl get istiorevision
     NAME              TYPE    READY   STATUS    IN USE   VERSION   AGE
     default-v1-25-3   Local   True    Healthy   True     v1.25.3   10m
     default-v1-26-0   Local   True    Healthy   False    v1.26.0   66s
@@ -290,7 +290,7 @@ Steps:
 11. Confirm there are two control plane pods running, one for each revision.
 
     ```console
-    $ kubectl get pods -n istio-system
+    kubectl get pods -n istio-system
     NAME                                      READY   STATUS    RESTARTS   AGE
     istiod-default-v1-25-3-c98fd9675-r7bfw    1/1     Running   0          10m
     istiod-default-v1-26-0-7495cdc7bf-v8t4g   1/1     Running   0          113s
@@ -351,15 +351,15 @@ Steps:
 16. Confirm the deletion of the old control plane and IstioRevision.
 
     ```console
-    $ kubectl get pods -n istio-system
+    kubectl get pods -n istio-system
     NAME                                      READY   STATUS    RESTARTS   AGE
     istiod-default-v1-26-0-7495cdc7bf-v8t4g   1/1     Running   0          4m40s
 
-    $ kubectl get istio
+    kubectl get istio
     NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
     default   1           1       1        default-v1-26-0   Healthy   v1.26.0   5m
 
-    $ kubectl get istiorevision
+    kubectl get istiorevision
     NAME              TYPE    READY   STATUS    IN USE   VERSION   AGE
     default-v1-26-0   Local   True    Healthy   True     v1.26.0   5m31s
     ```
@@ -423,7 +423,7 @@ Steps:
 3. Confirm the control plane is installed and is using the desired version.
 
     ```console
-    $ kubectl get istio
+    kubectl get istio
     NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
     default   1           1       1        default-v1-25-3   Healthy   v1.25.3   52s
     ```
@@ -437,7 +437,7 @@ Steps:
 4. Inspect the `IstioRevisionTag`.
 
     ```console
-    $ kubectl get istiorevisiontags
+    kubectl get istiorevisiontags
     NAME      STATUS                    IN USE   REVISION          AGE
     default   NotReferencedByAnything   False    default-v1-25-3   52s
     ```
@@ -472,7 +472,7 @@ Steps:
 7. Review the `IstioRevisionTag` resource after application deployment.
 
     ```console
-    $ kubectl get istiorevisiontag
+    kubectl get istiorevisiontag
     NAME      STATUS    IN USE   REVISION          AGE
     default   Healthy   True     default-v1-25-3   2m46s
     ```
@@ -500,16 +500,16 @@ Steps:
 10. Verify the `Istio`, `IstioRevision` and `IstioRevisionTag` resources. There will be a new revision created with the new version.
 
     ```console
-    $ kubectl get istio
+    kubectl get istio
     NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
     default   2           2       1        default-v1-26-0   Healthy   v1.26.0   9m23s
 
-    $ kubectl get istiorevision
+    kubectl get istiorevision
     NAME              TYPE    READY   STATUS    IN USE   VERSION   AGE
     default-v1-25-3   Local   True    Healthy   True     v1.25.3   10m
     default-v1-26-0   Local   True    Healthy   True    v1.26.0   66s
 
-    $ kubectl get istiorevisiontag
+    kubectl get istiorevisiontag
     NAME      STATUS    IN USE   REVISION          AGE
     default   Healthy   True     default-v1-26-0   10m44s
     ```
@@ -518,7 +518,7 @@ Steps:
 11. Confirm there are two control plane pods running, one for each revision.
 
     ```console
-    $ kubectl get pods -n istio-system
+    kubectl get pods -n istio-system
     NAME                                      READY   STATUS    RESTARTS   AGE
     istiod-default-v1-25-3-c98fd9675-r7bfw    1/1     Running   0          10m
     istiod-default-v1-26-0-7495cdc7bf-v8t4g   1/1     Running   0          113s
@@ -573,15 +573,15 @@ Steps:
 16. Confirm the deletion of the old control plane and IstioRevision.
 
     ```console
-    $ kubectl get pods -n istio-system
+    kubectl get pods -n istio-system
     NAME                                      READY   STATUS    RESTARTS   AGE
     istiod-default-v1-26-0-7495cdc7bf-v8t4g   1/1     Running   0          4m40s
 
-    $ kubectl get istio -n istio-system
+    kubectl get istio -n istio-system
     NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
     default   1           1       1        default-v1-26-0   Healthy   v1.26.0   5m
 
-    $ kubectl get istiorevision -n istio-system
+    kubectl get istiorevision -n istio-system
     NAME              TYPE    READY   STATUS    IN USE   VERSION   AGE
     default-v1-26-0   Local   True    Healthy   True     v1.26.0   5m31s
     ```


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [X] Documentation Update

#### What this PR does / why we need it:

It's a follow-up to #1141 as `claude-4-sonnet` was not good enough to find all code blocks with "$" prefix. :)
