### PR TITLE
CI: validate only the first commit message from the PR

### DIFF
--- a/.github/workflows/commit-validation.yaml
+++ b/.github/workflows/commit-validation.yaml
@@ -11,11 +11,18 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
-    - name: Validate PR commit
+    - name: Get first commit SHA in PR
+      id: first_commit
+      run: |
+        FIRST_COMMIT=$(git rev-list --reverse origin/${{ github.event.pull_request.base.ref }}..HEAD | head -n 1)
+        echo "first_commit_sha=$FIRST_COMMIT" >> $GITHUB_OUTPUT
+
+    - name: Validate the first commit from the PR
       uses: commit-check/commit-check-action@v0.9.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
+        commit: ${{ steps.first_commit.outputs.first_commit_sha }}
         message: true
         author-name: true
         author-email: true


### PR DESCRIPTION
This PR updates the commit-check GitHub action to validate only the first commit in a PR instead of every commit. This avoids validation for additional commits and provides some flexibility when subsequent commits can be described by the PR title.
