### PR TITLE
feat(helm): make managed-by label value configurable via ChartManagerOption

### DIFF
--- a/pkg/helm/postrenderer.go
+++ b/pkg/helm/postrenderer.go
@@ -35,15 +35,16 @@ const (
 )
 
 // NewHelmPostRenderer creates a Helm PostRenderer that adds the following to each rendered manifest:
-// - adds the "managed-by: sail-operator" label
+// - adds the "managed-by" label with the given managedByValue
 // - adds the specified OwnerReference
 // It also removes the failurePolicy field from ValidatingWebhookConfigurations on updates, so
 // the in-cluster setting stays as-is, to prevent clashing with the istiod validation controller.
-func NewHelmPostRenderer(ownerReference *metav1.OwnerReference, ownerNamespace string, isUpdate bool) postrender.PostRenderer {
+func NewHelmPostRenderer(ownerReference *metav1.OwnerReference, ownerNamespace string, isUpdate bool, managedByValue string) postrender.PostRenderer {
 	return HelmPostRenderer{
 		ownerReference: ownerReference,
 		ownerNamespace: ownerNamespace,
 		isUpdate:       isUpdate,
+		managedByValue: managedByValue,
 	}
 }
 
@@ -51,6 +52,7 @@ type HelmPostRenderer struct {
 	ownerReference *metav1.OwnerReference
 	ownerNamespace string
 	isUpdate       bool
+	managedByValue string
 }
 
 var _ postrender.PostRenderer = HelmPostRenderer{}
@@ -175,6 +177,6 @@ func (pr HelmPostRenderer) addOwnerReference(manifest map[string]any) (map[strin
 }
 
 func (pr HelmPostRenderer) addManagedByLabel(manifest map[string]any) (map[string]any, error) {
-	err := unstructured.SetNestedField(manifest, constants.ManagedByLabelValue, "metadata", "labels", constants.ManagedByLabelKey)
+	err := unstructured.SetNestedField(manifest, pr.managedByValue, "metadata", "labels", constants.ManagedByLabelKey)
 	return manifest, err
 }

--- a/pkg/helm/postrenderer_test.go
+++ b/pkg/helm/postrenderer_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/istio-ecosystem/sail-operator/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -308,6 +309,7 @@ spec:
 				ownerReference: tc.ownerReference,
 				ownerNamespace: tc.ownerNamespace,
 				isUpdate:       tc.isUpdate,
+				managedByValue: constants.ManagedByLabelValue,
 			}
 
 			actual, err := postRenderer.Run(bytes.NewBufferString(tc.input))


### PR DESCRIPTION
#### What type of PR is this?

- [x] Enhancement / New Feature

#### What this PR does / why we need it:

Allow callers to override the "managed-by" label value set on all Helm-managed resources by passing WithManagedByValue() to NewChartManager. The default remains "sail-operator" so existing operator behavior is unchanged. The value is threaded from ChartManager through HelmPostRenderer, replacing the previously hardcoded constant.

BREAKING CHANGE: NewHelmPostRenderer now requires a managedByValue parameter

With the Sail Library usecase, there are now more then just the "Sail Operator" that can be active in the same cluster so we need a way to distinguish between The Operator, and The Library. As well there could be many actors using the Sail Library in the same cluster.  