### PR TITLE
[release-1.26] fix: make pod readiness check more reliable after restart

### DIFF
--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -222,12 +222,7 @@ spec:
 						cl.Delete(ctx, &pod)
 					}
 
-					Expect(cl.List(ctx, samplePods, client.InNamespace(sampleNamespace))).To(Succeed())
-					Expect(samplePods.Items).ToNot(BeEmpty(), "No pods found in sample namespace")
-					for _, pod := range samplePods.Items {
-						Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key(pod.Name, sampleNamespace), &corev1.Pod{}).
-							Should(HaveConditionStatus(corev1.PodReady, metav1.ConditionTrue), "Pod is not Ready")
-					}
+					Eventually(common.CheckPodsReady).WithArguments(ctx, cl, sampleNamespace).Should(Succeed(), "Sample pods are not ready after restart")
 
 					Success("sample pods restarted and are ready")
 				})


### PR DESCRIPTION
The e2e test was re-listing pods immediately after deletion and waiting on specific pod names, which made it prone to race conditions. It could end up waiting on terminating pods which will never reach ready state. This PR modifies the code to use Eventually to fix the issue.
