### PR TITLE
[release-1.0] Use registry.istio.io

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -23,7 +23,7 @@ jobs:
   update-deps:
     runs-on: ubuntu-latest
     container:
-      image: gcr.io/istio-testing/build-tools:release-1.24-8ed83d624be60c383d395c2e03308527409c65e8
+      image: registry.istio.io/testing/build-tools:release-1.24-8ed83d624be60c383d395c2e03308527409c65e8
       options: --entrypoint ''
 
     steps:

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/sail-dev/sail-operator:1.0-latest
-    createdAt: "2025-09-18T08:19:57Z"
+    createdAt: "2026-03-23T13:47:40Z"
     description: Experimental operator for installing Istio service mesh
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -647,50 +647,50 @@ spec:
             template:
               metadata:
                 annotations:
-                  images.v1_23_0.cni: gcr.io/istio-release/install-cni:1.23.0
-                  images.v1_23_0.istiod: gcr.io/istio-release/pilot:1.23.0
-                  images.v1_23_0.proxy: gcr.io/istio-release/proxyv2:1.23.0
-                  images.v1_23_0.ztunnel: gcr.io/istio-release/ztunnel:1.23.0
-                  images.v1_23_3.cni: gcr.io/istio-release/install-cni:1.23.3
-                  images.v1_23_3.istiod: gcr.io/istio-release/pilot:1.23.3
-                  images.v1_23_3.proxy: gcr.io/istio-release/proxyv2:1.23.3
-                  images.v1_23_3.ztunnel: gcr.io/istio-release/ztunnel:1.23.3
-                  images.v1_23_4.cni: gcr.io/istio-release/install-cni:1.23.4
-                  images.v1_23_4.istiod: gcr.io/istio-release/pilot:1.23.4
-                  images.v1_23_4.proxy: gcr.io/istio-release/proxyv2:1.23.4
-                  images.v1_23_4.ztunnel: gcr.io/istio-release/ztunnel:1.23.4
-                  images.v1_23_5.cni: gcr.io/istio-release/install-cni:1.23.5
-                  images.v1_23_5.istiod: gcr.io/istio-release/pilot:1.23.5
-                  images.v1_23_5.proxy: gcr.io/istio-release/proxyv2:1.23.5
-                  images.v1_23_5.ztunnel: gcr.io/istio-release/ztunnel:1.23.5
-                  images.v1_23_6.cni: gcr.io/istio-release/install-cni:1.23.6
-                  images.v1_23_6.istiod: gcr.io/istio-release/pilot:1.23.6
-                  images.v1_23_6.proxy: gcr.io/istio-release/proxyv2:1.23.6
-                  images.v1_23_6.ztunnel: gcr.io/istio-release/ztunnel:1.23.6
-                  images.v1_24_1.cni: gcr.io/istio-release/install-cni:1.24.1
-                  images.v1_24_1.istiod: gcr.io/istio-release/pilot:1.24.1
-                  images.v1_24_1.proxy: gcr.io/istio-release/proxyv2:1.24.1
-                  images.v1_24_1.ztunnel: gcr.io/istio-release/ztunnel:1.24.1
-                  images.v1_24_2.cni: gcr.io/istio-release/install-cni:1.24.2
-                  images.v1_24_2.istiod: gcr.io/istio-release/pilot:1.24.2
-                  images.v1_24_2.proxy: gcr.io/istio-release/proxyv2:1.24.2
-                  images.v1_24_2.ztunnel: gcr.io/istio-release/ztunnel:1.24.2
-                  images.v1_24_3.cni: gcr.io/istio-release/install-cni:1.24.3
-                  images.v1_24_3.istiod: gcr.io/istio-release/pilot:1.24.3
-                  images.v1_24_3.proxy: gcr.io/istio-release/proxyv2:1.24.3
-                  images.v1_24_3.ztunnel: gcr.io/istio-release/ztunnel:1.24.3
-                  images.v1_24_4.cni: gcr.io/istio-release/install-cni:1.24.4
-                  images.v1_24_4.istiod: gcr.io/istio-release/pilot:1.24.4
-                  images.v1_24_4.proxy: gcr.io/istio-release/proxyv2:1.24.4
-                  images.v1_24_4.ztunnel: gcr.io/istio-release/ztunnel:1.24.4
-                  images.v1_24_5.cni: gcr.io/istio-release/install-cni:1.24.5
-                  images.v1_24_5.istiod: gcr.io/istio-release/pilot:1.24.5
-                  images.v1_24_5.proxy: gcr.io/istio-release/proxyv2:1.24.5
-                  images.v1_24_5.ztunnel: gcr.io/istio-release/ztunnel:1.24.5
-                  images.v1_24_6.cni: gcr.io/istio-release/install-cni:1.24.6
-                  images.v1_24_6.istiod: gcr.io/istio-release/pilot:1.24.6
-                  images.v1_24_6.proxy: gcr.io/istio-release/proxyv2:1.24.6
-                  images.v1_24_6.ztunnel: gcr.io/istio-release/ztunnel:1.24.6
+                  images.v1_23_0.cni: registry.istio.io/release/install-cni:1.23.0
+                  images.v1_23_0.istiod: registry.istio.io/release/pilot:1.23.0
+                  images.v1_23_0.proxy: registry.istio.io/release/proxyv2:1.23.0
+                  images.v1_23_0.ztunnel: registry.istio.io/release/ztunnel:1.23.0
+                  images.v1_23_3.cni: registry.istio.io/release/install-cni:1.23.3
+                  images.v1_23_3.istiod: registry.istio.io/release/pilot:1.23.3
+                  images.v1_23_3.proxy: registry.istio.io/release/proxyv2:1.23.3
+                  images.v1_23_3.ztunnel: registry.istio.io/release/ztunnel:1.23.3
+                  images.v1_23_4.cni: registry.istio.io/release/install-cni:1.23.4
+                  images.v1_23_4.istiod: registry.istio.io/release/pilot:1.23.4
+                  images.v1_23_4.proxy: registry.istio.io/release/proxyv2:1.23.4
+                  images.v1_23_4.ztunnel: registry.istio.io/release/ztunnel:1.23.4
+                  images.v1_23_5.cni: registry.istio.io/release/install-cni:1.23.5
+                  images.v1_23_5.istiod: registry.istio.io/release/pilot:1.23.5
+                  images.v1_23_5.proxy: registry.istio.io/release/proxyv2:1.23.5
+                  images.v1_23_5.ztunnel: registry.istio.io/release/ztunnel:1.23.5
+                  images.v1_23_6.cni: registry.istio.io/release/install-cni:1.23.6
+                  images.v1_23_6.istiod: registry.istio.io/release/pilot:1.23.6
+                  images.v1_23_6.proxy: registry.istio.io/release/proxyv2:1.23.6
+                  images.v1_23_6.ztunnel: registry.istio.io/release/ztunnel:1.23.6
+                  images.v1_24_1.cni: registry.istio.io/release/install-cni:1.24.1
+                  images.v1_24_1.istiod: registry.istio.io/release/pilot:1.24.1
+                  images.v1_24_1.proxy: registry.istio.io/release/proxyv2:1.24.1
+                  images.v1_24_1.ztunnel: registry.istio.io/release/ztunnel:1.24.1
+                  images.v1_24_2.cni: registry.istio.io/release/install-cni:1.24.2
+                  images.v1_24_2.istiod: registry.istio.io/release/pilot:1.24.2
+                  images.v1_24_2.proxy: registry.istio.io/release/proxyv2:1.24.2
+                  images.v1_24_2.ztunnel: registry.istio.io/release/ztunnel:1.24.2
+                  images.v1_24_3.cni: registry.istio.io/release/install-cni:1.24.3
+                  images.v1_24_3.istiod: registry.istio.io/release/pilot:1.24.3
+                  images.v1_24_3.proxy: registry.istio.io/release/proxyv2:1.24.3
+                  images.v1_24_3.ztunnel: registry.istio.io/release/ztunnel:1.24.3
+                  images.v1_24_4.cni: registry.istio.io/release/install-cni:1.24.4
+                  images.v1_24_4.istiod: registry.istio.io/release/pilot:1.24.4
+                  images.v1_24_4.proxy: registry.istio.io/release/proxyv2:1.24.4
+                  images.v1_24_4.ztunnel: registry.istio.io/release/ztunnel:1.24.4
+                  images.v1_24_5.cni: registry.istio.io/release/install-cni:1.24.5
+                  images.v1_24_5.istiod: registry.istio.io/release/pilot:1.24.5
+                  images.v1_24_5.proxy: registry.istio.io/release/proxyv2:1.24.5
+                  images.v1_24_5.ztunnel: registry.istio.io/release/ztunnel:1.24.5
+                  images.v1_24_6.cni: registry.istio.io/release/install-cni:1.24.6
+                  images.v1_24_6.istiod: registry.istio.io/release/pilot:1.24.6
+                  images.v1_24_6.proxy: registry.istio.io/release/proxyv2:1.24.6
+                  images.v1_24_6.ztunnel: registry.istio.io/release/ztunnel:1.24.6
                   kubectl.kubernetes.io/default-container: sail-operator
                 labels:
                   app.kubernetes.io/created-by: sailoperator
@@ -820,92 +820,92 @@ spec:
   provider:
     name: Red Hat, Inc.
   relatedImages:
-    - image: gcr.io/istio-release/install-cni:1.23.0
+    - image: registry.istio.io/release/install-cni:1.23.0
       name: v1_23_0.cni
-    - image: gcr.io/istio-release/pilot:1.23.0
+    - image: registry.istio.io/release/pilot:1.23.0
       name: v1_23_0.istiod
-    - image: gcr.io/istio-release/proxyv2:1.23.0
+    - image: registry.istio.io/release/proxyv2:1.23.0
       name: v1_23_0.proxy
-    - image: gcr.io/istio-release/ztunnel:1.23.0
+    - image: registry.istio.io/release/ztunnel:1.23.0
       name: v1_23_0.ztunnel
-    - image: gcr.io/istio-release/install-cni:1.23.3
+    - image: registry.istio.io/release/install-cni:1.23.3
       name: v1_23_3.cni
-    - image: gcr.io/istio-release/pilot:1.23.3
+    - image: registry.istio.io/release/pilot:1.23.3
       name: v1_23_3.istiod
-    - image: gcr.io/istio-release/proxyv2:1.23.3
+    - image: registry.istio.io/release/proxyv2:1.23.3
       name: v1_23_3.proxy
-    - image: gcr.io/istio-release/ztunnel:1.23.3
+    - image: registry.istio.io/release/ztunnel:1.23.3
       name: v1_23_3.ztunnel
-    - image: gcr.io/istio-release/install-cni:1.23.4
+    - image: registry.istio.io/release/install-cni:1.23.4
       name: v1_23_4.cni
-    - image: gcr.io/istio-release/pilot:1.23.4
+    - image: registry.istio.io/release/pilot:1.23.4
       name: v1_23_4.istiod
-    - image: gcr.io/istio-release/proxyv2:1.23.4
+    - image: registry.istio.io/release/proxyv2:1.23.4
       name: v1_23_4.proxy
-    - image: gcr.io/istio-release/ztunnel:1.23.4
+    - image: registry.istio.io/release/ztunnel:1.23.4
       name: v1_23_4.ztunnel
-    - image: gcr.io/istio-release/install-cni:1.23.5
+    - image: registry.istio.io/release/install-cni:1.23.5
       name: v1_23_5.cni
-    - image: gcr.io/istio-release/pilot:1.23.5
+    - image: registry.istio.io/release/pilot:1.23.5
       name: v1_23_5.istiod
-    - image: gcr.io/istio-release/proxyv2:1.23.5
+    - image: registry.istio.io/release/proxyv2:1.23.5
       name: v1_23_5.proxy
-    - image: gcr.io/istio-release/ztunnel:1.23.5
+    - image: registry.istio.io/release/ztunnel:1.23.5
       name: v1_23_5.ztunnel
-    - image: gcr.io/istio-release/install-cni:1.23.6
+    - image: registry.istio.io/release/install-cni:1.23.6
       name: v1_23_6.cni
-    - image: gcr.io/istio-release/pilot:1.23.6
+    - image: registry.istio.io/release/pilot:1.23.6
       name: v1_23_6.istiod
-    - image: gcr.io/istio-release/proxyv2:1.23.6
+    - image: registry.istio.io/release/proxyv2:1.23.6
       name: v1_23_6.proxy
-    - image: gcr.io/istio-release/ztunnel:1.23.6
+    - image: registry.istio.io/release/ztunnel:1.23.6
       name: v1_23_6.ztunnel
-    - image: gcr.io/istio-release/install-cni:1.24.1
+    - image: registry.istio.io/release/install-cni:1.24.1
       name: v1_24_1.cni
-    - image: gcr.io/istio-release/pilot:1.24.1
+    - image: registry.istio.io/release/pilot:1.24.1
       name: v1_24_1.istiod
-    - image: gcr.io/istio-release/proxyv2:1.24.1
+    - image: registry.istio.io/release/proxyv2:1.24.1
       name: v1_24_1.proxy
-    - image: gcr.io/istio-release/ztunnel:1.24.1
+    - image: registry.istio.io/release/ztunnel:1.24.1
       name: v1_24_1.ztunnel
-    - image: gcr.io/istio-release/install-cni:1.24.2
+    - image: registry.istio.io/release/install-cni:1.24.2
       name: v1_24_2.cni
-    - image: gcr.io/istio-release/pilot:1.24.2
+    - image: registry.istio.io/release/pilot:1.24.2
       name: v1_24_2.istiod
-    - image: gcr.io/istio-release/proxyv2:1.24.2
+    - image: registry.istio.io/release/proxyv2:1.24.2
       name: v1_24_2.proxy
-    - image: gcr.io/istio-release/ztunnel:1.24.2
+    - image: registry.istio.io/release/ztunnel:1.24.2
       name: v1_24_2.ztunnel
-    - image: gcr.io/istio-release/install-cni:1.24.3
+    - image: registry.istio.io/release/install-cni:1.24.3
       name: v1_24_3.cni
-    - image: gcr.io/istio-release/pilot:1.24.3
+    - image: registry.istio.io/release/pilot:1.24.3
       name: v1_24_3.istiod
-    - image: gcr.io/istio-release/proxyv2:1.24.3
+    - image: registry.istio.io/release/proxyv2:1.24.3
       name: v1_24_3.proxy
-    - image: gcr.io/istio-release/ztunnel:1.24.3
+    - image: registry.istio.io/release/ztunnel:1.24.3
       name: v1_24_3.ztunnel
-    - image: gcr.io/istio-release/install-cni:1.24.4
+    - image: registry.istio.io/release/install-cni:1.24.4
       name: v1_24_4.cni
-    - image: gcr.io/istio-release/pilot:1.24.4
+    - image: registry.istio.io/release/pilot:1.24.4
       name: v1_24_4.istiod
-    - image: gcr.io/istio-release/proxyv2:1.24.4
+    - image: registry.istio.io/release/proxyv2:1.24.4
       name: v1_24_4.proxy
-    - image: gcr.io/istio-release/ztunnel:1.24.4
+    - image: registry.istio.io/release/ztunnel:1.24.4
       name: v1_24_4.ztunnel
-    - image: gcr.io/istio-release/install-cni:1.24.5
+    - image: registry.istio.io/release/install-cni:1.24.5
       name: v1_24_5.cni
-    - image: gcr.io/istio-release/pilot:1.24.5
+    - image: registry.istio.io/release/pilot:1.24.5
       name: v1_24_5.istiod
-    - image: gcr.io/istio-release/proxyv2:1.24.5
+    - image: registry.istio.io/release/proxyv2:1.24.5
       name: v1_24_5.proxy
-    - image: gcr.io/istio-release/ztunnel:1.24.5
+    - image: registry.istio.io/release/ztunnel:1.24.5
       name: v1_24_5.ztunnel
-    - image: gcr.io/istio-release/install-cni:1.24.6
+    - image: registry.istio.io/release/install-cni:1.24.6
       name: v1_24_6.cni
-    - image: gcr.io/istio-release/pilot:1.24.6
+    - image: registry.istio.io/release/pilot:1.24.6
       name: v1_24_6.istiod
-    - image: gcr.io/istio-release/proxyv2:1.24.6
+    - image: registry.istio.io/release/proxyv2:1.24.6
       name: v1_24_6.proxy
-    - image: gcr.io/istio-release/ztunnel:1.24.6
+    - image: registry.istio.io/release/ztunnel:1.24.6
       name: v1_24_6.ztunnel
   version: 1.0.6

--- a/hack/download-charts.sh
+++ b/hack/download-charts.sh
@@ -100,12 +100,12 @@ function patchIstioCharts() {
 
 # The charts use docker.io as the default registry, but this leads to issues
 # because of Docker Hub's rate limiting. This function modifies the hub field
-# in all charts to use gcr.io/istio-release instead of docker.io/istio.
-# gcr.io also contains the official images for Istio and they ar an exact match.
-function replaceDockerHubWithGcrIo() {
-  echo "replacing docker.io/istio with gcr.io/istio-release in all charts"
+# in all charts to use registry.istio.io/release instead of docker.io/istio.
+# registry.istio.io also contains the official images for Istio and they are an exact match.
+function replaceDockerHubWithRegistryIstio() {
+  echo "replacing docker.io/istio with registry.istio.io/release in all charts"
 
-  find "${CHARTS_DIR}" -name values.yaml -exec sed -i 's/hub: docker.io\/istio/hub: gcr.io\/istio-release/g' {} \;
+  find "${CHARTS_DIR}" -name values.yaml -exec sed -i 's/hub: docker.io\/istio/hub: registry.istio.io\/release/g' {} \;
 }
 
 function convertIstioProfiles() {
@@ -148,6 +148,6 @@ version: 0.1.0
 
 downloadIstioManifests
 patchIstioCharts
-replaceDockerHubWithGcrIo
+replaceDockerHubWithRegistryIstio
 convertIstioProfiles
 createRevisionTagChart

--- a/resources/v1.23.0/charts/cni/values.yaml
+++ b/resources/v1.23.0/charts/cni/values.yaml
@@ -110,7 +110,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.23.0

--- a/resources/v1.23.0/charts/istiod-remote/values.yaml
+++ b/resources/v1.23.0/charts/istiod-remote/values.yaml
@@ -199,7 +199,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.0
     # Variant of the image to use.

--- a/resources/v1.23.0/charts/istiod/values.yaml
+++ b/resources/v1.23.0/charts/istiod/values.yaml
@@ -236,7 +236,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.0
     # Variant of the image to use.

--- a/resources/v1.23.0/charts/revisiontags/values.yaml
+++ b/resources/v1.23.0/charts/revisiontags/values.yaml
@@ -236,7 +236,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.0
     # Variant of the image to use.

--- a/resources/v1.23.0/charts/ztunnel/values.yaml
+++ b/resources/v1.23.0/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set defaults.foo=bar`, just set `--set foo=bar`.
 defaults:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.23.0
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/resources/v1.23.3/charts/cni/values.yaml
+++ b/resources/v1.23.3/charts/cni/values.yaml
@@ -110,7 +110,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.23.3

--- a/resources/v1.23.3/charts/istiod-remote/values.yaml
+++ b/resources/v1.23.3/charts/istiod-remote/values.yaml
@@ -199,7 +199,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.3
     # Variant of the image to use.

--- a/resources/v1.23.3/charts/istiod/values.yaml
+++ b/resources/v1.23.3/charts/istiod/values.yaml
@@ -236,7 +236,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.3
     # Variant of the image to use.

--- a/resources/v1.23.3/charts/revisiontags/values.yaml
+++ b/resources/v1.23.3/charts/revisiontags/values.yaml
@@ -236,7 +236,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.3
     # Variant of the image to use.

--- a/resources/v1.23.3/charts/ztunnel/values.yaml
+++ b/resources/v1.23.3/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set defaults.foo=bar`, just set `--set foo=bar`.
 defaults:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.23.3
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/resources/v1.23.4/charts/cni/values.yaml
+++ b/resources/v1.23.4/charts/cni/values.yaml
@@ -113,7 +113,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.23.4

--- a/resources/v1.23.4/charts/istiod-remote/values.yaml
+++ b/resources/v1.23.4/charts/istiod-remote/values.yaml
@@ -199,7 +199,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.4
     # Variant of the image to use.

--- a/resources/v1.23.4/charts/istiod/values.yaml
+++ b/resources/v1.23.4/charts/istiod/values.yaml
@@ -236,7 +236,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.4
     # Variant of the image to use.

--- a/resources/v1.23.4/charts/revisiontags/values.yaml
+++ b/resources/v1.23.4/charts/revisiontags/values.yaml
@@ -236,7 +236,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.4
     # Variant of the image to use.

--- a/resources/v1.23.4/charts/ztunnel/values.yaml
+++ b/resources/v1.23.4/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set defaults.foo=bar`, just set `--set foo=bar`.
 defaults:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.23.4
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/resources/v1.23.5/charts/cni/values.yaml
+++ b/resources/v1.23.5/charts/cni/values.yaml
@@ -113,7 +113,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.23.5

--- a/resources/v1.23.5/charts/istiod-remote/values.yaml
+++ b/resources/v1.23.5/charts/istiod-remote/values.yaml
@@ -199,7 +199,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.5
     # Variant of the image to use.

--- a/resources/v1.23.5/charts/istiod/values.yaml
+++ b/resources/v1.23.5/charts/istiod/values.yaml
@@ -236,7 +236,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.5
     # Variant of the image to use.

--- a/resources/v1.23.5/charts/revisiontags/values.yaml
+++ b/resources/v1.23.5/charts/revisiontags/values.yaml
@@ -236,7 +236,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.5
     # Variant of the image to use.

--- a/resources/v1.23.5/charts/ztunnel/values.yaml
+++ b/resources/v1.23.5/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set defaults.foo=bar`, just set `--set foo=bar`.
 defaults:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.23.5
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/resources/v1.23.6/charts/cni/values.yaml
+++ b/resources/v1.23.6/charts/cni/values.yaml
@@ -113,7 +113,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.23.6

--- a/resources/v1.23.6/charts/istiod-remote/values.yaml
+++ b/resources/v1.23.6/charts/istiod-remote/values.yaml
@@ -199,7 +199,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.6
     # Variant of the image to use.

--- a/resources/v1.23.6/charts/istiod/values.yaml
+++ b/resources/v1.23.6/charts/istiod/values.yaml
@@ -236,7 +236,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.6
     # Variant of the image to use.

--- a/resources/v1.23.6/charts/revisiontags/values.yaml
+++ b/resources/v1.23.6/charts/revisiontags/values.yaml
@@ -236,7 +236,7 @@ defaults:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.23.6
     # Variant of the image to use.

--- a/resources/v1.23.6/charts/ztunnel/values.yaml
+++ b/resources/v1.23.6/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set defaults.foo=bar`, just set `--set foo=bar`.
 defaults:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.23.6
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/resources/v1.24.1/charts/cni/values.yaml
+++ b/resources/v1.24.1/charts/cni/values.yaml
@@ -112,7 +112,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.24.1

--- a/resources/v1.24.1/charts/istiod/values.yaml
+++ b/resources/v1.24.1/charts/istiod/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.1
     # Variant of the image to use.

--- a/resources/v1.24.1/charts/revisiontags/values.yaml
+++ b/resources/v1.24.1/charts/revisiontags/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.1
     # Variant of the image to use.

--- a/resources/v1.24.1/charts/ztunnel/values.yaml
+++ b/resources/v1.24.1/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
 _internal_defaults_do_not_set:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.24.1
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/resources/v1.24.2/charts/cni/values.yaml
+++ b/resources/v1.24.2/charts/cni/values.yaml
@@ -112,7 +112,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.24.2

--- a/resources/v1.24.2/charts/istiod/values.yaml
+++ b/resources/v1.24.2/charts/istiod/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.2
     # Variant of the image to use.

--- a/resources/v1.24.2/charts/revisiontags/values.yaml
+++ b/resources/v1.24.2/charts/revisiontags/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.2
     # Variant of the image to use.

--- a/resources/v1.24.2/charts/ztunnel/values.yaml
+++ b/resources/v1.24.2/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
 _internal_defaults_do_not_set:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.24.2
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/resources/v1.24.3/charts/cni/values.yaml
+++ b/resources/v1.24.3/charts/cni/values.yaml
@@ -112,7 +112,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.24.3

--- a/resources/v1.24.3/charts/istiod/values.yaml
+++ b/resources/v1.24.3/charts/istiod/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.3
     # Variant of the image to use.

--- a/resources/v1.24.3/charts/revisiontags/values.yaml
+++ b/resources/v1.24.3/charts/revisiontags/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.3
     # Variant of the image to use.

--- a/resources/v1.24.3/charts/ztunnel/values.yaml
+++ b/resources/v1.24.3/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
 _internal_defaults_do_not_set:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.24.3
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/resources/v1.24.4/charts/cni/values.yaml
+++ b/resources/v1.24.4/charts/cni/values.yaml
@@ -112,7 +112,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.24.4

--- a/resources/v1.24.4/charts/istiod/values.yaml
+++ b/resources/v1.24.4/charts/istiod/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.4
     # Variant of the image to use.

--- a/resources/v1.24.4/charts/revisiontags/values.yaml
+++ b/resources/v1.24.4/charts/revisiontags/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.4
     # Variant of the image to use.

--- a/resources/v1.24.4/charts/ztunnel/values.yaml
+++ b/resources/v1.24.4/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
 _internal_defaults_do_not_set:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.24.4
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/resources/v1.24.5/charts/cni/values.yaml
+++ b/resources/v1.24.5/charts/cni/values.yaml
@@ -112,7 +112,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.24.5

--- a/resources/v1.24.5/charts/istiod/values.yaml
+++ b/resources/v1.24.5/charts/istiod/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.5
     # Variant of the image to use.

--- a/resources/v1.24.5/charts/revisiontags/values.yaml
+++ b/resources/v1.24.5/charts/revisiontags/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.5
     # Variant of the image to use.

--- a/resources/v1.24.5/charts/ztunnel/values.yaml
+++ b/resources/v1.24.5/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
 _internal_defaults_do_not_set:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.24.5
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/resources/v1.24.6/charts/cni/values.yaml
+++ b/resources/v1.24.6/charts/cni/values.yaml
@@ -112,7 +112,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
 
     # Default tag for Istio images.
     tag: 1.24.6

--- a/resources/v1.24.6/charts/istiod/values.yaml
+++ b/resources/v1.24.6/charts/istiod/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.6
     # Variant of the image to use.

--- a/resources/v1.24.6/charts/revisiontags/values.yaml
+++ b/resources/v1.24.6/charts/revisiontags/values.yaml
@@ -240,7 +240,7 @@ _internal_defaults_do_not_set:
     # Default hub for Istio images.
     # Releases are published to docker hub under 'istio' project.
     # Dev builds from prow are on gcr.io
-    hub: gcr.io/istio-release
+    hub: registry.istio.io/release
     # Default tag for Istio images.
     tag: 1.24.6
     # Variant of the image to use.

--- a/resources/v1.24.6/charts/ztunnel/values.yaml
+++ b/resources/v1.24.6/charts/ztunnel/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
 _internal_defaults_do_not_set:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-  hub: gcr.io/istio-release
+  hub: registry.istio.io/release
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
   tag: 1.24.6
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -263,7 +263,7 @@ The following environment variables define the behavior of the test run:
 * NAMESPACE=sail-operator - The namespace where the operator will be deployed and the test will run.
 * CONTROL_PLANE_NS=istio-system - The namespace where the control plane will be deployed.
 * DEPLOYMENT_NAME=sail-operator - The name of the operator deployment.
-* EXPECTED_REGISTRY=`^docker\.io|^gcr\.io` - Which image registry should the operand images come from. Useful for downstream tests.
+* EXPECTED_REGISTRY=`^docker\.io|^gcr\.io|^registry\.istio\.io` - Which image registry should the operand images come from. Useful for downstream tests.
 
 ### Customizing the test run
 

--- a/tests/e2e/ambient/ambient_suite_test.go
+++ b/tests/e2e/ambient/ambient_suite_test.go
@@ -39,7 +39,7 @@ var (
 	ztunnelNamespace      = env.Get("ZTUNNEL_NAMESPACE", "ztunnel")
 	istioCniName          = env.Get("ISTIOCNI_NAME", "default")
 	skipDeploy            = env.GetBool("SKIP_DEPLOY", false)
-	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io")
+	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io|^registry\\.istio\\.io")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 
 	k kubectl.Kubectl

--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -43,7 +43,7 @@ var (
 	istioCniNamespace     = env.Get("ISTIOCNI_NAMESPACE", "istio-cni")
 	istioCniName          = env.Get("ISTIOCNI_NAME", "default")
 	skipDeploy            = env.GetBool("SKIP_DEPLOY", false)
-	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io")
+	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io|^registry\\.istio\\.io")
 	sampleNamespace       = env.Get("SAMPLE_NAMESPACE", "sample")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 	ipFamily              = env.Get("IP_FAMILY", "ipv4")

--- a/tests/e2e/dualstack/dualstack_suite_test.go
+++ b/tests/e2e/dualstack/dualstack_suite_test.go
@@ -38,7 +38,7 @@ var (
 	istioCniNamespace     = env.Get("ISTIOCNI_NAMESPACE", "istio-cni")
 	istioCniName          = env.Get("ISTIOCNI_NAME", "default")
 	skipDeploy            = env.GetBool("SKIP_DEPLOY", false)
-	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io")
+	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io|^registry\\.istio\\.io")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 	ipFamily              = env.Get("IP_FAMILY", "ipv4")
 

--- a/tests/e2e/integ-suite-kind.sh
+++ b/tests/e2e/integ-suite-kind.sh
@@ -58,7 +58,7 @@ function setup_kind_registry() {
   if [[ "${running}" != 'true' ]]; then
       docker run \
         -d --restart=always -p "${KIND_REGISTRY_PORT}:5000" --name "${KIND_REGISTRY_NAME}" \
-        gcr.io/istio-testing/registry:2
+        registry.istio.io/testing/registry:2
 
     # Allow kind nodes to reach the registry
     docker network connect "kind" "${KIND_REGISTRY_NAME}"

--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -38,7 +38,7 @@ make update-common
 
 # update build container used in github actions
 NEW_IMAGE_MASTER=$(grep IMAGE_VERSION= < common/scripts/setup_env.sh | cut -d= -f2)
-sed -i -e "s|\(gcr.io/istio-testing/build-tools\):master.*|\1:$NEW_IMAGE_MASTER|" .github/workflows/update-deps.yaml
+sed -i -e "s|\(registry.istio.io/testing/build-tools\):release-1.24.*|\1:$NEW_IMAGE_MASTER|" .github/workflows/update-deps.yaml
 
 # Update go dependencies
 export GO111MODULE=on


### PR DESCRIPTION
Using registry.istio.io instead of gcr.io which will be no longer available for Istio from 2027

 