### PR TITLE
Changes on crd-ref-docs templates to add API version to the CRD

### DIFF
--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -10,14 +10,14 @@
 package v1 contains API Schema definitions for the sailoperator.io v1 API group
 
 ### Resource Types
-- [Istio](#istio)
-- [IstioCNI](#istiocni)
-- [IstioCNIList](#istiocnilist)
-- [IstioList](#istiolist)
-- [IstioRevision](#istiorevision)
-- [IstioRevisionList](#istiorevisionlist)
-- [IstioRevisionTag](#istiorevisiontag)
-- [IstioRevisionTagList](#istiorevisiontaglist)
+- [Istio](#istio-v1)
+- [IstioCNI](#istiocni-v1)
+- [IstioCNIList](#istiocnilist-v1)
+- [IstioList](#istiolist-v1)
+- [IstioRevision](#istiorevision-v1)
+- [IstioRevisionList](#istiorevisionlist-v1)
+- [IstioRevisionTag](#istiorevisiontag-v1)
+- [IstioRevisionTagList](#istiorevisiontaglist-v1)
 
 
 
@@ -517,7 +517,7 @@ _Appears in:_
 
 
 
-#### Istio
+#### Istio (v1)
 
 
 
@@ -545,7 +545,7 @@ _Appears in:_
 | `status` _[IstioStatus](#istiostatus)_ |  |  |  |
 
 
-#### IstioCNI
+#### IstioCNI (v1)
 
 
 
@@ -626,7 +626,7 @@ _Appears in:_
 | `Ready` | IstioCNIConditionReady signifies whether the istio-cni-node DaemonSet is ready.  |
 
 
-#### IstioCNIList
+#### IstioCNIList (v1)
 
 
 
@@ -749,7 +749,7 @@ _Appears in:_
 | `DependenciesHealthy` | IstioConditionDependenciesHealthy signifies whether the dependencies required by this Istio are healthy. For example, an Istio with spec.values.pilot.cni.enabled=true requires the IstioCNI resource to be deployed and ready for the Istio revision to be considered healthy. The DependenciesHealthy condition is used to indicate that the IstioCNI resource is healthy.  |
 
 
-#### IstioList
+#### IstioList (v1)
 
 
 
@@ -769,7 +769,7 @@ IstioList contains a list of Istio
 | `items` _[Istio](#istio) array_ |  |  |  |
 
 
-#### IstioRevision
+#### IstioRevision (v1)
 
 
 
@@ -865,7 +865,7 @@ _Appears in:_
 | `DependenciesHealthy` | IstioRevisionConditionDependenciesHealthy signifies whether the dependencies required by this IstioRevision are healthy. For example, an IstioRevision with spec.values.pilot.cni.enabled=true requires the IstioCNI resource to be deployed and ready for the Istio revision to be considered healthy. The DependenciesHealthy condition is used to indicate that the IstioCNI resource is healthy.  |
 
 
-#### IstioRevisionList
+#### IstioRevisionList (v1)
 
 
 
@@ -921,7 +921,7 @@ _Appears in:_
 | `state` _[IstioRevisionConditionReason](#istiorevisionconditionreason)_ | Reports the current state of the object. |  |  |
 
 
-#### IstioRevisionTag
+#### IstioRevisionTag (v1)
 
 
 
@@ -1005,7 +1005,7 @@ _Appears in:_
 | `InUse` | IstioRevisionConditionInUse signifies whether any workload is configured to use the revision.  |
 
 
-#### IstioRevisionTagList
+#### IstioRevisionTagList (v1)
 
 
 
@@ -3409,12 +3409,12 @@ _Appears in:_
 Package v1alpha1 contains API Schema definitions for the sailoperator.io v1alpha1 API group
 
 ### Resource Types
-- [ZTunnel](#ztunnel)
-- [ZTunnelList](#ztunnellist)
+- [ZTunnel](#ztunnel-v1alpha1)
+- [ZTunnelList](#ztunnellist-v1alpha1)
 
 
 
-#### ZTunnel
+#### ZTunnel (v1alpha1)
 
 
 
@@ -3495,7 +3495,7 @@ _Appears in:_
 | `Ready` | ZTunnelConditionReady signifies whether the ztunnel DaemonSet is ready.  |
 
 
-#### ZTunnelList
+#### ZTunnelList (v1alpha1)
 
 
 

--- a/hack/api-docs/templates/markdown/gv_details.tpl
+++ b/hack/api-docs/templates/markdown/gv_details.tpl
@@ -8,7 +8,12 @@
 {{- if $gv.Kinds  }}
 ### Resource Types
 {{- range $gv.SortedKinds }}
-- {{ $gv.TypeForKind . | markdownRenderTypeLink }}
+{{- $type := $gv.TypeForKind . }}
+{{- if $type.GVK }}
+- [{{ $type.Name }}](#{{ $type.Name | lower }}-{{ $type.GVK.Version }})
+{{- else }}
+- [{{ $type.Name }}](#{{ $type.Name | lower }})
+{{- end }}
 {{- end }}
 {{ end }}
 

--- a/hack/api-docs/templates/markdown/type.tpl
+++ b/hack/api-docs/templates/markdown/type.tpl
@@ -3,7 +3,11 @@
 {{- if markdownShouldRenderType $type -}}
 {{- if not $type.Markers.hidefromdoc -}}
 
+{{- if $type.GVK -}}
+#### {{ $type.Name }} ({{ $type.GVK.Version }})
+{{- else -}}
 #### {{ $type.Name }}
+{{- end }}
 
 {{ if $type.IsAlias }}_Underlying type:_ _{{ markdownRenderTypeLink $type.UnderlyingType  }}_{{ end }}
 


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [X] Optimization
- [ ] Test
- [X] Documentation Update

#### What this PR does / why we need it:
Adding some small changes into the templates to add more information into the api reference doc to show the API version and avoid confusion when you have more than one version of a CRD

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
