### PR TITLE
Fix commit check workflow to only check the first PR commit

### DIFF
--- a/.github/workflows/commit-validation.yaml
+++ b/.github/workflows/commit-validation.yaml
@@ -11,18 +11,16 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
-    - name: Get first commit SHA in PR
-      id: first_commit
+    - name: Checkout the first commit in the PR
       run: |
         FIRST_COMMIT=$(git rev-list --reverse origin/${{ github.event.pull_request.base.ref }}..HEAD | head -n 1)
-        echo "first_commit_sha=$FIRST_COMMIT" >> $GITHUB_OUTPUT
+        git checkout "$FIRST_COMMIT"
 
     - name: Validate the first commit from the PR
       uses: commit-check/commit-check-action@v0.9.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        commit: ${{ steps.first_commit.outputs.first_commit_sha }}
         message: true
         author-name: true
         author-email: true


### PR DESCRIPTION
The commit-check github action was silently ignoring the "commit:" input. As a result, the action was checking all the commits. This PR fixes it by checking out the first commit of the PR before running the action, so that HEAD points to the correct commit when commit-check runs.
