### PR TITLE
Unpining OLM version as 0.38.0 is reverting the breaking change

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -562,8 +562,7 @@ HELM_VERSION ?= v3.19.1
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 CONTROLLER_RUNTIME_BRANCH ?= release-0.22
 OPM_VERSION ?= v1.61.0
-# using 0.35.0 until https://github.com/operator-framework/operator-lifecycle-manager/issues/3675 is fixed
-OLM_VERSION ?= v0.35.0
+OLM_VERSION ?= v0.38.0
 GITLEAKS_VERSION ?= v8.29.0
 ISTIOCTL_VERSION ?= 1.26.2
 RUNME_VERSION ?= 3.15.4

--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -85,11 +85,8 @@ OPM_LATEST_VERSION=$(getLatestVersion operator-framework/operator-registry)
 "$SED_CMD" -i "s|OPM_VERSION ?= .*|OPM_VERSION ?= ${OPM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update olm
-# FIXME
-# TODO
-#OLM_LATEST_VERSION=$(getLatestVersion operator-framework/operator-lifecycle-manager)
-# using 0.35.0 until https://github.com/operator-framework/operator-lifecycle-manager/issues/3675 is fixed
-#"$SED_CMD" -i "s|OLM_VERSION ?= .*|OLM_VERSION ?= ${OLM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+OLM_LATEST_VERSION=$(getLatestVersion operator-framework/operator-lifecycle-manager)
+"$SED_CMD" -i "s|OLM_VERSION ?= .*|OLM_VERSION ?= ${OLM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update kube-rbac-proxy
 RBAC_PROXY_LATEST_VERSION=$(getLatestVersion brancz/kube-rbac-proxy | cut -d/ -f1)


### PR DESCRIPTION
The problem causing https://github.com/operator-framework/operator-lifecycle-manager/issues/3675 is reverted in 0.38.0 so we can use that version.

 