### PR TITLE
Make getProxyVersion robust to changes in istioctl proxy-status format

### DIFF
--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -18,6 +18,7 @@ package controlplane
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -273,15 +274,32 @@ func getProxyVersion(podName, namespace string) (*semver.Version, error) {
 	}
 
 	lines := strings.Split(proxyStatus, "\n")
+	colSplit := regexp.MustCompile(`\s{2,}`)
+
+	versionIdx := -1
+	headers := colSplit.Split(strings.TrimSpace(lines[0]), -1)
+	for i, header := range headers {
+		if header == "VERSION" {
+			versionIdx = i
+			break
+		}
+	}
+	if versionIdx == -1 {
+		return nil, fmt.Errorf("VERSION header not found")
+	}
+
 	var versionStr string
-	for _, line := range lines {
+	for _, line := range lines[1:] {
 		if strings.Contains(line, podName+"."+namespace) {
-			values := strings.Fields(line)
-			versionStr = values[len(values)-1]
+			values := colSplit.Split(strings.TrimSpace(line), -1)
+			versionStr = values[versionIdx]
 			break
 		}
 	}
 
+	if versionStr == "" {
+		return nil, fmt.Errorf("pod %s not found in proxy status output for namespace %s", podName, namespace)
+	}
 	version, err := semver.NewVersion(versionStr)
 	if err != nil {
 		return version, fmt.Errorf("error parsing sidecar version %q: %w", versionStr, err)


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

Make getProxyVersion robust to changes in istioctl proxy-status format

- Detect VERSION column dynamically
- Avoid relying on last-column extraction

#### Which issue(s) this PR fixes:

Allows to avoid failing the test if the output format has changed in istioctl:

```
  Unexpected error:
      <*fmt.wrapError | 0xc003706560>: 
      error parsing sidecar version "(CDS,LDS,EDS,RDS)": invalid semantic version
      {
          msg: "error parsing sidecar version \"(CDS,LDS,EDS,RDS)\": invalid semantic version",
          err: <*errors.errorString | 0x2dd8740>{
              s: "invalid semantic version",
          },
      }
```

```
    NAME                                      CLUSTER        ISTIOD                                      VERSION     SUBSCRIBED TYPES
    helloworld-v1-6bcd6bdf6f-gshs8.sample     Kubernetes     istiod-default-v1-26-4-6b87f56d5c-c2r68     1.26.4      4 (CDS,LDS,EDS,RDS)
```

Update:

Replaced `strings.Fields()` with `regex.split()` to avoid extra fields due to spaces:  "SYNCED (3s)"

```
    NAME                                      CLUSTER        CDS             LDS             EDS             RDS             ECDS        ISTIOD                                      VERSION
    helloworld-v1-865dd7fc8d-hfwvg.sample     Kubernetes     SYNCED (3s)     SYNCED (3s)     SYNCED (3s)     SYNCED (3s)     IGNORED     istiod-default-v1-27-2-7fb6868c45-sld6f     1.27.2
```