### PR TITLE
feat: add PREVENT_IMAGE_OVERWRITE check to avoid overwriting release …

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,11 @@ jobs:
 
     - uses: actions/checkout@v4
 
+    - name: Install skopeo
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y skopeo
+
     # this should avoid ERROR: failed to build: failed to read GITHUB_EVENT_PATH "/home/runner/work/_temp/_github_workflow/event.json"
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -47,6 +52,8 @@ jobs:
     - name: Build and push operator image
       run: |
         make docker-buildx
+      env:
+        PREVENT_IMAGE_OVERWRITE: true
 
     - name: Generate bundle metadata
       run: |

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -85,6 +85,8 @@ IMAGE_BASE ?= sail-operator
 IMAGE ?= ${HUB}/${IMAGE_BASE}:${TAG}
 # Namespace to deploy the controller in
 NAMESPACE ?= sail-operator
+# Prevent overwriting existing images in registry (default: false, set to true in release workflows)
+PREVENT_IMAGE_OVERWRITE ?= false
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.30.0
 
@@ -314,6 +316,22 @@ endif
 
 .PHONY: docker-buildx
 docker-buildx: build-all ## Build and push docker image with cross-platform support.
+ifeq ($(PREVENT_IMAGE_OVERWRITE),true)
+	@echo "Checking if image ${IMAGE} already exists..."
+	@if command -v skopeo >/dev/null 2>&1; then \
+		if skopeo inspect docker://${IMAGE} >/dev/null 2>&1; then \
+			echo "ERROR: Image tag ${IMAGE} already exists in the registry!"; \
+			echo "Please ensure you are releasing a new version."; \
+			exit 1; \
+		else \
+			echo "Image tag ${IMAGE} does not exist. Proceeding with build and push."; \
+		fi; \
+	else \
+		echo "ERROR: skopeo is not installed. Cannot verify if image already exists."; \
+		echo "Install skopeo or set PREVENT_IMAGE_OVERWRITE=false to skip this check."; \
+		exit 1; \
+	fi
+endif
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	docker buildx ls --format "{{.Name}}" | grep project-v4-builder || docker buildx create --name project-v4-builder


### PR DESCRIPTION
…images

Add optional image existence check to docker-buildx target controlled by PREVENT_IMAGE_OVERWRITE environment variable. When enabled, the build will fail if the target image tag already exists in the registry, preventing accidental overwrites of release images.

The check uses skopeo to inspect the remote registry and defaults to false for normal development workflows. The release workflow explicitly enables this protection by setting PREVENT_IMAGE_OVERWRITE=true.

 
Fixes https://github.com/istio-ecosystem/sail-operator/issues/1684

