### PR TITLE
Fix license linter after Helm v3→v4 migration

### DIFF
--- a/common/config/license-lint.yml
+++ b/common/config/license-lint.yml
@@ -79,6 +79,7 @@ allowlisted_modules:
 
 # Helm is Apache 2.0: https://github.com/helm/helm/blob/master/LICENSE
 # However, it has a bunch of LICENSE test files that our linter fails to understand
+- helm.sh/helm/v3
 - helm.sh/helm/v4
 
 # https://github.com/pelletier/go-toml/blob/master/LICENSE


### PR DESCRIPTION
## Problem

After the Helm v4 migration (#1644), `make update-common` syncs `common/config/license-lint.yml` from `istio/common-files`, which only has `helm.sh/helm/v3` in the allowlist. This caused the Automator update-deps PR (#1837) to drop the `helm.sh/helm/v4` entry, making the license linter fail with 23 unrecognized licenses:

```
ERROR: Some modules have unrecognized licenses:
  helm.sh/helm/v4: path '.../testdata/frobnitz/LICENSE'
  ...
```

Related #1837

🤖 Generated with [Claude Code](https://claude.com/claude-code)