### PR TITLE
[release-1.27] Make sure to skip cleanup of operator in e2e (#1351)

### DIFF
--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -195,7 +195,7 @@ uninstall_operator() {
 cleanup() {
   # Do not let cleanup errors affect the final exit code
   set +e
-  if [ "${OLM}" != "true" ] && [ "${SKIP_DEPLOY}" != "true" ]; then
+  if [ "${OLM}" != "true" ] && [ "${SKIP_DEPLOY}" != "true" ] && [ "${SKIP_CLEANUP}" != "true" ]; then
     if [ "${MULTICLUSTER}" == true ]; then
       KUBECONFIG="${KUBECONFIG}" uninstall_operator || true
       # shellcheck disable=SC2153  # KUBECONFIG2 is set by multicluster setup scripts
@@ -300,5 +300,4 @@ go run github.com/onsi/ginkgo/v2/ginkgo -tags e2e \
 --timeout 60m --junit-report="${ARTIFACTS}/report.xml" ${GINKGO_FLAGS:-} "${WD}"/...
 TEST_EXIT_CODE=$?
 
-echo "JUnit report: ${ARTIFACTS}/report.xml"
-exit ${TEST_EXIT_CODE}
+exit "${TEST_EXIT_CODE}"


### PR DESCRIPTION
In case it was requested, don't delete the deployed operator.

 
Fixes #1409


