### PR TITLE
Make sure a correct helm values file is used

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -154,6 +154,8 @@ BUNDLE_MANIFEST_DATE := $(shell cat bundle/manifests/${OPERATOR_NAME}.clusterser
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
+# We are overwriting the version as we are appending a suffix for nightly builds,
+# otherwise it would be taken directly from helm values.
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests


### PR DESCRIPTION
It's possible to define a helm values file via HELM_VALUES_FILE env variable so we have to obey that when patching the file. We also need an option to disable the patching for ossm.

 