### PR TITLE
Increase e2e timeout when waiting for service LB

### DIFF
--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -109,7 +109,7 @@ func GetSVCLoadBalancerAddress(ctx context.Context, cl client.Client, ns, svcNam
 	Eventually(func() ([]corev1.LoadBalancerIngress, error) {
 		err := cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: svcName}, svc)
 		return svc.Status.LoadBalancer.Ingress, err
-	}, "1m", "1s").ShouldNot(BeEmpty(), "LoadBalancer should be ready")
+	}, "3m", "1s").ShouldNot(BeEmpty(), "LoadBalancer should be ready")
 
 	if svc.Status.LoadBalancer.Ingress[0].IP != "" {
 		return svc.Status.LoadBalancer.Ingress[0].IP


### PR DESCRIPTION
When running in KIND this is fine, but sometimes when running in a "real" cloud environment, this can cause unnecessary test failures due to timing out before the LB is up and running.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
