### PR TITLE
Add Claude Code command for updating EOL Istio versions

### DIFF
--- a/.claude/commands/update-eol-versions.md
+++ b/.claude/commands/update-eol-versions.md
@@ -46,7 +46,7 @@ This command automates the process of marking End-of-Life (EOL) Istio versions i
 - Preserve all existing version entries - do not remove them from the file
 - The `eol: true` flag makes versions uninstallable but keeps them as valid spec.version values for API compatibility
 - For EOL versions, keep only `name:`, `eol:` and `ref:` sections
-- Always verify the changes before committing
+- Show the changes and ask the user to confirm the changes before committing
 
 ## Example Version Entry
 


### PR DESCRIPTION
Adds a custom Claude Code slash command (/update-eol-versions) that automates the process of marking End-of-Life Istio versions in versions.yaml. The command fetches the current supported versions from istio.io and updates the EOL status accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 