### PR TITLE
[release-1.27] Enable TLSv1.2 for ZTunnel when in FIPS mode (#1596)

### DIFF
--- a/controllers/ztunnel/ztunnel_controller.go
+++ b/controllers/ztunnel/ztunnel_controller.go
@@ -157,6 +157,12 @@ func (r *Reconciler) installHelmChart(ctx context.Context, ztunnel *v1.ZTunnel) 
 		return fmt.Errorf("failed to apply profile: %w", err)
 	}
 
+	// apply FipsValues on top of mergedHelmValues from profile
+	mergedHelmValues, err = istiovalues.ApplyZTunnelFipsValues(mergedHelmValues)
+	if err != nil {
+		return fmt.Errorf("failed to apply FIPS values: %w", err)
+	}
+
 	// Apply any user Overrides configured as part of values.ztunnel
 	// This step was not required for the IstioCNI resource because the Helm templates[*] automatically override values.cni
 	// [*]https://github.com/istio/istio/blob/0200fd0d4c3963a72f36987c2e8c2887df172abf/manifests/charts/istio-cni/templates/zzy_descope_legacy.yaml#L3

--- a/pkg/istiovalues/fips.go
+++ b/pkg/istiovalues/fips.go
@@ -53,3 +53,13 @@ func ApplyFipsValues(values helm.Values) (helm.Values, error) {
 	}
 	return values, nil
 }
+
+// ApplyZTunnelFipsValues sets value ztunnel.env.TLS12_ENABLED if FIPS mode is enabled in the system.
+func ApplyZTunnelFipsValues(values helm.Values) (helm.Values, error) {
+	if FipsEnabled {
+		if err := values.SetIfAbsent("ztunnel.env.TLS12_ENABLED", "true"); err != nil {
+			return nil, fmt.Errorf("failed to set ztunnel.env.TLS12_ENABLED: %w", err)
+		}
+	}
+	return values, nil
+}

--- a/pkg/revision/values_test.go
+++ b/pkg/revision/values_test.go
@@ -107,6 +107,8 @@ apiVersion: sailoperator.io/v1
 kind: IstioRevision
 spec:`)), 0o644))
 
+	originalFipsEnabled := istiovalues.FipsEnabled
+	t.Cleanup(func() { istiovalues.FipsEnabled = originalFipsEnabled })
 	istiovalues.FipsEnabled = true
 	values := &v1.Values{}
 	result, err := ComputeValues(values, namespace, version, config.PlatformOpenShift, "default", "",


### PR DESCRIPTION
* Enable TLSv1.2 for ZTunnel when in FIPS mode

This change builds on https://github.com/istio/ztunnel/pull/1711 which adds TLSv1.2 support to ZTunnel when `TLS12_ENABLED` is set to `true`. This patch will always set the env var when in FIPS mode, for all versions of ZTunnel, even though it is only supported from 1.29+, but the env var will simply be ignored by versions that don't support it.

* Make sure that FipsEnabled is restored to original value

In our tests, we sometimes set FipsEnabled manually. We should make sure to reset it to its original value during test cleanup.

Cherry-pick of https://github.com/istio-ecosystem/sail-operator/pull/1547