### PR TITLE
Fix yq expression syntax in configuration-converter

### DIFF
--- a/tools/configuration-converter.sh
+++ b/tools/configuration-converter.sh
@@ -117,7 +117,7 @@ function boolean_2_string(){
 # Note that if there is an entry except spec.components.<component>.enabled: true/false converter will delete them and warn user 
 function validate_spec_components(){
     if [[ $(yq eval '.spec.components' "$OUTPUT") != "null" ]]; then
-        yq -i 'del(.spec.components.[] | keys[] | select(. != "enabled")) | .spec.values *= .spec.components | del (.spec.components)' "$OUTPUT"    
+        yq -i 'with(.spec.components[]; del( .[] | select(key != "enabled") )) | .spec.values *= .spec.components | del(.spec.components)' "$OUTPUT"
         echo "Only values in the format spec.components.<component>.enabled: true/false are supported for conversion. For more details, refer to the documentation: https://github.com/istio-ecosystem/sail-operator/tree/main/docs#components-field"
     fi
 }


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
The validate_spec_components function in configuration-converter.sh was failing with "Error: bad expression, please check expression syntax" on extracting "components" keys.

The original command attempted to delete non-"enabled" keys using: del(.spec.components.[] | keys[] | select(. != "enabled"))

This failed because:
- `.spec.components.[]` incorrectly tries to iterate over object values
- `keys[]` syntax doesn't work in this pipeline context in yq v4
- `select(. != "enabled")` references values instead of key names
- No proper context management for applying deletions back to document

Replaced with proper yq v4 syntax using the `with()` function.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
