### PR TITLE
Fix invalid version in image

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -78,7 +78,7 @@ endif
 # Image hub to use
 HUB ?= quay.io/sail-dev
 # Image tag to use
-TAG ?= ${MINOR_VERSION}
+TAG ?= ${VERSION}
 # Image base to use
 IMAGE_BASE ?= sail-operator
 # Image URL to use all building/pushing image targets

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -44,8 +44,8 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
-    containerImage: quay.io/sail-dev/sail-operator:1.29
-    createdAt: "2026-03-11T09:16:34Z"
+    containerImage: quay.io/sail-dev/sail-operator:1.29.1
+    createdAt: "2026-03-11T15:58:35Z"
     description: The Sail Operator manages the lifecycle of your Istio control plane. It provides custom resources for you to deploy and manage your control plane components.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -890,7 +890,7 @@ spec:
                       - --zap-log-level=info
                     command:
                       - /sail-operator
-                    image: quay.io/sail-dev/sail-operator:1.29
+                    image: quay.io/sail-dev/sail-operator:1.29.1
                     livenessProbe:
                       httpGet:
                         path: /healthz

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -132,7 +132,7 @@ csv:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
-image: quay.io/sail-dev/sail-operator:1.29
+image: quay.io/sail-dev/sail-operator:1.29.1
 # We're commenting out the imagePullPolicy to use k8s defaults
 # imagePullPolicy: Always
 operator:


### PR DESCRIPTION
For releasing 1.29.0 and 1.29.1 , we released with wrong image tag which cause that during 1.29.1 release, we override 1.29.0 image 