### PR TITLE
Add CLAUDE.md to the sail operator repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Instructions
+
+This file imports AGENTS.md, which serves as the primary agent instructions document for all AI coding agents working with this repository.
+
+@AGENTS.md


### PR DESCRIPTION
Claude does not currently support reading from AGENTS.md, and there’s an [open issue](https://github.com/anthropics/claude-code/issues/6235) tracking it. This PR adds a workaround by embedding AGENTS.md into CLAUDE.md so AGENTS.md can remain a living document.
