### PR TITLE
set preserve-unknown-fields on gatewayClasses

### DIFF
--- a/api/v1/values_types.gen.go
+++ b/api/v1/values_types.gen.go
@@ -996,6 +996,8 @@ type Values struct {
 	// +kubebuilder:validation:Schemaless
 	Experimental json.RawMessage `json:"experimental,omitempty"`
 	// Configuration for Gateway Classes
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	GatewayClasses json.RawMessage `json:"gatewayClasses,omitempty"`
 }
 

--- a/bundle/manifests/sailoperator.io_istiorevisions.yaml
+++ b/bundle/manifests/sailoperator.io_istiorevisions.yaml
@@ -117,8 +117,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   gatewayClasses:
                     description: Configuration for Gateway Classes
-                    format: byte
-                    type: string
+                    x-kubernetes-preserve-unknown-fields: true
                   global:
                     description: Global configuration for Istio components.
                     properties:

--- a/bundle/manifests/sailoperator.io_istios.yaml
+++ b/bundle/manifests/sailoperator.io_istios.yaml
@@ -190,8 +190,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   gatewayClasses:
                     description: Configuration for Gateway Classes
-                    format: byte
-                    type: string
+                    x-kubernetes-preserve-unknown-fields: true
                   global:
                     description: Global configuration for Istio components.
                     properties:

--- a/chart/crds/sailoperator.io_istiorevisions.yaml
+++ b/chart/crds/sailoperator.io_istiorevisions.yaml
@@ -117,8 +117,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   gatewayClasses:
                     description: Configuration for Gateway Classes
-                    format: byte
-                    type: string
+                    x-kubernetes-preserve-unknown-fields: true
                   global:
                     description: Global configuration for Istio components.
                     properties:

--- a/chart/crds/sailoperator.io_istios.yaml
+++ b/chart/crds/sailoperator.io_istios.yaml
@@ -190,8 +190,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   gatewayClasses:
                     description: Configuration for Gateway Classes
-                    format: byte
-                    type: string
+                    x-kubernetes-preserve-unknown-fields: true
                   global:
                     description: Global configuration for Istio components.
                     properties:

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -3293,7 +3293,7 @@ _Appears in:_
 | `profile` _string_ | Specifies which installation configuration profile to apply. |  |  |
 | `compatibilityVersion` _string_ | Specifies the compatibility version to use. When this is set, the control plane will be configured with the same defaults as the specified version. |  |  |
 | `experimental` _[RawMessage](#rawmessage)_ | Specifies experimental helm fields that could be removed or changed in the future |  | Schemaless: \{\}   |
-| `gatewayClasses` _[RawMessage](#rawmessage)_ | Configuration for Gateway Classes |  |  |
+| `gatewayClasses` _[RawMessage](#rawmessage)_ | Configuration for Gateway Classes |  | Schemaless: \{\}   |
 
 
 #### WaypointConfig

--- a/hack/api_transformer/transform.yaml
+++ b/hack/api_transformer/transform.yaml
@@ -147,6 +147,9 @@ inputFiles:
       Values.Experimental:
       - "// +kubebuilder:pruning:PreserveUnknownFields"
       - "// +kubebuilder:validation:Schemaless"
+      Values.GatewayClasses:
+      - "// +kubebuilder:pruning:PreserveUnknownFields"
+      - "// +kubebuilder:validation:Schemaless"
       Values.DefaultRevision:
       - "// +hidefromdoc"
       - "// Deprecated: This field is ignored. The default revision is expected to be configurable elsewhere."


### PR DESCRIPTION
#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Enables preserve-unknown-fields for gatewayClasses.

Since the field does not have a schema, we need to retain any nested fields to pass through to the Helm chart.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
