### PR TITLE
add debug logging when detecting FIPS mode

### DIFF
--- a/pkg/istiovalues/fips.go
+++ b/pkg/istiovalues/fips.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/helm"
+
+	"istio.io/istio/pkg/log"
 )
 
 var (
@@ -35,11 +37,15 @@ func init() {
 func detectFipsMode(filepath string) {
 	contents, err := os.ReadFile(filepath)
 	if err != nil {
+		log.Infof("FIPS detection: failed to read %s: %v; FIPS mode disabled", filepath, err)
 		FipsEnabled = false
 	} else {
 		fipsEnabled := strings.TrimSuffix(string(contents), "\n")
 		if fipsEnabled == "1" {
 			FipsEnabled = true
+			log.Infof("FIPS detection: %s contains %q; FIPS mode enabled", filepath, fipsEnabled)
+		} else {
+			log.Infof("FIPS detection: %s contains %q (expected \"1\"); FIPS mode disabled", filepath, fipsEnabled)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

When trying to debug an issue in testing, I noticed that if `detectFipsMode` failed to read the fips mode for any reason it would fail silently and set FIPS mode to false. This was not the root cause of the issue but I figured adding some debug logging here could help prevent future issues.