### PR TITLE
Fix missing MaxConcurrentReconciles in ZTunnel controller

### DIFF
--- a/controllers/ztunnel/ztunnel_controller.go
+++ b/controllers/ztunnel/ztunnel_controller.go
@@ -149,6 +149,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}
 				return log
 			},
+			MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles,
 		}).
 
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged

--- a/controllers/ztunnel/ztunnel_controller_test.go
+++ b/controllers/ztunnel/ztunnel_controller_test.go
@@ -588,8 +588,9 @@ func normalize(condition v1.ZTunnelCondition) v1.ZTunnelCondition {
 
 func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
 	return config.ReconcilerConfig{
-		ResourceFS:     os.DirFS(t.TempDir()),
-		Platform:       config.PlatformKubernetes,
-		DefaultProfile: "",
+		ResourceFS:              os.DirFS(t.TempDir()),
+		Platform:                config.PlatformKubernetes,
+		DefaultProfile:          "",
+		MaxConcurrentReconciles: 1,
 	}
 }


### PR DESCRIPTION
All controllers (such as Istio and IstioCNI) configure MaxConcurrentReconciles based on the config, but the ztunnel controller was ignoring it. This PR fixes it.
