### PR TITLE
[release-1.28] Add the possibility to override the test timeout (#1788)

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -35,3 +35,12 @@ func GetBool(key string, defaultValue bool) bool {
 	}
 	return boolValue
 }
+
+func GetInt(key string, defaultValue int) int {
+	value := Get(key, strconv.Itoa(defaultValue))
+	intValue, err := strconv.Atoi(value)
+	if err != nil {
+		return defaultValue
+	}
+	return intValue
+}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -112,3 +112,51 @@ func TestGetBool(t *testing.T) {
 		})
 	}
 }
+
+func TestGetInt(t *testing.T) {
+	intKey := "ENV_TEST_TEST_GET_INT_VALID"
+	intValue := "42"
+	t.Setenv(intKey, intValue)
+
+	notIntKey := "ENV_TEST_TEST_GET_INT_INVALID"
+	notIntValue := "not an int"
+	t.Setenv(notIntKey, notIntValue)
+
+	tests := []struct {
+		name         string
+		key          string
+		defaultValue int
+		want         int
+	}{
+		{
+			name:         "empty-key",
+			key:          "",
+			defaultValue: 100,
+			want:         100,
+		},
+		{
+			name:         "missing-env-var",
+			key:          "NONEXISTENT_ENV_VAR",
+			defaultValue: 200,
+			want:         200,
+		},
+		{
+			name:         "int-value",
+			key:          intKey,
+			defaultValue: 0,
+			want:         42,
+		},
+		{
+			name:         "non-int-value-returns-default",
+			key:          notIntKey,
+			defaultValue: 300,
+			want:         300,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetInt(tt.key, tt.defaultValue)
+			assert.Equalf(t, tt.want, got, "GetInt(%v, %v)", tt.key, tt.defaultValue)
+		})
+	}
+}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -293,6 +293,7 @@ The following environment variables define the behavior of the test run:
 * DEPLOYMENT_NAME=sail-operator - The name of the operator deployment.
 * EXPECTED_REGISTRY=`^docker\.io|^gcr\.io|^registry\.istio\.io` - Which image registry should the operand images come from. Useful for downstream tests.
 * KEEP_ON_FAILURE - If set to true, when using a local KIND cluster, don't clean it up when the test fails. This allows to debug the failure.
+* DEFAULT_TEST_TIMEOUT=180 - The default timeout in seconds for `Eventually` assertions. Increase this value when running tests on slow clusters (e.g., `DEFAULT_TEST_TIMEOUT=300` for 5 minutes).
 
 ### Customizing the test run
 

--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
@@ -36,12 +37,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	defaultTimeout = 180
-)
+var defaultTimeout = env.GetInt("DEFAULT_TEST_TIMEOUT", 180)
 
 var _ = Describe("Ambient configuration ", Label("smoke", "ambient"), Ordered, func() {
-	SetDefaultEventuallyTimeout(defaultTimeout * time.Second)
+	SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
 	debugInfoLogged := false

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
@@ -42,7 +43,7 @@ import (
 )
 
 var _ = Describe("Control Plane Installation", Label("smoke", "control-plane", "slow"), Ordered, func() {
-	SetDefaultEventuallyTimeout(180 * time.Second)
+	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false
 

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
@@ -37,7 +38,7 @@ import (
 )
 
 var _ = Describe("Control Plane updates", Label("control-plane", "slow"), Ordered, func() {
-	SetDefaultEventuallyTimeout(180 * time.Second)
+	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false
 

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
@@ -45,7 +46,7 @@ const (
 )
 
 var _ = Describe("DualStack configuration ", Label("dualstack"), Ordered, func() {
-	SetDefaultEventuallyTimeout(180 * time.Second)
+	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
 	debugInfoLogged := false

--- a/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
+++ b/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
@@ -44,7 +45,7 @@ const (
 )
 
 var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-external"), Ordered, func() {
-	SetDefaultEventuallyTimeout(180 * time.Second)
+	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
 	Describe("External Control Plane Multi-Network configuration", func() {

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
@@ -39,7 +40,7 @@ import (
 )
 
 var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-multiprimary"), Ordered, func() {
-	SetDefaultEventuallyTimeout(180 * time.Second)
+	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
 	Describe("Multi-Primary Multi-Network configuration", func() {

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
@@ -40,7 +41,7 @@ import (
 )
 
 var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-primaryremote"), Ordered, func() {
-	SetDefaultEventuallyTimeout(180 * time.Second)
+	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
 	Describe("Primary-Remote - Multi-Network configuration", func() {

--- a/tests/e2e/multicontrolplane/multi_control_plane_test.go
+++ b/tests/e2e/multicontrolplane/multi_control_plane_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
@@ -34,7 +35,7 @@ import (
 )
 
 var _ = Describe("Multi control plane deployment model", Label("smoke", "multicontrol-plane"), Ordered, func() {
-	SetDefaultEventuallyTimeout(180 * time.Second)
+	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false
 	latestVersion := istioversion.GetLatestPatchVersions()[0]

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
@@ -57,7 +58,7 @@ var sailCRDs = []string{
 }
 
 var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
-	SetDefaultEventuallyTimeout(180 * time.Second)
+	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
 	Describe("installation", func() {


### PR DESCRIPTION
Backports https://github.com/istio-ecosystem/sail-operator/pull/1788 
Fixes https://github.com/istio-ecosystem/sail-operator/issues/1789