### PR TITLE
Fix make gen errors when vendor folder is present

### DIFF
--- a/hack/extract-istio-crds.sh
+++ b/hack/extract-istio-crds.sh
@@ -16,10 +16,10 @@
 
 set -euo pipefail
 
-INPUT_FILE="$(go list -m -f '{{.Dir}}' istio.io/istio)/manifests/charts/base/files/crd-all.gen.yaml"
+INPUT_FILE="$(go list -mod=readonly -m -f '{{.Dir}}' istio.io/istio)/manifests/charts/base/files/crd-all.gen.yaml"
 # check if the file exists and adjust the file path if necessary (this is needed because older Istio versions have the CRDs in a different location)
 if [ ! -f "${INPUT_FILE}" ]; then
-  INPUT_FILE="$(go list -m -f '{{.Dir}}' istio.io/istio)/manifests/charts/base/crds/crd-all.gen.yaml"
+  INPUT_FILE="$(go list -mod=readonly -m -f '{{.Dir}}' istio.io/istio)/manifests/charts/base/crds/crd-all.gen.yaml"
 fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
When vendor mode is enabled in this project, the command "go list" can return an empty string, causing errors while running "make gen" command. This PR modifies the command to use "-mod=readonly" which ensures the Go command properly resolves the module directory even when vendoring is in use.
