### PR TITLE
fix(e2e): Add cleanup trap to prevent false positives in CI test runs

### DIFF
--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -146,6 +146,7 @@ await_operator() {
   "${COMMAND}" wait --for=condition=available deployment/"${DEPLOYMENT_NAME}" -n "${NAMESPACE}" --timeout=5m
 }
 
+# shellcheck disable=SC2329  # Function is invoked indirectly via trap
 uninstall_operator() {
   echo "Uninstalling sail-operator (KUBECONFIG=${KUBECONFIG})"
   helm uninstall sail-operator --namespace "${NAMESPACE}"
@@ -153,12 +154,14 @@ uninstall_operator() {
 }
 
 # Ensure cleanup always runs and that the original test exit code is preserved
+# shellcheck disable=SC2329  # Function is invoked indirectly via trap
 cleanup() {
   # Do not let cleanup errors affect the final exit code
   set +e
   if [ "${OLM}" != "true" ] && [ "${SKIP_DEPLOY}" != "true" ]; then
     if [ "${MULTICLUSTER}" == true ]; then
       KUBECONFIG="${KUBECONFIG}" uninstall_operator || true
+      # shellcheck disable=SC2153  # KUBECONFIG2 is set by multicluster setup scripts
       KUBECONFIG="${KUBECONFIG2}" uninstall_operator || true
     else
       uninstall_operator || true

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -93,6 +93,11 @@ var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
 				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Deployment status")
 		})
 
+		// TODO: TEMPORARY TEST - Remove this test after verifying CI error handling
+		It("TEMPORARY: should fail to test CI error handling", func(ctx SpecContext) {
+			Fail("This test intentionally fails to verify CI correctly reports test failures")
+		})
+
 		It("serves metrics securely", func(ctx SpecContext) {
 			metricsReaderRoleName := "metrics-reader"
 			metricsServiceName := deploymentName + "-metrics-service"

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -93,11 +93,6 @@ var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
 				Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Error getting Deployment status")
 		})
 
-		// TODO: TEMPORARY TEST - Remove this test after verifying CI error handling
-		It("TEMPORARY: should fail to test CI error handling", func(ctx SpecContext) {
-			Fail("This test intentionally fails to verify CI correctly reports test failures")
-		})
-
 		It("serves metrics securely", func(ctx SpecContext) {
 			metricsReaderRoleName := "metrics-reader"
 			metricsServiceName := deploymentName + "-metrics-service"


### PR DESCRIPTION
The e2e test script was storing the Ginkgo exit code but could still exit unexpectedly before cleanup, causing CI to mark incomplete test runs as successful (false positives).

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
**Problem:**
The e2e test script was storing the Ginkgo exit code, but could still exit unexpectedly before cleanup, causing CI to mark incomplete test runs as successful (false positives).

**Solution:**
- Added a `cleanup()` function with `trap cleanup EXIT INT TERM` to ensure uninstall always runs
- Moved cleanup logic to the trap so it executes on normal exit, interrupts, and terminations
- Simplified the main flow to immediately exit with the captured Ginkgo exit code
- Cleanup errors are suppressed to preserve the original test result

**Result:**
- CI now correctly reflects test failures and interruptions
- JUnit reports are still generated and cleanup always occurs
- No more false positive test results from incomplete runs



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #1226

Related Issue/PR #

#### Additional information:
