### PR TITLE
Enable external registry support for OCP e2e tests in CI

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -15,6 +15,7 @@ This end-to-end test suite utilizes Ginkgo, a testing framework known for its ex
     1. [Pre-requisites](#pre-requisites)
     1. [How to Run the test](#how-to-run-the-test)
     1. [Running the test locally](#running-the-test-locally)
+    1. [Test Run scenarios while running on OCP](#test-run-scenarios-while-running-on-ocp)
     1. [Settings for end-to-end test execution](#settings-for-end-to-end-test-execution)
     1. [Customizing the test run](#customizing-the-test-run)    
     1. [Get test definitions for the end-to-end test](#get-test-definitions-for-the-end-to-end-test)
@@ -246,6 +247,35 @@ Note: if you are running the test against a cluster that has a different archite
 
 ```
 TARGET_ARCH=arm64 make test.e2e.ocp
+```
+
+#### Test Run scenarios while running on OCP
+When running the E2E test on OpenShift clusters, the framework supports three different registry scenarios:
+
+**Scenario 1: Test run with Internal Registry (Default behaviour)**
+For test run on OpenShift with the default settings, no additional configuration is needed. The test scripts will automatically configure and use the OpenShift internal registry:
+
+```sh
+# No HUB setting needed - uses internal registry by default
+make test.e2e.ocp
+```
+
+**Scenario 2: Test run with CI Mode with External Registry**
+In CI environments, set `CI=true` to use external registries with proper tagging:
+
+```sh
+export CI=true
+# Uses default HUB=quay.io/sail-dev with auto-generated tags if no PR_NUMBER var is being set 
+make test.e2e.ocp
+```
+
+**Scenario 3: Test run with custom External Registry**
+For custom external registries, specify your own HUB value:
+
+```sh
+export HUB=your-registry.com/your-namespace
+export TAG=your-tag
+make test.e2e.ocp
 ```
 
 ### Settings for end-to-end test execution

--- a/tests/e2e/setup/build-and-push-operator.sh
+++ b/tests/e2e/setup/build-and-push-operator.sh
@@ -85,8 +85,8 @@ build_and_push_operator_image() {
 }
 
 # Main logic
-# Only use internal registry for OCP local development (when HUB is localhost:5000)
-if [ "${OCP}" == "true" ] && [ "${HUB}" == "localhost:5000" ]; then
+# Only use internal registry for OCP local development (when USE_INTERNAL_REGISTRY is set)
+if [ "${OCP}" == "true" ] && [ "${USE_INTERNAL_REGISTRY:-false}" == "true" ]; then
   echo "Setting up OCP internal registry for local development..."
   get_internal_registry
 fi


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Adding support to push to quay.io during any execution that runs over OCP cluster. This will simplify the build and push of the testing image because there is no need to enable the internal OCP registry anymore when running on CI. Now it handles 3 scenarios:

* Running locally against an OCP cluster and we want to use the internal OCP registry
```
make test.e2e.ocp
```
* Running on CI, and we want to push to quay.io to avoid this workaround of using the internal OCP registry:
```
CI=true PR_NUMBER=PR<number> make test.e2e.ocp
```
Note: if we don't want to set PR_NUMBER it will set the tag to TAG="ci-test-$(date +%s)"
* Running locally but the user want to push to another registry:
```
HUB=quay.io/frherrer make test.e2e.ocp
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
