### PR TITLE
fix: use operator name as prefix in metrics-reader clusterrole.

### DIFF
--- a/bundle/manifests/sailoperator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/sailoperator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -5,11 +5,11 @@ metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: sailoperator
-    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/instance: sailoperator-metrics-reader
     app.kubernetes.io/managed-by: helm
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/part-of: sailoperator
-  name: metrics-reader
+  name: sailoperator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics

--- a/chart/templates/rbac/auth_proxy_client_clusterrole.yaml
+++ b/chart/templates/rbac/auth_proxy_client_clusterrole.yaml
@@ -4,11 +4,11 @@ metadata:
   labels:
     app.kubernetes.io/created-by: {{ .Values.name }}
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/instance: {{ .Values.name }}-metrics-reader
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/managed-by: helm
     app.kubernetes.io/part-of: {{ .Values.name }}
-  name: metrics-reader
+  name: {{ .Values.name }}-metrics-reader
 rules:
 - nonResourceURLs:
   - "/metrics"

--- a/tests/e2e/cleanup-ocp.sh
+++ b/tests/e2e/cleanup-ocp.sh
@@ -183,10 +183,10 @@ cleanup_cluster_resources() {
   echo "=== Cleaning up cluster-level resources ==="
 
   echo "Removing cluster role bindings..."
-  ${COMMAND} delete clusterrolebinding metrics-reader-rolebinding --ignore-not-found
+  ${COMMAND} delete clusterrolebinding sailoperator-metrics-reader-rolebinding --ignore-not-found
 
   echo "Removing cluster roles..."
-  ${COMMAND} delete clusterrole metrics-reader --ignore-not-found
+  ${COMMAND} delete clusterrole sailoperator-metrics-reader --ignore-not-found
 }
 
 # Main cleanup flow following official documentation order

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
 		})
 
 		It("serves metrics securely", func(ctx SpecContext) {
-			metricsReaderRoleName := "metrics-reader"
+			metricsReaderRoleName := "sailoperator-metrics-reader"
 			metricsServiceName := deploymentName + "-metrics-service"
 
 			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
@@ -101,7 +101,7 @@ var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metrics-reader-rolebinding
+  name: sailoperator-metrics-reader-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [x] Bug Fix

#### What this PR does / why we need it:
When deploying the operator with OLM v1, the operator-controller performs a server-side dry-run apply on the entire bundle before installation. If a ClusterRole named `metrics-reader` already exists on the cluster and is owned by another operator, the installation fails with:
```
ClusterRole 'metrics-reader' already exists in namespace '' and cannot be managed by operator-controller
```
This was not an issue with OLM v0, where each CSV reconciled its own cluster-scoped resources independently without ownership conflict checks.

The fix is adding as prefix the operator name to the ClusterRole, following the same convention used by other operators (e.g. [VPA Operator](https://github.com/kubernetes/autoscaler/blob/3ac5fc596fe04b18dd764f35c766cda0cb4cd512/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender-clusterroles.yaml#L6)).

Rename metrics-reader → sailoperator-metrics-reader


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
