### PR TITLE
Adding CI env var to e2e test workflow

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -97,6 +97,10 @@ endif
 # Set DOCKER_BUILD_FLAGS to specify flags to pass to 'docker build', default to empty. Example: --platform=linux/arm64
 DOCKER_BUILD_FLAGS ?= "--platform=$(TARGET_OS)/$(TARGET_ARCH)"
 
+# Set CI environment variable to true when running in CI environment
+CI ?= false
+
+# Set GOTEST_FLAGS and GINKGO_FLAGS for test targets
 GOTEST_FLAGS := $(if $(VERBOSE),-v) $(if $(COVERAGE),-coverprofile=$(REPO_ROOT)/out/coverage-unit.out)
 GINKGO_FLAGS ?= $(if $(VERBOSE),-v) $(if $(CI),--no-color) $(if $(COVERAGE),-coverprofile=coverage-integration.out -coverpkg=./... --output-dir=out)
 
@@ -215,7 +219,7 @@ test.scorecard: operator-sdk ## Run the operator scorecard test.
 
 .PHONY: test.e2e.ocp
 test.e2e.ocp: istioctl ## Run the end-to-end tests against an existing OCP cluster. While running on OCP in downstream you need to set ISTIOCTL_DOWNLOAD_URL to the URL where the istioctl productized binary.
-	GINKGO_FLAGS="$(GINKGO_FLAGS)" ${SOURCE_DIR}/tests/e2e/integ-suite-ocp.sh
+	GINKGO_FLAGS="$(GINKGO_FLAGS)" CI=${CI} ${SOURCE_DIR}/tests/e2e/integ-suite-ocp.sh
 
 .PHONY: test.e2e.ocp.cleanup
 test.e2e.ocp.cleanup: verify-kubeconfig ## Clean up leftover artifacts from e2e.ocp tests

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -97,8 +97,8 @@ endif
 # Set DOCKER_BUILD_FLAGS to specify flags to pass to 'docker build', default to empty. Example: --platform=linux/arm64
 DOCKER_BUILD_FLAGS ?= "--platform=$(TARGET_OS)/$(TARGET_ARCH)"
 
-# Set CI environment variable to true when running in CI environment
-CI ?= false
+# Set SKIP_INTERNAL_REGISTRY_SETUP environment variable to true to skip the internal registry setup.
+SKIP_INTERNAL_REGISTRY_SETUP ?= false
 
 # Set GOTEST_FLAGS and GINKGO_FLAGS for test targets
 GOTEST_FLAGS := $(if $(VERBOSE),-v) $(if $(COVERAGE),-coverprofile=$(REPO_ROOT)/out/coverage-unit.out)
@@ -219,7 +219,7 @@ test.scorecard: operator-sdk ## Run the operator scorecard test.
 
 .PHONY: test.e2e.ocp
 test.e2e.ocp: istioctl ## Run the end-to-end tests against an existing OCP cluster. While running on OCP in downstream you need to set ISTIOCTL_DOWNLOAD_URL to the URL where the istioctl productized binary.
-	GINKGO_FLAGS="$(GINKGO_FLAGS)" CI=${CI} ${SOURCE_DIR}/tests/e2e/integ-suite-ocp.sh
+	GINKGO_FLAGS="$(GINKGO_FLAGS)" SKIP_INTERNAL_REGISTRY_SETUP=${SKIP_INTERNAL_REGISTRY_SETUP} ${SOURCE_DIR}/tests/e2e/integ-suite-ocp.sh
 
 .PHONY: test.e2e.ocp.cleanup
 test.e2e.ocp.cleanup: verify-kubeconfig ## Clean up leftover artifacts from e2e.ocp tests

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -174,7 +174,7 @@ check_cluster_operators() {
 
 install_operator() {
   echo "Installing sail-operator (KUBECONFIG=${KUBECONFIG})"
-  "${COMMAND}" create namespace "${NAMESPACE}"
+  "${COMMAND}" create namespace "${NAMESPACE}" || true
   helm install sail-operator "${SOURCE_DIR}"/chart --namespace "${NAMESPACE}" --set image="${HUB}/${IMAGE_BASE}:${TAG}" --set operatorLogLevel=3
 }
 
@@ -230,7 +230,7 @@ if [ "${SKIP_BUILD}" == "false" ]; then
 
     # Workaround for OCP helm operator installation issues:
     # To avoid any cleanup issues, after we build and push the image we check if the namespace exists and delete it if it does.
-    # The test logic already handles the namespace creation and deletion during the test run. 
+    # The test logic already handles the namespace creation and deletion during the test run.
     if ${COMMAND} get ns "${NAMESPACE}" &>/dev/null; then
       echo "Namespace ${NAMESPACE} already exists. Deleting it to avoid conflicts."
       ${COMMAND} delete ns "${NAMESPACE}"

--- a/tests/e2e/setup/build-and-push-operator.sh
+++ b/tests/e2e/setup/build-and-push-operator.sh
@@ -36,11 +36,11 @@ get_internal_registry() {
       "until ${COMMAND} get route default-route -n openshift-image-registry &>/dev/null; do sleep 5; done"
   fi
 
-  setup_ci_environment
+  setup_environment
 }
 
-setup_ci_environment() {
-  echo "Setting up CI environment for OCP..."
+setup_environment() {
+  echo "Setting up environment for OCP..."
 
   URL=$(${COMMAND} get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
 
@@ -64,7 +64,7 @@ setup_ci_environment() {
     fi
   fi
 
-  echo "CI environment setup complete. Using external registry: ${HUB}"
+  echo "Environment setup complete. Using external registry: ${HUB}"
 }
 
 build_and_push_operator_image() {
@@ -97,12 +97,12 @@ build_and_push_operator_image() {
 
 # Main logic
 if [ "${OCP}" == "true" ]; then
-  if [ "${CI}" == "false" ]; then
+  if [ "${SKIP_INTERNAL_REGISTRY_SETUP}" == "false" ]; then
     echo "Setting up OCP internal registry..."
     get_internal_registry
   else
-    echo "CI=true, setting up minimal OCP environment..."
-    setup_ci_environment
+    echo "SKIP_INTERNAL_REGISTRY_SETUP=true, setting up minimal OCP environment..."
+    setup_environment
   fi
 fi
 


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
This variable controls the creation of the internal image registry route for OCP cluster while running the test. This means that we need to set the creation of the route during a separated ci steps, this will add stability and control for the test workflow. Also the env var can be used to set others CI specific features later on

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
