### PR TITLE
Make sure there are no empty channels after cleaning nightly builds

### DIFF
--- a/hack/operatorhub/clean-nightlies.sh
+++ b/hack/operatorhub/clean-nightlies.sh
@@ -61,6 +61,9 @@ do
   fi
 done
 
+# remove empty channels https://github.com/istio-ecosystem/sail-operator/issues/1192
+yq 'del(.entries[] | select(.entries | select(length == 0)))'  -i catalog-templates/basic.yaml
+
 # regenerate catalogs and validate them
 make catalogs
 make validate-catalogs


### PR DESCRIPTION
When cleaning the last remaining nightly build the channel remains empty which is not a valid state. We need to clean empty channels as well.

Fixes https://github.com/istio-ecosystem/sail-operator/issues/1192
