### PR TITLE
Add kubebuilder validation for revisionTagTargetRef

### DIFF
--- a/api/v1/istiorevisiontags_types.go
+++ b/api/v1/istiorevisiontags_types.go
@@ -35,8 +35,7 @@ type IstioRevisionTagSpec struct {
 type IstioRevisionTagTargetReference struct {
 	// Kind is the kind of the target resource.
 	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Enum=Istio;IstioRevision
 	// +kubebuilder:validation:Required
 	Kind string `json:"kind"`
 

--- a/bundle/manifests/sailoperator.io_istiorevisiontags.yaml
+++ b/bundle/manifests/sailoperator.io_istiorevisiontags.yaml
@@ -71,8 +71,9 @@ spec:
                 properties:
                   kind:
                     description: Kind is the kind of the target resource.
-                    maxLength: 253
-                    minLength: 1
+                    enum:
+                    - Istio
+                    - IstioRevision
                     type: string
                   name:
                     description: Name is the name of the target resource.

--- a/chart/crds/sailoperator.io_istiorevisiontags.yaml
+++ b/chart/crds/sailoperator.io_istiorevisiontags.yaml
@@ -71,8 +71,9 @@ spec:
                 properties:
                   kind:
                     description: Kind is the kind of the target resource.
-                    maxLength: 253
-                    minLength: 1
+                    enum:
+                    - Istio
+                    - IstioRevision
                     type: string
                   name:
                     description: Name is the name of the target resource.

--- a/docs/api-reference/sailoperator.io.md
+++ b/docs/api-reference/sailoperator.io.md
@@ -1095,7 +1095,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `kind` _string_ | Kind is the kind of the target resource. |  | MaxLength: 253  MinLength: 1  Required: \{\}   |
+| `kind` _string_ | Kind is the kind of the target resource. |  | Enum: [Istio IstioRevision]  Required: \{\}   |
 | `name` _string_ | Name is the name of the target resource. |  | MaxLength: 253  MinLength: 1  Required: \{\}   |
 
 


### PR DESCRIPTION
The `IstioRevisionTagTargetReference` can point to either `Istio` or `IstioRevision`.
So, instead of validating on the length, this PR adds kubebuilder validation.
