### PR TITLE
istio: ignore `defaultRevision`

### DIFF
--- a/pkg/istiovalues/overrides.go
+++ b/pkg/istiovalues/overrides.go
@@ -14,7 +14,10 @@
 
 package istiovalues
 
-import v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+import (
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"istio.io/istio/pkg/ptr"
+)
 
 func ApplyOverrides(revisionName string, namespace string, values *v1.Values) {
 	// Set revision name to "" if revision name is "default". This is a temporary fix until we fix the injection
@@ -30,4 +33,8 @@ func ApplyOverrides(revisionName string, namespace string, values *v1.Values) {
 		values.Global = &v1.GlobalConfig{}
 	}
 	values.Global.IstioNamespace = &namespace
+
+	// Force defaultRevision to be empty to prevent creation of the default validator webhook.
+	// This field is deprecated and should be ignored by the operator.
+	values.DefaultRevision = ptr.Of("")
 }

--- a/pkg/istiovalues/overrides_test.go
+++ b/pkg/istiovalues/overrides_test.go
@@ -41,6 +41,7 @@ func TestApplyOverrides(t *testing.T) {
 				Global: &v1.GlobalConfig{
 					IstioNamespace: ptr.Of("ns1"),
 				},
+				DefaultRevision: ptr.Of(""),
 			},
 		},
 		{
@@ -53,6 +54,7 @@ func TestApplyOverrides(t *testing.T) {
 				Global: &v1.GlobalConfig{
 					IstioNamespace: ptr.Of("ns1"),
 				},
+				DefaultRevision: ptr.Of(""),
 			},
 		},
 		{
@@ -67,6 +69,7 @@ func TestApplyOverrides(t *testing.T) {
 				Global: &v1.GlobalConfig{
 					IstioNamespace: ptr.Of("ns1"),
 				},
+				DefaultRevision: ptr.Of(""),
 			},
 		},
 		{
@@ -83,6 +86,22 @@ func TestApplyOverrides(t *testing.T) {
 				Global: &v1.GlobalConfig{
 					IstioNamespace: ptr.Of("ns1"),
 				},
+				DefaultRevision: ptr.Of(""),
+			},
+		},
+		{
+			name:      "defaultRevision-is-ignored-when-set-by-user",
+			revision:  "my-revision",
+			namespace: "ns1",
+			values: v1.Values{
+				DefaultRevision: ptr.Of("my-revision"),
+			},
+			expectedValues: v1.Values{
+				Revision: ptr.Of("my-revision"),
+				Global: &v1.GlobalConfig{
+					IstioNamespace: ptr.Of("ns1"),
+				},
+				DefaultRevision: ptr.Of(""),
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

- [X] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

Istio resource includes the `defaultRevision` field which is used for controlling creation of the default validation webhook, which belongs to the base chart. Since the base chart is intended for managing cluster-scoped objects, it shouldn't be exposed in the Istio resource, because different revisions or tenants can affect webhooks created by others.

That field was deprecated in #760, hidden from documentation, but it wasn't actually ignored as a comment for that field says.

This may be potentially a breaking change for users who rely on the default revision webhook, so we may consider adding a CRD for managing cluster-scoped objects first.
