### PR TITLE
Revert default MaxConcurrentReconciles to 1

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,7 +56,7 @@ func main() {
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&configFile, "config-file", "/etc/sail-operator/config.properties", "Location of the config file, propagated by k8s downward APIs")
 	flag.StringVar(&reconcilerCfg.ResourceDirectory, "resource-directory", "/var/lib/sail-operator/resources", "Where to find resources (e.g. charts)")
-	flag.IntVar(&reconcilerCfg.MaxConcurrentReconciles, "max-concurrent-reconciles", 5,
+	flag.IntVar(&reconcilerCfg.MaxConcurrentReconciles, "max-concurrent-reconciles", 1,
 		"MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.")
 	flag.BoolVar(&logAPIRequests, "log-api-requests", false, "Whether to log each request sent to the Kubernetes API server")
 	flag.BoolVar(&printVersion, "version", printVersion, "Prints version information and exits")

--- a/controllers/istio/istio_controller_test.go
+++ b/controllers/istio/istio_controller_test.go
@@ -1094,6 +1094,6 @@ func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
 		ResourceDirectory:       t.TempDir(),
 		Platform:                config.PlatformKubernetes,
 		DefaultProfile:          "",
-		MaxConcurrentReconciles: 5,
+		MaxConcurrentReconciles: 1,
 	}
 }

--- a/controllers/istiocni/istiocni_controller_test.go
+++ b/controllers/istiocni/istiocni_controller_test.go
@@ -708,6 +708,6 @@ func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
 		ResourceDirectory:       t.TempDir(),
 		Platform:                config.PlatformKubernetes,
 		DefaultProfile:          "",
-		MaxConcurrentReconciles: 5,
+		MaxConcurrentReconciles: 1,
 	}
 }

--- a/controllers/istiorevision/istiorevision_controller_test.go
+++ b/controllers/istiorevision/istiorevision_controller_test.go
@@ -1056,6 +1056,6 @@ func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
 		ResourceDirectory:       t.TempDir(),
 		Platform:                config.PlatformKubernetes,
 		DefaultProfile:          "",
-		MaxConcurrentReconciles: 5,
+		MaxConcurrentReconciles: 1,
 	}
 }

--- a/controllers/istiorevisiontag/istiorevisiontag_controller_test.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller_test.go
@@ -280,7 +280,7 @@ func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
 		ResourceDirectory:       t.TempDir(),
 		Platform:                config.PlatformKubernetes,
 		DefaultProfile:          "",
-		MaxConcurrentReconciles: 5,
+		MaxConcurrentReconciles: 1,
 	}
 }
 

--- a/controllers/webhook/webhook_controller_test.go
+++ b/controllers/webhook/webhook_controller_test.go
@@ -618,6 +618,6 @@ func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
 		ResourceDirectory:       t.TempDir(),
 		Platform:                config.PlatformKubernetes,
 		DefaultProfile:          "",
-		MaxConcurrentReconciles: 5,
+		MaxConcurrentReconciles: 1,
 	}
 }


### PR DESCRIPTION
We increased this to 5 recently but we decided that we want more testing around the feature before we change the default. Users can still manually increase it.

I'm also reverting it in the tests to make sure the tests use the same settings as a default deployment. We'll need to invest in proper testing of different values.
