### PR TITLE
Fix api_transformer's handling of inline comments

### DIFF
--- a/hack/api_transformer/main.go
+++ b/hack/api_transformer/main.go
@@ -292,7 +292,14 @@ func (t *FileTransformer) processFile() (*ast.File, error) {
 					}
 					for _, f := range structType.Fields.List {
 						if slices.Contains(ct.IncludeFields, f.Names[0].Name) {
-							structCopy.Fields.List = append(structCopy.Fields.List, f)
+							fCopy := &ast.Field{
+								Comment: nil, // remove inline comments
+								Doc:     f.Doc,
+								Names:   f.Names,
+								Type:    f.Type,
+								Tag:     f.Tag,
+							}
+							structCopy.Fields.List = append(structCopy.Fields.List, fCopy)
 						}
 					}
 					declCopy := &ast.GenDecl{


### PR DESCRIPTION
Copying inline comments leads to corruption of the output sometimes. I still don't fully understand how - it's likely because of how we're re-using existing AST nodes to create the new AST and don't recreate the position information in it.

This fixes the problems we're seeing on release-1.27 branch when adding the NativeNftables field.
