### PR TITLE
Adding TARGET_ARCH to tag definition when run on CI true

### DIFF
--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -155,13 +155,13 @@ initialize_variables() {
       # Use PR_NUMBER if available, otherwise generate timestamp tag
       # Use TARGET_ARCH to differentiate tags for different architectures in CI, avoid race conditions in CI when multiple runs are pushing to the same default tag
       if [ -n "${PR_NUMBER:-}" ]; then
-      TAG="pr-${PR_NUMBER}-${TARGET_ARCH}"
-      export TAG
-      echo "Using PR-based tag: ${TAG}"
+        TAG="pr-${PR_NUMBER}-${TARGET_ARCH}"
+        export TAG
+        echo "Using PR-based tag: ${TAG}"
       else
-      TAG="ci-test-$(date +%s)-${TARGET_ARCH}"
-      export TAG
-      echo "Using timestamp-based tag: ${TAG}"
+        TAG="ci-test-$(date +%s)-${TARGET_ARCH}"
+        export TAG
+        echo "Using timestamp-based tag: ${TAG}"
       fi
     elif [ "${CI}" == "true" ]; then
       # Additional CI mode check - handle CI mode regardless of HUB value


### PR DESCRIPTION
Adding export TAG=pr-- when CI is true to avoid race conditions when building and pushing multiple arch jobs at the same time

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
