### PR TITLE
Add OCP-specific flag to CreateRemoteSecret

### DIFF
--- a/tests/e2e/util/istioctl/istioctl.go
+++ b/tests/e2e/util/istioctl/istioctl.go
@@ -53,6 +53,9 @@ func CreateRemoteSecret(remoteKubeconfig, namespace, secretName, internalIP stri
 	if len(additionalFlags) != 0 {
 		cmd += (" " + strings.Join(additionalFlags, " "))
 	}
+	if env.GetBool("OCP", false) {
+		cmd += " --create-service-account=false"
+	}
 
 	yaml, err := shell.ExecuteCommand(cmd)
 


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

Use the '--create-service-account=false' flag when creating remote secrets on OpenShift.

Allows to avoid OCP specific failures:

```
[FAILED] Unexpected error:
      <*errors.errorString | 0xc003a3a970>: 
      error executing command: /usr/bin/sh -c /home/jenkins/workspace/sail/sail-operator-e2e-tests/sail-operator/bin/istioctl create-remote-secret --kubeconfig /home/jenkins/workspace/sail/sail-operator-e2e-tests/kubeconfig2.yaml --namespace istio-system --name remote --server=https://api.user-rhos-d-5.servicemesh.rhqeaws.com:6443/: error: could not get access token to read resources from local kube-apiserver: '--create-service-account=false' should be set when using OpenShift Service Mesh Operator
      Error: could not get access token to read resources from local kube-apiserver: '--create-service-account=false' should be set when using OpenShift Service Mesh Operator
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

https://issues.redhat.com/browse/OSSM-8193

#### Additional information:
