### PR TITLE
Fix ZTunnel name field in UI

### DIFF
--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -29,6 +29,17 @@ metadata:
             "namespace": "istio-cni",
             "version": "v1.27.3"
           }
+        },
+        {
+          "apiVersion": "sailoperator.io/v1alpha1",
+          "kind": "ZTunnel",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "namespace": "ztunnel",
+            "version": "v1.27.3"
+          }
         }
       ]
     capabilities: Seamless Upgrades

--- a/chart/samples/ztunnel-sample.yaml
+++ b/chart/samples/ztunnel-sample.yaml
@@ -1,0 +1,7 @@
+apiVersion: sailoperator.io/v1alpha1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: v1.27.3
+  namespace: ztunnel

--- a/chart/templates/olm/samples.yaml
+++ b/chart/templates/olm/samples.yaml
@@ -2,4 +2,6 @@
 {{ .Files.Get "samples/istio-sample.yaml" }}
 ---
 {{ .Files.Get "samples/istiocni-sample.yaml" }}
+---
+{{ .Files.Get "samples/ztunnel-sample.yaml" }}
 {{ end }}


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
When deploying ZTunnel resource from OCP UI, is has a name "example" defined by default.
Since we're explicitly require the name of the resource to be "default", the field needs to be changed.

Update the default definition of the ZTunnel name field to be - "default".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes https://issues.redhat.com/browse/OSSM-11231
