### PR TITLE
fix: allow automator commits without message

### DIFF
--- a/.commit-check.yml
+++ b/.commit-check.yml
@@ -1,7 +1,7 @@
 # More config examples could be found here - https://github.com/commit-check/commit-check/blob/main/.commit-check.yml
 checks:
   - check: message
-    regex: '^([^\n]+)\n\n(?!(Signed-off-by:))([\s\S]+)$'
+    regex: '^Automator(.|\n)*$|^([^\n]+)\n\n(?!(Signed-off-by:))([\s\S]+)$'
     error: "The commit message should be structured as follows:\n
     <commit header>\n\n
     <commit body>"


### PR DESCRIPTION
This makes sure that our Automator commits pass the commit check.