### PR TITLE
[release-1.27] set preserve-unknown-fields on gatewayClasses

### DIFF
--- a/api/v1/values_types.gen.go
+++ b/api/v1/values_types.gen.go
@@ -971,6 +971,8 @@ type Values struct {
 	// +kubebuilder:validation:Schemaless
 	Experimental json.RawMessage `json:"experimental,omitempty"`
 	// Configuration for Gateway Classes
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	GatewayClasses json.RawMessage `json:"gatewayClasses,omitempty"`
 }
 

--- a/bundle/manifests/sailoperator.io_istiorevisions.yaml
+++ b/bundle/manifests/sailoperator.io_istiorevisions.yaml
@@ -117,8 +117,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   gatewayClasses:
                     description: Configuration for Gateway Classes
-                    format: byte
-                    type: string
+                    x-kubernetes-preserve-unknown-fields: true
                   global:
                     description: Global configuration for Istio components.
                     properties:

--- a/bundle/manifests/sailoperator.io_istios.yaml
+++ b/bundle/manifests/sailoperator.io_istios.yaml
@@ -190,8 +190,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   gatewayClasses:
                     description: Configuration for Gateway Classes
-                    format: byte
-                    type: string
+                    x-kubernetes-preserve-unknown-fields: true
                   global:
                     description: Global configuration for Istio components.
                     properties:

--- a/chart/crds/sailoperator.io_istiorevisions.yaml
+++ b/chart/crds/sailoperator.io_istiorevisions.yaml
@@ -117,8 +117,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   gatewayClasses:
                     description: Configuration for Gateway Classes
-                    format: byte
-                    type: string
+                    x-kubernetes-preserve-unknown-fields: true
                   global:
                     description: Global configuration for Istio components.
                     properties:

--- a/chart/crds/sailoperator.io_istios.yaml
+++ b/chart/crds/sailoperator.io_istios.yaml
@@ -190,8 +190,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   gatewayClasses:
                     description: Configuration for Gateway Classes
-                    format: byte
-                    type: string
+                    x-kubernetes-preserve-unknown-fields: true
                   global:
                     description: Global configuration for Istio components.
                     properties:

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -3218,7 +3218,7 @@ _Appears in:_
 | `profile` _string_ | Specifies which installation configuration profile to apply. |  |  |
 | `compatibilityVersion` _string_ | Specifies the compatibility version to use. When this is set, the control plane will be configured with the same defaults as the specified version. |  |  |
 | `experimental` _[RawMessage](#rawmessage)_ | Specifies experimental helm fields that could be removed or changed in the future |  | Schemaless: \{\}   |
-| `gatewayClasses` _[RawMessage](#rawmessage)_ | Configuration for Gateway Classes |  |  |
+| `gatewayClasses` _[RawMessage](#rawmessage)_ | Configuration for Gateway Classes |  | Schemaless: \{\}   |
 
 
 #### WaypointConfig

--- a/hack/api_transformer/transform.yaml
+++ b/hack/api_transformer/transform.yaml
@@ -147,6 +147,9 @@ inputFiles:
       Values.Experimental:
       - "// +kubebuilder:pruning:PreserveUnknownFields"
       - "// +kubebuilder:validation:Schemaless"
+      Values.GatewayClasses:
+      - "// +kubebuilder:pruning:PreserveUnknownFields"
+      - "// +kubebuilder:validation:Schemaless"
       Values.DefaultRevision:
       - "// +hidefromdoc"
       - "// Deprecated: This field is ignored. The default revision is expected to be configurable elsewhere."

--- a/tests/integration/api/istiorevision_test.go
+++ b/tests/integration/api/istiorevision_test.go
@@ -841,6 +841,46 @@ var _ = Describe("IstioRevision resource", Label("istiorevision"), Ordered, func
 			}
 		})
 	})
+
+	When("the IstioRevision has Spec.Values.GatewayClasses set", func() {
+		BeforeAll(func() {
+			rev = &v1.IstioRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: revName,
+				},
+				Spec: v1.IstioRevisionSpec{
+					Version:   istioversion.Default,
+					Namespace: istioNamespace,
+					Values: &v1.Values{
+						Global: &v1.GlobalConfig{
+							IstioNamespace: ptr.Of(istioNamespace),
+						},
+						Revision: ptr.Of(revName),
+						Pilot: &v1.PilotConfig{
+							Image: ptr.Of(pilotImage),
+						},
+						GatewayClasses: []byte(`{"istio":{"service":{"spec":{"type":"ClusterIP"}}}}`),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, rev)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			deleteAllIstioRevisions(ctx)
+		})
+
+		It("creates a configmap in the istiorevision-test namespace with the gateway class customization", func() {
+			// Format of ConfigMap name is "istio-<revision>-gatewayclass-<gatewayclass-name>"
+			cmKey := client.ObjectKey{Name: "istio-test-istiorevision-gatewayclass-istio", Namespace: istioNamespace}
+			cm := &corev1.ConfigMap{}
+			Eventually(k8sClient.Get).WithArguments(ctx, cmKey, cm).Should(Succeed())
+			Expect(cm.Labels).To(HaveKeyWithValue("gateway.istio.io/defaults-for-class", "istio"))
+			Expect(cm.Data).To(HaveKeyWithValue("service", `spec:
+  type: ClusterIP
+`))
+		})
+	})
 })
 
 func waitForInFlightReconcileToFinish() {


### PR DESCRIPTION
Since the field does not have a schema, we need to retain any nested fields to pass through to the Helm chart.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Cherry-pick of #1465 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #1499

Related Issue/PR #

#### Additional information:
