### PR TITLE
Allow set multicluster flag with env

### DIFF
--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -32,7 +32,7 @@ parse_flags() {
   SKIP_DEPLOY=${SKIP_DEPLOY:-false}
   OLM=${OLM:-false}
   DESCRIBE=false
-  MULTICLUSTER=false
+  MULTICLUSTER=${MULTICLUSTER:-false}
   while [ $# -gt 0 ]; do
     case "$1" in
       --ocp)


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

Now in test run
```
export MULTICLUSTER="true"
make test.e2e.ocp
```
multicluster option will be ignored and stay **false**

PR allows to set MULTICLUSTER varialbe not only with arg as `--multicluster` but also with the ENV variable 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

https://issues.redhat.com/browse/OSSM-8193

#### Additional information:
