### PR TITLE
Remove explicit labelling for multicluster network

### DIFF
--- a/docs/deployment-models/multicluster.md
+++ b/docs/deployment-models/multicluster.md
@@ -123,13 +123,11 @@ These steps are common to every multi-cluster deployment and should be completed
 
 6. Push the intermediate CAs to each cluster.
     ```bash
-    kubectl --context "${CTX_CLUSTER1}" label namespace istio-system topology.istio.io/network=network1
     kubectl get secret -n istio-system --context "${CTX_CLUSTER1}" cacerts || kubectl create secret generic cacerts -n istio-system --context "${CTX_CLUSTER1}" \
       --from-file=east/ca-cert.pem \
       --from-file=east/ca-key.pem \
       --from-file=east/root-cert.pem \
       --from-file=east/cert-chain.pem
-    kubectl --context "${CTX_CLUSTER2}" label namespace istio-system topology.istio.io/network=network2
     kubectl get secret -n istio-system --context "${CTX_CLUSTER2}" cacerts || kubectl create secret generic cacerts -n istio-system --context "${CTX_CLUSTER2}" \
       --from-file=west/ca-cert.pem \
       --from-file=west/ca-key.pem \
@@ -407,11 +405,10 @@ In this setup there is a Primary cluster (`cluster1`) and a Remote cluster (`clu
     EOF
     ```
 
-6. Set the controlplane cluster and network for `cluster2`.
+6. Set the controlplane cluster for `cluster2`.
 
     ```bash
     kubectl --context="${CTX_CLUSTER2}" annotate namespace istio-system topology.istio.io/controlPlaneClusters=cluster1
-    kubectl --context="${CTX_CLUSTER2}" label namespace istio-system topology.istio.io/network=network2
     ```
 
 7. Install a remote secret on `cluster1` that provides access to the `cluster2` API server.

--- a/docs/deployment-models/resources/setup-multi-primary.sh
+++ b/docs/deployment-models/resources/setup-multi-primary.sh
@@ -80,7 +80,6 @@ kubectl get ns sail-operator --context "${CTX_CLUSTER2}" || make -C "${SCRIPT_DI
 # 3. Create istio-system namespace on each cluster and configure a common root CA. 
 
 kubectl get ns istio-system --context "${CTX_CLUSTER1}" || kubectl create namespace istio-system --context "${CTX_CLUSTER1}"
-kubectl --context "${CTX_CLUSTER1}" label namespace istio-system topology.istio.io/network=network1
 kubectl get secret -n istio-system --context "${CTX_CLUSTER1}" cacerts || kubectl create secret generic cacerts -n istio-system --context "${CTX_CLUSTER1}" \
   --from-file=${CERTS_DIR}/east/ca-cert.pem \
   --from-file=${CERTS_DIR}/east/ca-key.pem \
@@ -88,7 +87,6 @@ kubectl get secret -n istio-system --context "${CTX_CLUSTER1}" cacerts || kubect
   --from-file=${CERTS_DIR}/east/cert-chain.pem
 
 kubectl get ns istio-system --context "${CTX_CLUSTER2}" || kubectl create namespace istio-system --context "${CTX_CLUSTER2}"
-kubectl --context "${CTX_CLUSTER2}" label namespace istio-system topology.istio.io/network=network2
 kubectl get secret -n istio-system --context "${CTX_CLUSTER2}" cacerts || kubectl create secret generic cacerts -n istio-system --context "${CTX_CLUSTER2}" \
   --from-file=${CERTS_DIR}/west/ca-cert.pem \
   --from-file=${CERTS_DIR}/west/ca-key.pem \

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -181,7 +181,6 @@ values:
 								"merge",
 								`{"metadata":{"annotations":{"topology.istio.io/controlPlaneClusters":"cluster1"}}}`)).
 							To(Succeed(), "Error patching istio-system namespace")
-						Expect(k2.Label("namespace", controlPlaneNamespace, "topology.istio.io/network", "network2")).To(Succeed(), "Error labeling istio-system namespace")
 
 						// To be able to access the remote cluster from the primary cluster, we need to create a secret in the primary cluster
 						// Remote Istio resource will not be Ready until the secret is created

--- a/tests/e2e/util/certs/certs.go
+++ b/tests/e2e/util/certs/certs.go
@@ -226,12 +226,6 @@ func PushIntermediateCA(k kubectl.Kubectl, ns, zone, network, basePath string, c
 	// Check if the secret exists in the cluster
 	_, err := common.GetObject(context.Background(), cl, kube.Key("cacerts", ns), &corev1.Secret{})
 	if err != nil {
-		// Label the namespace with the network
-		err = k.Label("namespace", ns, "topology.istio.io/network", network)
-		if err != nil {
-			return fmt.Errorf("failed to label namespace: %w", err)
-		}
-
 		// Read the pem content from the files
 		caCertPath := filepath.Join(certDir, zone, "ca-cert.pem")
 		caKeyPath := filepath.Join(certDir, zone, "ca-key.pem")


### PR DESCRIPTION
The network is already specified as part of the `Istio` CR and as such is passed to the Istio control plane when installed. The label seems not to be needed in such a case.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
