### PR TITLE
[release-1.27] Remove Profile printcolumn from ztunnel status (#1386)

### DIFF
--- a/api/v1/ztunnel_types.go
+++ b/api/v1/ztunnel_types.go
@@ -160,7 +160,6 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Namespace",type="string",JSONPath=".spec.namespace",description="The namespace for the ztunnel component."
-// +kubebuilder:printcolumn:name="Profile",type="string",JSONPath=".spec.values.profile",description="The selected profile (collection of value presets)."
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description="Whether the Istio ztunnel installation is ready to handle requests."
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="The current state of this object."
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.version",description="The version of the Istio ztunnel installation."

--- a/bundle/manifests/sailoperator.io_ztunnels.yaml
+++ b/bundle/manifests/sailoperator.io_ztunnels.yaml
@@ -21,10 +21,6 @@ spec:
       jsonPath: .spec.namespace
       name: Namespace
       type: string
-    - description: The selected profile (collection of value presets).
-      jsonPath: .spec.values.profile
-      name: Profile
-      type: string
     - description: Whether the Istio ztunnel installation is ready to handle requests.
       jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready

--- a/chart/crds/sailoperator.io_ztunnels.yaml
+++ b/chart/crds/sailoperator.io_ztunnels.yaml
@@ -21,10 +21,6 @@ spec:
       jsonPath: .spec.namespace
       name: Namespace
       type: string
-    - description: The selected profile (collection of value presets).
-      jsonPath: .spec.values.profile
-      name: Profile
-      type: string
     - description: Whether the Istio ztunnel installation is ready to handle requests.
       jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready


### PR DESCRIPTION
The `Profile` field was removed from the v1 ZTunnel API as part of the API graduation from v1alpha1 to v1. This PR removes the associated printcolumn.

(cherry picked from commit 68f34360e7f48dc27ff9333078f47374098dc92a)