### PR TITLE
Fix SIGPIPE error in update-istio-in-docs.sh script

### DIFF
--- a/hack/update-istio-in-docs.sh
+++ b/hack/update-istio-in-docs.sh
@@ -33,7 +33,10 @@ fi
 
 echo "Extracting the latest two 'version' values from $YAML_FILE..."
 
+# Disable pipefail temporarily to avoid SIGPIPE error from head
+set +o pipefail
 LATEST_VERSIONS=$(yq '.versions[] | select(.version) | .version' "$YAML_FILE" | head -n 2)
+set -o pipefail
 if [ -z "$LATEST_VERSIONS" ]; then
     echo "No versions with a 'version' property found."
     exit 1


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
The script was failing in CI with exit code 141 due to SIGPIPE when using 'head -n 2' with 'set -o pipefail'. This temporarily disables pipefail around the problematic command to handle the SIGPIPE gracefully while maintaining script safety.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #https://github.com/istio-ecosystem/sail-operator/issues/1403. I'll add the test in a separate PR

#### Additional information:
