### PR TITLE
refactor: move watches and predicates into separate pkg

### DIFF
--- a/controllers/istiocni/istiocni_controller.go
+++ b/controllers/istiocni/istiocni_controller.go
@@ -28,19 +28,16 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/errlist"
 	"github.com/istio-ecosystem/sail-operator/pkg/helm"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
-	"github.com/istio-ecosystem/sail-operator/pkg/predicate"
 	sharedreconcile "github.com/istio-ecosystem/sail-operator/pkg/reconcile"
 	"github.com/istio-ecosystem/sail-operator/pkg/reconciler"
+	"github.com/istio-ecosystem/sail-operator/pkg/watches"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -146,7 +143,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	namespaceHandler := wrapEventHandler(logger, handler.EnqueueRequestsFromMapFunc(r.mapNamespaceToReconcileRequest))
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
 			LogConstructor: func(req *reconcile.Request) logr.Logger {
 				log := logger
@@ -157,33 +154,16 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 			MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles,
 		}).
-
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged
-		// +lint-watches:ignore: IstioCNI (not found in charts, but this is the main resource watched by this controller)
 		Watches(&v1.IstioCNI{}, mainObjectHandler).
-		Named("istiocni").
+		Named("istiocni")
 
-		// namespaced resources
-		Watches(&corev1.ConfigMap{}, ownedResourceHandler).
-		Watches(&appsv1.DaemonSet{}, ownedResourceHandler).
-		Watches(&corev1.ResourceQuota{}, ownedResourceHandler).
+	// Register watches for all chart-produced resource types.
+	watches.RegisterOwnedWatches(b, watches.CNIWatches, ownedResourceHandler, nil)
 
-		// +lint-watches:ignore: NetworkPolicy (FIXME: NetworkPolicy has not yet been added upstream, but is WIP)
-		Watches(&networkingv1.NetworkPolicy{}, ownedResourceHandler, builder.WithPredicates(predicate.IgnoreUpdate())).
-
-		// We use predicate.IgnoreUpdate() so that we skip the reconciliation when a pull secret is added to the ServiceAccount.
-		// This is necessary so that we don't remove the newly-added secret.
-		// TODO: this is a temporary hack until we implement the correct solution on the Helm-render side
-		Watches(&corev1.ServiceAccount{}, ownedResourceHandler, builder.WithPredicates(predicate.IgnoreUpdate())).
-
-		// TODO: only register NetAttachDef if the CRD is installed (may also need to watch for CRD creation)
-		// Owns(&multusv1.NetworkAttachmentDefinition{}).
-
-		// cluster-scoped resources
-		// +lint-watches:ignore: Namespace (not present in charts, but must be watched to reconcile IstioCni when its namespace is created)
+	return b.
+		// Non-chart watches
 		Watches(&corev1.Namespace{}, namespaceHandler).
-		Watches(&rbacv1.ClusterRole{}, ownedResourceHandler).
-		Watches(&rbacv1.ClusterRoleBinding{}, ownedResourceHandler).
 		Complete(reconciler.NewStandardReconcilerWithFinalizer[*v1.IstioCNI](r.Client, r.Reconcile, r.Finalize, constants.FinalizerName))
 }
 

--- a/controllers/istiorevision/istiorevision_controller.go
+++ b/controllers/istiorevision/istiorevision_controller.go
@@ -28,19 +28,14 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/errlist"
 	"github.com/istio-ecosystem/sail-operator/pkg/helm"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
-	predicate2 "github.com/istio-ecosystem/sail-operator/pkg/predicate"
 	sharedreconcile "github.com/istio-ecosystem/sail-operator/pkg/reconcile"
 	"github.com/istio-ecosystem/sail-operator/pkg/reconciler"
 	"github.com/istio-ecosystem/sail-operator/pkg/revision"
 	"github.com/istio-ecosystem/sail-operator/pkg/validation"
+	"github.com/istio-ecosystem/sail-operator/pkg/watches"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	policyv1 "k8s.io/api/policy/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,10 +44,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"istio.io/istio/pkg/ptr"
@@ -258,7 +251,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// or if it's owned by an Endpoints object which in turn is owned by an IstioRevision.
 	endpointSliceHandler := wrapEventHandler(logger, handler.EnqueueRequestsFromMapFunc(r.mapEndpointSliceToReconcileRequests))
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
 			LogConstructor: func(req *reconcile.Request) logr.Logger {
 				log := logger
@@ -270,61 +263,24 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles,
 		}).
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged
-		// +lint-watches:ignore: IstioRevision (not found in charts, but this is the main resource watched by this controller)
 		Watches(&v1.IstioRevision{}, mainObjectHandler).
-		Named("istiorevision").
+		Named("istiorevision")
 
-		// namespaced resources
-		Watches(&corev1.ConfigMap{}, ownedResourceHandler, builder.WithPredicates(predicate2.IgnoreUpdateWhenAnnotation())).
-		// We don't ignore the status for Deployments because we use it to calculate the IstioRevision status
-		Watches(&appsv1.Deployment{}, ownedResourceHandler, builder.WithPredicates(predicate2.IgnoreUpdateWhenAnnotation())).
-		// +lint-watches:ignore: Endpoints (older versions of istiod chart create Endpoints for remote installs, but this controller watches EndpointSlices)
-		// +lint-watches:ignore: EndpointSlice (istiod chart creates Endpoints for remote installs, but this controller watches EndpointSlices)
-		Watches(&discoveryv1.EndpointSlice{}, endpointSliceHandler, builder.WithPredicates(predicate2.IgnoreUpdateWhenAnnotation())).
-		Watches(&corev1.Service{}, ownedResourceHandler,
-			builder.WithPredicates(ignoreStatusChange(), predicate2.IgnoreUpdateWhenAnnotation())).
+	// Register watches for all chart-produced resource types.
+	// EndpointSlice uses a different handler; all others use ownedResourceHandler.
+	handlerOverrides := map[string]handler.EventHandler{
+		"EndpointSlice": endpointSliceHandler,
+	}
+	watches.RegisterOwnedWatches(b, watches.IstiodWatches, ownedResourceHandler, handlerOverrides)
 
-		// +lint-watches:ignore: NetworkPolicy (FIXME: NetworkPolicy has not yet been added upstream, but is WIP)
-		Watches(&networkingv1.NetworkPolicy{}, ownedResourceHandler,
-			builder.WithPredicates(ignoreStatusChange(), predicate2.IgnoreUpdateWhenAnnotation())).
-
-		// We use predicate.IgnoreUpdate() so that we skip the reconciliation when a pull secret is added to the ServiceAccount.
-		// This is necessary so that we don't remove the newly-added secret.
-		// TODO: this is a temporary hack until we implement the correct solution on the Helm-render side
-		Watches(&corev1.ServiceAccount{}, ownedResourceHandler, builder.WithPredicates(predicate2.IgnoreUpdate())).
-		Watches(&rbacv1.Role{}, ownedResourceHandler, builder.WithPredicates(predicate2.IgnoreUpdateWhenAnnotation())).
-		Watches(&rbacv1.RoleBinding{}, ownedResourceHandler, builder.WithPredicates(predicate2.IgnoreUpdateWhenAnnotation())).
-		Watches(&policyv1.PodDisruptionBudget{}, ownedResourceHandler,
-			builder.WithPredicates(ignoreStatusChange(), predicate2.IgnoreUpdateWhenAnnotation())).
-		Watches(&autoscalingv2.HorizontalPodAutoscaler{}, ownedResourceHandler,
-			builder.WithPredicates(ignoreStatusChange(), predicate2.IgnoreUpdateWhenAnnotation())).
-
-		// +lint-watches:ignore: Namespace (not found in charts, but must be watched to reconcile IstioRevision when its namespace is created)
-		Watches(&corev1.Namespace{}, nsHandler, builder.WithPredicates(ignoreStatusChange()), builder.WithPredicates(predicate2.IgnoreUpdateWhenAnnotation())).
-
-		// +lint-watches:ignore: Pod (not found in charts, but must be watched to reconcile IstioRevision when a pod references it)
-		Watches(&corev1.Pod{}, podHandler, builder.WithPredicates(ignoreStatusChange(), predicate2.IgnoreUpdateWhenAnnotation())).
-
-		// +lint-watches:ignore: IstioRevisionTag (not found in charts, but must be watched to reconcile IstioRevision when a pod references it)
+	return b.
+		// Non-chart watches: these resources are not produced by Helm charts but
+		// must be watched for controller-specific reasons.
+		Watches(&corev1.Namespace{}, nsHandler, builder.WithPredicates(watches.IgnoreAnnotation(), watches.AsPredicate(watches.IgnoreStatusChanges()))).
+		Watches(&corev1.Pod{}, podHandler, builder.WithPredicates(watches.IgnoreAnnotation(), watches.AsPredicate(watches.IgnoreStatusChanges()))).
 		Watches(&v1.IstioRevisionTag{}, revisionTagHandler).
-
-		// cluster-scoped resources
-		Watches(&rbacv1.ClusterRole{}, ownedResourceHandler, builder.WithPredicates(predicate2.IgnoreUpdateWhenAnnotation())).
-		Watches(&rbacv1.ClusterRoleBinding{}, ownedResourceHandler, builder.WithPredicates(predicate2.IgnoreUpdateWhenAnnotation())).
-		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler,
-			builder.WithPredicates(webhookConfigPredicate(), predicate2.IgnoreUpdateWhenAnnotation())).
-		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler,
-			builder.WithPredicates(webhookConfigPredicate(), predicate2.IgnoreUpdateWhenAnnotation())).
-
-		// +lint-watches:ignore: IstioCNI (not found in charts, but this controller needs to watch it to update the IstioRevision status)
 		Watches(&v1.IstioCNI{}, istioCniHandler).
-
-		// +lint-watches:ignore: ZTunnel (not found in charts, but this controller needs to watch it to update the IstioRevision status)
 		Watches(&v1.ZTunnel{}, ztunnelHandler).
-
-		// +lint-watches:ignore: ValidatingAdmissionPolicy (TODO: fix this when CI supports golang 1.22 and k8s 1.30)
-		// +lint-watches:ignore: ValidatingAdmissionPolicyBinding (TODO: fix this when CI supports golang 1.22 and k8s 1.30)
-		// +lint-watches:ignore: CustomResourceDefinition (prevents `make lint-watches` from bugging us about CRDs)
 		Complete(reconciler.NewStandardReconcilerWithFinalizer[*v1.IstioRevision](r.Client, r.Reconcile, r.Finalize, constants.FinalizerName))
 }
 
@@ -710,71 +666,6 @@ func (r *Reconciler) mapZTunnelToReconcileRequests(ctx context.Context, _ client
 		}
 	}
 	return reqs
-}
-
-// ignoreStatusChange returns a predicate that ignores watch events where only the resource status changes; if
-// there are any other changes to the resource, the event is not ignored.
-// This ensures that the controller doesn't reconcile the entire IstioRevision every time the status of an owned
-// resource is updated. Without this predicate, the controller would continuously reconcile the IstioRevision
-// because the status.currentMetrics of the HorizontalPodAutoscaler object was updated.
-func ignoreStatusChange() predicate.Funcs {
-	return predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return specWasUpdated(e.ObjectOld, e.ObjectNew) ||
-				!reflect.DeepEqual(e.ObjectNew.GetLabels(), e.ObjectOld.GetLabels()) ||
-				!reflect.DeepEqual(e.ObjectNew.GetAnnotations(), e.ObjectOld.GetAnnotations()) ||
-				!reflect.DeepEqual(e.ObjectNew.GetOwnerReferences(), e.ObjectOld.GetOwnerReferences()) ||
-				!reflect.DeepEqual(e.ObjectNew.GetFinalizers(), e.ObjectOld.GetFinalizers())
-		},
-	}
-}
-
-func specWasUpdated(oldObject client.Object, newObject client.Object) bool {
-	// for HPAs, k8s doesn't set metadata.generation, so we actually have to check whether the spec was updated
-	if oldHpa, ok := oldObject.(*autoscalingv2.HorizontalPodAutoscaler); ok {
-		if newHpa, ok := newObject.(*autoscalingv2.HorizontalPodAutoscaler); ok {
-			return !reflect.DeepEqual(oldHpa.Spec, newHpa.Spec)
-		}
-	}
-
-	// for other resources, comparing the metadata.generation suffices
-	return oldObject.GetGeneration() != newObject.GetGeneration()
-}
-
-func webhookConfigPredicate() predicate.Funcs {
-	return predicate.Funcs{
-		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
-			if e.ObjectOld == nil || e.ObjectNew == nil {
-				return false
-			}
-
-			// Istiod updates the caBundle and failurePolicy fields in its webhook configs.
-			// We must ignore changes to these fields to prevent an endless update loop.
-			// We must use deep copies to avoid mutating the shared informer cache.
-			oldCopy := e.ObjectOld.DeepCopyObject().(client.Object)
-			newCopy := e.ObjectNew.DeepCopyObject().(client.Object)
-			clearIgnoredFields(oldCopy)
-			clearIgnoredFields(newCopy)
-			return !reflect.DeepEqual(newCopy, oldCopy)
-		},
-	}
-}
-
-func clearIgnoredFields(obj client.Object) {
-	obj.SetResourceVersion("")
-	obj.SetGeneration(0)
-	obj.SetManagedFields(nil)
-	switch webhookConfig := obj.(type) {
-	case *admissionv1.ValidatingWebhookConfiguration:
-		for i := range len(webhookConfig.Webhooks) {
-			webhookConfig.Webhooks[i].FailurePolicy = nil
-			webhookConfig.Webhooks[i].ClientConfig.CABundle = nil
-		}
-	case *admissionv1.MutatingWebhookConfiguration:
-		for i := range len(webhookConfig.Webhooks) {
-			webhookConfig.Webhooks[i].ClientConfig.CABundle = nil
-		}
-	}
 }
 
 func wrapEventHandler(logger logr.Logger, handler handler.EventHandler) handler.EventHandler {

--- a/controllers/istiorevision/istiorevision_controller_test.go
+++ b/controllers/istiorevision/istiorevision_controller_test.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"istio.io/istio/pkg/ptr"
@@ -951,129 +950,6 @@ func TestDetermineInUseCondition(t *testing.T) {
 				}
 			})
 		}
-	}
-}
-
-func TestIgnoreStatusChangePredicate(t *testing.T) {
-	predicate := ignoreStatusChange()
-
-	oldObj := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			ResourceVersion: "1",
-			Generation:      1,
-			Finalizers:      []string{"finalizer1"},
-			Labels:          map[string]string{"app": "test"},
-			Annotations:     map[string]string{"annotation1": "value1"},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "v1",
-					Kind:       "IstioRevision",
-					Name:       "myrev",
-				},
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-		},
-		Status: corev1.ServiceStatus{
-			LoadBalancer: corev1.LoadBalancerStatus{
-				Ingress: []corev1.LoadBalancerIngress{
-					{
-						IP: "1.1.1.1",
-					},
-				},
-			},
-			Conditions: nil,
-		},
-	}
-
-	tests := []struct {
-		name     string
-		update   func(svc *corev1.Service)
-		expected bool
-	}{
-		{
-			name:     "No changes",
-			update:   func(svc *corev1.Service) {},
-			expected: false,
-		},
-		{
-			name: "ResourceVersion changed",
-			update: func(svc *corev1.Service) {
-				svc.ResourceVersion = "2"
-			},
-			expected: false,
-		},
-		{
-			name: "Spec changed",
-			update: func(svc *corev1.Service) {
-				svc.ResourceVersion = "2"
-				svc.Generation++
-				svc.Spec.Type = corev1.ServiceTypeNodePort
-			},
-			expected: true,
-		},
-		{
-			name: "Status changed",
-			update: func(svc *corev1.Service) {
-				svc.ResourceVersion = "2"
-				svc.Status.LoadBalancer.Ingress[0].IP = "2.2.2.2"
-			},
-			expected: false,
-		},
-		{
-			name: "Spec and status changed",
-			update: func(svc *corev1.Service) {
-				svc.ResourceVersion = "2"
-				svc.Generation++
-				svc.Spec.Type = corev1.ServiceTypeNodePort
-				svc.Status.LoadBalancer.Ingress[0].IP = "2.2.2.2"
-			},
-			expected: true,
-		},
-		{
-			name: "Labels changed",
-			update: func(svc *corev1.Service) {
-				svc.ResourceVersion = "2"
-				svc.Labels["app"] = "new-value"
-			},
-			expected: true,
-		},
-		{
-			name: "Annotations changed",
-			update: func(svc *corev1.Service) {
-				svc.ResourceVersion = "2"
-				svc.Annotations["annotation1"] = "new-value"
-			},
-			expected: true,
-		},
-		{
-			name: "OwnerReferences changed",
-			update: func(svc *corev1.Service) {
-				svc.ResourceVersion = "2"
-				svc.OwnerReferences[0].Name = "new-owner"
-			},
-			expected: true,
-		},
-		{
-			name: "Finalizers changed",
-			update: func(svc *corev1.Service) {
-				svc.ResourceVersion = "2"
-				svc.Finalizers = append(svc.Finalizers, "finalizer2")
-			},
-			expected: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewWithT(t)
-			newObj := oldObj.DeepCopy()
-			tc.update(newObj)
-
-			result := predicate.Update(event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj})
-			g.Expect(result).To(Equal(tc.expected), "unexpected result of predicate.Update()")
-		})
 	}
 }
 

--- a/controllers/ztunnel/ztunnel_controller.go
+++ b/controllers/ztunnel/ztunnel_controller.go
@@ -29,18 +29,16 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/errlist"
 	"github.com/istio-ecosystem/sail-operator/pkg/helm"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
-	"github.com/istio-ecosystem/sail-operator/pkg/predicate"
 	sharedreconcile "github.com/istio-ecosystem/sail-operator/pkg/reconcile"
 	"github.com/istio-ecosystem/sail-operator/pkg/reconciler"
+	"github.com/istio-ecosystem/sail-operator/pkg/watches"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -140,7 +138,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	namespaceHandler := wrapEventHandler(logger, handler.EnqueueRequestsFromMapFunc(r.mapNamespaceToReconcileRequest))
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
 			LogConstructor: func(req *reconcile.Request) logr.Logger {
 				log := logger
@@ -151,27 +149,17 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 			MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles,
 		}).
-
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged
 		Watches(&v1alpha1.ZTunnel{}, mainObjectHandler).
 		Watches(&v1.ZTunnel{}, mainObjectHandler).
-		Named("ztunnel").
+		Named("ztunnel")
 
-		// namespaced resources
-		Watches(&corev1.ConfigMap{}, ownedResourceHandler).
-		Watches(&appsv1.DaemonSet{}, ownedResourceHandler).
-		Watches(&corev1.ResourceQuota{}, ownedResourceHandler).
+	// Register watches for all chart-produced resource types.
+	watches.RegisterOwnedWatches(b, watches.ZTunnelWatches, ownedResourceHandler, nil)
 
-		// We use predicate.IgnoreUpdate() so that we skip the reconciliation when a pull secret is added to the ServiceAccount.
-		// This is necessary so that we don't remove the newly-added secret.
-		// TODO: this is a temporary hack until we implement the correct solution on the Helm-render side
-		Watches(&corev1.ServiceAccount{}, ownedResourceHandler, builder.WithPredicates(predicate.IgnoreUpdate())).
-
-		// cluster-scoped resources
-		// +lint-watches:ignore: Namespace (not present in charts, but must be watched to reconcile ZTunnel when its namespace is created)
+	return b.
+		// Non-chart watches
 		Watches(&corev1.Namespace{}, namespaceHandler).
-		Watches(&rbacv1.ClusterRole{}, ownedResourceHandler).
-		Watches(&rbacv1.ClusterRoleBinding{}, ownedResourceHandler).
 		Complete(reconciler.NewStandardReconcilerWithFinalizer[*v1.ZTunnel](r.Client, r.Reconcile, r.Finalize, constants.FinalizerName))
 }
 

--- a/hack/lint-watches.sh
+++ b/hack/lint-watches.sh
@@ -16,65 +16,76 @@
 
 set -euo pipefail
 
-check_watches() {
-    # path to the controller implementation
-    controllerPath=$1
+# Validates that the static watch lists in pkg/watches/ match the resource
+# kinds produced by the Helm charts in resources/. Each watch list file
+# contains typed object prototypes (e.g. &corev1.ConfigMap{}) whose Go type
+# name matches the Kubernetes Kind.
+
+check_watchlist() {
+    # path to the watch list Go file (e.g. pkg/watches/istiod.go)
+    watchlistPath=$1
     shift
     # space-separated list of file path patterns indicating which Helm charts to inspect
     chartPaths="$*"
+
+    echo "--- Checking $watchlistPath ---"
 
     # Find kinds in charts
     # shellcheck disable=SC2086
     read -r -a chartKinds <<< "$(grep -rEo "^kind: ([A-Za-z0-9]+)" --no-filename $chartPaths | sed -e 's/^kind: //g' | sort | uniq | tr '\n' ' ')"
     echo "Kinds in charts: ${chartKinds[*]}"
 
-    # Find watched kinds in istiorevision_controller.go
-    read -r -a watchedKinds <<< "$(grep -Eo "(Owns|Watches)\\((.*)" "$controllerPath" | sed 's/.*&[^.]*\.\([^{}]*\).*/\1/' | sort | uniq | tr '\n' ' ')"
-    echo "Watched kinds: ${watchedKinds[*]}"
+    # Extract kinds from the watch list by parsing typed object prototypes (e.g. &corev1.ConfigMap{})
+    read -r -a watchlistKinds <<< "$(grep -Eo '&\w+\.\w+\{\}' "$watchlistPath" | sed 's/&[a-zA-Z0-9]*\.\([A-Za-z0-9]*\){}/\1/' | sort | uniq | tr '\n' ' ')"
+    echo "Watch list kinds: ${watchlistKinds[*]}"
 
-    # Find ignored kinds in istiorevision_controller.go
-    read -r -a ignoredKinds <<< "$(sed -n 's/.*\+lint-watches:ignore:\s*\(\w*\).*/\1/p' "$controllerPath" | sort | uniq | tr '\n' ' ')"
-    echo "Ignored kinds: ${ignoredKinds[*]}"
+    # Find ignored kinds
+    local ignoredKinds=()
+    if grep -q '+lint-watches:ignore' "$watchlistPath"; then
+        read -r -a ignoredKinds <<< "$(sed -n 's/.*\+lint-watches:ignore:\s*\(\w*\).*/\1/p' "$watchlistPath" | sort | uniq | tr '\n' ' ')"
+        echo "Ignored kinds: ${ignoredKinds[*]}"
+    fi
 
-    # Check for missing and unnecessary watches
-    local unwatched_kinds=()
+    # Check for chart kinds missing from the watch list
+    local missing_kinds=()
     for kind in "${chartKinds[@]}"; do
         # shellcheck disable=SC2076
-        if [[ ! " ${watchedKinds[*]} ${ignoredKinds[*]} " =~ " $kind " ]]; then
-            unwatched_kinds+=("$kind")
+        if [[ ! " ${watchlistKinds[*]} ${ignoredKinds[*]} " =~ " $kind " ]]; then
+            missing_kinds+=("$kind")
         fi
     done
 
-    local unneeded_watches=()
-    for kind in "${watchedKinds[@]}"; do
+    # Check for watch list entries not in charts
+    local extra_kinds=()
+    for kind in "${watchlistKinds[@]}"; do
         # shellcheck disable=SC2076
         if [[ ! " ${chartKinds[*]} ${ignoredKinds[*]} " =~ " $kind " ]]; then
-            unneeded_watches+=("$kind")
+            extra_kinds+=("$kind")
         fi
     done
 
-    # Print unwatched kinds, if any
-    if [[ ${#unwatched_kinds[@]} -gt 0 ]]; then
-        printf "FAIL: The following kinds aren't watched in %s:\n" "$controllerPath"
-        for kind in "${unwatched_kinds[@]}"; do
+    if [[ ${#missing_kinds[@]} -gt 0 ]]; then
+        printf "FAIL: The following chart kinds are missing from %s:\n" "$watchlistPath"
+        for kind in "${missing_kinds[@]}"; do
             printf "  - %s\n" "$kind"
         done
         exit 1
     else
-        printf "%s watches all kinds found in Helm charts.\n" "$controllerPath"
+        printf "%s covers all kinds found in Helm charts.\n" "$watchlistPath"
     fi
 
-    # Print unnecessary watches, if any
-    if [[ ${#unneeded_watches[@]} -gt 0 ]]; then
-        printf "FAIL: The following kinds are watched in %s, but are not present in the charts:\n" "$controllerPath"
-        for kind in "${unneeded_watches[@]}"; do
+    if [[ ${#extra_kinds[@]} -gt 0 ]]; then
+        printf "FAIL: The following kinds in %s are not present in the charts:\n" "$watchlistPath"
+        for kind in "${extra_kinds[@]}"; do
             printf "  - %s\n" "$kind"
         done
         exit 1
     else
-        printf "%s does not watch any kinds that aren't found in Helm charts.\n" "$controllerPath"
+        printf "%s does not contain kinds that aren't found in Helm charts.\n" "$watchlistPath"
     fi
+    echo ""
 }
 
-check_watches "./controllers/istiorevision/istiorevision_controller.go" "./resources/*/charts/istiod ./resources/*/charts/istiod-remote ./resources/*/charts/base"
-check_watches "./controllers/istiocni/istiocni_controller.go" "./resources/*/charts/cni"
+check_watchlist "./pkg/watches/istiod.go" "./resources/*/charts/istiod ./resources/*/charts/base"
+check_watchlist "./pkg/watches/cni.go" "./resources/*/charts/cni"
+check_watchlist "./pkg/watches/ztunnel.go" "./resources/*/charts/ztunnel"

--- a/pkg/watches/cni.go
+++ b/pkg/watches/cni.go
@@ -1,0 +1,42 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watches
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// CNIWatches is the static list of resource types produced by the cni
+// Helm chart and the update filter for each.
+//
+// This list is validated against chart templates by hack/lint-watches.sh.
+//
+// +lint-watches:ignore: NetworkAttachmentDefinition (TODO: not yet watched; requires CRD existence check)
+var CNIWatches = []WatchedResource{
+	// namespaced resources
+	{Object: &corev1.ConfigMap{}},
+	{Object: &appsv1.DaemonSet{}},
+	{Object: &networkingv1.NetworkPolicy{}, ShouldReconcile: IgnoreAllUpdates()},
+	{Object: &corev1.ResourceQuota{}},
+	// ServiceAccount: ignore all updates to prevent removing pull secrets added by other controllers
+	{Object: &corev1.ServiceAccount{}, ShouldReconcile: IgnoreAllUpdates()},
+
+	// cluster-scoped resources
+	{Object: &rbacv1.ClusterRole{}},
+	{Object: &rbacv1.ClusterRoleBinding{}},
+}

--- a/pkg/watches/istiod.go
+++ b/pkg/watches/istiod.go
@@ -1,0 +1,54 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watches
+
+import (
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// IstiodWatches is the static list of resource types produced by the base and
+// istiod Helm charts and the update filter for each.
+//
+// This list is validated against chart templates by hack/lint-watches.sh.
+//
+// +lint-watches:ignore: Endpoints (older chart versions create Endpoints, but the controller watches EndpointSlices)
+var IstiodWatches = []WatchedResource{
+	{Object: &corev1.ConfigMap{}},
+	// Deployment: don't ignore status — it's used to compute IstioRevision status
+	{Object: &appsv1.Deployment{}},
+	{Object: &discoveryv1.EndpointSlice{}},
+	{Object: &autoscalingv2.HorizontalPodAutoscaler{}, ShouldReconcile: IgnoreStatusChanges()},
+	{Object: &networkingv1.NetworkPolicy{}, ShouldReconcile: IgnoreStatusChanges()},
+	{Object: &policyv1.PodDisruptionBudget{}, ShouldReconcile: IgnoreStatusChanges()},
+	{Object: &rbacv1.Role{}},
+	{Object: &rbacv1.RoleBinding{}},
+	{Object: &corev1.Service{}, ShouldReconcile: IgnoreStatusChanges()},
+	{Object: &corev1.ServiceAccount{}, ShouldReconcile: IgnoreAllUpdates()},
+
+	// cluster-scoped
+	{Object: &rbacv1.ClusterRole{}},
+	{Object: &rbacv1.ClusterRoleBinding{}},
+	{Object: &admissionv1.MutatingWebhookConfiguration{}, ShouldReconcile: WebhookFilter()},
+	{Object: &admissionv1.ValidatingAdmissionPolicy{}, Skipped: true},
+	{Object: &admissionv1.ValidatingAdmissionPolicyBinding{}, Skipped: true},
+	{Object: &admissionv1.ValidatingWebhookConfiguration{}, ShouldReconcile: WebhookFilter()},
+}

--- a/pkg/watches/watches.go
+++ b/pkg/watches/watches.go
@@ -1,0 +1,156 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package watches defines the static lists of resource types produced by each
+// Istio Helm chart and the update-filtering functions for each resource.
+// The lists are validated against chart templates by hack/lint-watches.sh.
+package watches
+
+import (
+	"reflect"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const ignoreAnnotation = "sailoperator.io/ignore"
+
+// ShouldReconcileFunc returns true if an update should trigger reconciliation.
+type ShouldReconcileFunc func(oldObj, newObj client.Object) bool
+
+// WatchedResource pairs a typed object prototype with its update filter.
+type WatchedResource struct {
+	// Object is a typed prototype (e.g. &corev1.ConfigMap{}) used to set up a typed informer.
+	Object client.Object
+	// ShouldReconcile filters update events. Nil means all updates trigger reconciliation.
+	ShouldReconcile ShouldReconcileFunc
+	// Skipped means the chart produces this kind but it's intentionally not watched.
+	Skipped bool
+}
+
+// IgnoreAnnotation returns a predicate that skips update events when the new
+// object has the sailoperator.io/ignore annotation set to "true".
+func IgnoreAnnotation() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectNew == nil {
+				return false
+			}
+			return e.ObjectNew.GetAnnotations()[ignoreAnnotation] != "true"
+		},
+	}
+}
+
+// IgnoreAllUpdates skips all update events.
+func IgnoreAllUpdates() ShouldReconcileFunc {
+	return func(_, _ client.Object) bool { return false }
+}
+
+// IgnoreStatusChanges skips updates where only the status changed.
+func IgnoreStatusChanges() ShouldReconcileFunc {
+	return func(oldObj, newObj client.Object) bool {
+		return specWasUpdated(oldObj, newObj) ||
+			!reflect.DeepEqual(newObj.GetLabels(), oldObj.GetLabels()) ||
+			!reflect.DeepEqual(newObj.GetAnnotations(), oldObj.GetAnnotations()) ||
+			!reflect.DeepEqual(newObj.GetOwnerReferences(), oldObj.GetOwnerReferences()) ||
+			!reflect.DeepEqual(newObj.GetFinalizers(), oldObj.GetFinalizers())
+	}
+}
+
+// WebhookFilter ignores changes to fields managed by istiod (caBundle, failurePolicy).
+func WebhookFilter() ShouldReconcileFunc {
+	return func(oldObj, newObj client.Object) bool {
+		oldCopy := oldObj.DeepCopyObject().(client.Object)
+		newCopy := newObj.DeepCopyObject().(client.Object)
+		clearWebhookFields(oldCopy)
+		clearWebhookFields(newCopy)
+		return !reflect.DeepEqual(newCopy, oldCopy)
+	}
+}
+
+// specWasUpdated checks if the spec changed. Handles the HPA special case
+// where k8s doesn't increment metadata.generation.
+func specWasUpdated(oldObj, newObj client.Object) bool {
+	if oldHpa, ok := oldObj.(*autoscalingv2.HorizontalPodAutoscaler); ok {
+		if newHpa, ok := newObj.(*autoscalingv2.HorizontalPodAutoscaler); ok {
+			return !reflect.DeepEqual(oldHpa.Spec, newHpa.Spec)
+		}
+	}
+	return oldObj.GetGeneration() != newObj.GetGeneration()
+}
+
+// RegisterOwnedWatches registers watches for all non-skipped resources.
+// The ignore annotation predicate is always applied.
+func RegisterOwnedWatches(
+	b *builder.Builder,
+	watchList []WatchedResource,
+	defaultHandler handler.EventHandler,
+	handlerOverrides map[string]handler.EventHandler,
+) {
+	for _, wr := range watchList {
+		if wr.Skipped {
+			continue
+		}
+
+		h := defaultHandler
+		if handlerOverrides != nil {
+			kind := reflect.TypeOf(wr.Object).Elem().Name()
+			if override, ok := handlerOverrides[kind]; ok {
+				h = override
+			}
+		}
+
+		predicates := []predicate.Predicate{IgnoreAnnotation()}
+		if wr.ShouldReconcile != nil {
+			predicates = append(predicates, AsPredicate(wr.ShouldReconcile))
+		}
+		b.Watches(wr.Object, h, builder.WithPredicates(predicates...))
+	}
+}
+
+// AsPredicate wraps a ShouldReconcileFunc as a controller-runtime predicate.
+func AsPredicate(fn ShouldReconcileFunc) predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			return fn(e.ObjectOld, e.ObjectNew)
+		},
+	}
+}
+
+// clearWebhookFields clears fields managed by istiod on webhook configurations.
+func clearWebhookFields(obj client.Object) {
+	obj.SetResourceVersion("")
+	obj.SetGeneration(0)
+	obj.SetManagedFields(nil)
+
+	switch wc := obj.(type) {
+	case *admissionv1.ValidatingWebhookConfiguration:
+		for i := range wc.Webhooks {
+			wc.Webhooks[i].FailurePolicy = nil
+			wc.Webhooks[i].ClientConfig.CABundle = nil
+		}
+	case *admissionv1.MutatingWebhookConfiguration:
+		for i := range wc.Webhooks {
+			wc.Webhooks[i].ClientConfig.CABundle = nil
+		}
+	}
+}

--- a/pkg/watches/watches_test.go
+++ b/pkg/watches/watches_test.go
@@ -1,0 +1,156 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watches
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIgnoreStatusChanges(t *testing.T) {
+	shouldReconcile := IgnoreStatusChanges()
+
+	oldObj := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "1",
+			Generation:      1,
+			Finalizers:      []string{"finalizer1"},
+			Labels:          map[string]string{"app": "test"},
+			Annotations:     map[string]string{"annotation1": "value1"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "IstioRevision",
+					Name:       "myrev",
+				},
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{
+						IP: "1.1.1.1",
+					},
+				},
+			},
+			Conditions: nil,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		update   func(svc *corev1.Service)
+		expected bool
+	}{
+		{
+			name:     "No changes",
+			update:   func(svc *corev1.Service) {},
+			expected: false,
+		},
+		{
+			name: "ResourceVersion changed",
+			update: func(svc *corev1.Service) {
+				svc.ResourceVersion = "2"
+			},
+			expected: false,
+		},
+		{
+			name: "Spec changed",
+			update: func(svc *corev1.Service) {
+				svc.ResourceVersion = "2"
+				svc.Generation++
+				svc.Spec.Type = corev1.ServiceTypeNodePort
+			},
+			expected: true,
+		},
+		{
+			name: "Status changed",
+			update: func(svc *corev1.Service) {
+				svc.ResourceVersion = "2"
+				svc.Status.LoadBalancer.Ingress[0].IP = "2.2.2.2"
+			},
+			expected: false,
+		},
+		{
+			name: "Spec and status changed",
+			update: func(svc *corev1.Service) {
+				svc.ResourceVersion = "2"
+				svc.Generation++
+				svc.Spec.Type = corev1.ServiceTypeNodePort
+				svc.Status.LoadBalancer.Ingress[0].IP = "2.2.2.2"
+			},
+			expected: true,
+		},
+		{
+			name: "Labels changed",
+			update: func(svc *corev1.Service) {
+				svc.ResourceVersion = "2"
+				svc.Labels["app"] = "new-value"
+			},
+			expected: true,
+		},
+		{
+			name: "Annotations changed",
+			update: func(svc *corev1.Service) {
+				svc.ResourceVersion = "2"
+				svc.Annotations["annotation1"] = "new-value"
+			},
+			expected: true,
+		},
+		{
+			name: "OwnerReferences changed",
+			update: func(svc *corev1.Service) {
+				svc.ResourceVersion = "2"
+				svc.OwnerReferences[0].Name = "new-owner"
+			},
+			expected: true,
+		},
+		{
+			name: "Finalizers changed",
+			update: func(svc *corev1.Service) {
+				svc.ResourceVersion = "2"
+				svc.Finalizers = append(svc.Finalizers, "finalizer2")
+			},
+			expected: true,
+		},
+		{
+			name: "Ignore annotation added",
+			update: func(svc *corev1.Service) {
+				svc.ResourceVersion = "2"
+				svc.Annotations[ignoreAnnotation] = "true"
+			},
+			// IgnoreStatusChanges sees the annotation change and returns true.
+			// The ignore annotation is handled by a separate predicate (ignoreAnnotationPredicate).
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			newObj := oldObj.DeepCopy()
+			tc.update(newObj)
+
+			result := shouldReconcile(oldObj, newObj)
+			g.Expect(result).To(Equal(tc.expected))
+		})
+	}
+}

--- a/pkg/watches/ztunnel.go
+++ b/pkg/watches/ztunnel.go
@@ -1,0 +1,39 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watches
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ZTunnelWatches is the static list of resource types produced by the ztunnel
+// Helm chart and the update filter for each.
+//
+// This list is validated against chart templates by hack/lint-watches.sh.
+var ZTunnelWatches = []WatchedResource{
+	// namespaced resources
+	{Object: &appsv1.DaemonSet{}},
+	{Object: &networkingv1.NetworkPolicy{}},
+	{Object: &corev1.ResourceQuota{}},
+	// ServiceAccount: ignore all updates to prevent removing pull secrets added by other controllers
+	{Object: &corev1.ServiceAccount{}, ShouldReconcile: IgnoreAllUpdates()},
+
+	// cluster-scoped resources
+	{Object: &rbacv1.ClusterRole{}},
+	{Object: &rbacv1.ClusterRoleBinding{}},
+}


### PR DESCRIPTION
this will help trim down the pkg/install library by making the watches easily accessible from outside the controller pkgs.

cc @aslakknutsen 