### PR TITLE
[release-1.0] Enable OLM true for OCP cluster on e2e test (#1765)

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -569,12 +569,12 @@ $(GITLEAKS): $(LOCALBIN)
 
 # Openshift Platform flag
 # If is set to true will add `--set platform=openshift` to the helm template command
-OPENSHIFT_PLATFORM ?= true
+OCP ?= true
 
 .PHONY: bundle
 bundle: gen-all-except-bundle helm operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	@TEMPL_FLAGS="$(HELM_TEMPL_DEF_FLAGS)"; \
-	if [ "$(OPENSHIFT_PLATFORM)" = "true" ]; then \
+	if [ "$(OCP)" = "true" ]; then \
 		TEMPL_FLAGS="$$TEMPL_FLAGS --set platform=openshift"; \
 	fi; \
 	$(HELM) template chart chart $$TEMPL_FLAGS --set image='$(IMAGE)' --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -569,12 +569,12 @@ $(GITLEAKS): $(LOCALBIN)
 
 # Openshift Platform flag
 # If is set to true will add `--set platform=openshift` to the helm template command
-OCP ?= true
+OPENSHIFT_PLATFORM ?= true
 
 .PHONY: bundle
 bundle: gen-all-except-bundle helm operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	@TEMPL_FLAGS="$(HELM_TEMPL_DEF_FLAGS)"; \
-	if [ "$(OCP)" = "true" ]; then \
+	if [ "$(OPENSHIFT_PLATFORM)" = "true" ]; then \
 		TEMPL_FLAGS="$$TEMPL_FLAGS --set platform=openshift"; \
 	fi; \
 	$(HELM) template chart chart $$TEMPL_FLAGS --set image='$(IMAGE)' --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -251,7 +251,7 @@ if [ "${SKIP_BUILD}" == "false" ]; then
     IMAGE="${HUB}/${IMAGE_BASE}:${TAG}" \
     IMAGE_TAG_BASE="${IMAGE_TAG_BASE}" \
     BUNDLE_IMG="${BUNDLE_IMG}" \
-    OCP="${OCP}" \
+    OPENSHIFT_PLATFORM="${OCP}" \
     make bundle bundle-build bundle-push
 
     if [ "${OCP}" == "false" ]; then

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -99,10 +99,6 @@ parse_flags() {
 
   if [ "${OLM}" == "true" ]; then
     echo "OLM deployment enabled"
-    if [ "${OCP}" == "true" ]; then
-      echo "Skipping operator deployment using OLM on OCP clusters due to certificate issues with the internal registry."
-      exit 1
-    fi
   fi
 }
 
@@ -124,6 +120,8 @@ initialize_variables() {
   IP_FAMILY=${IP_FAMILY:-ipv4}
   ISTIO_MANIFEST="chart/samples/istio-sample.yaml"
   CI=${CI:-"false"}
+  USE_INTERNAL_REGISTRY=${USE_INTERNAL_REGISTRY:-"false"}
+  FIPS_CLUSTER=${FIPS_CLUSTER:-"false"}
 
 
   if [ "${OCP}" == "true" ]; then
@@ -253,23 +251,28 @@ if [ "${SKIP_BUILD}" == "false" ]; then
     IMAGE="${HUB}/${IMAGE_BASE}:${TAG}" \
     IMAGE_TAG_BASE="${IMAGE_TAG_BASE}" \
     BUNDLE_IMG="${BUNDLE_IMG}" \
-    OPENSHIFT_PLATFORM=false \
+    OCP="${OCP}" \
     make bundle bundle-build bundle-push
 
-    # Install OLM in the cluster because it's not available by default in kind.
-    OLM_INSTALL_ARGS=""
-    if [ "${OLM_VERSION}" != "" ]; then
-      OLM_INSTALL_ARGS+="--version ${OLM_VERSION}"
+    if [ "${OCP}" == "false" ]; then
+      # Install OLM in the cluster because it's not available by default in kind.
+      OLM_INSTALL_ARGS=""
+      if [ "${OLM_VERSION}" != "" ]; then
+        OLM_INSTALL_ARGS+="--version ${OLM_VERSION}"
+      fi
+
+      # Ensure kubeconfig is set to the kind cluster
+      kind export kubeconfig --name="${KIND_CLUSTER_NAME}"
+      # shellcheck disable=SC2086
+      ${OPERATOR_SDK} olm install ${OLM_INSTALL_ARGS}
+
+      ${COMMAND} wait catalogsource operatorhubio-catalog -n olm --for 'jsonpath={.status.connectionState.lastObservedState}=READY' --timeout=5m
+    else
+      # On OCP, wait for different CatalogSources as operatorhubio-catalog might not exist
+      ${COMMAND} wait catalogsource redhat-operators -n openshift-marketplace --for 'jsonpath={.status.connectionState.lastObservedState}=READY' --timeout=5m || true
     fi
-    # shellcheck disable=SC2086
-    ${OPERATOR_SDK} olm install ${OLM_INSTALL_ARGS}
 
-    # Wait for for the CatalogSource to be CatalogSource.status.connectionState.lastObservedState == READY
-    ${COMMAND} wait catalogsource operatorhubio-catalog -n olm --for 'jsonpath={.status.connectionState.lastObservedState}=READY' --timeout=5m
-
-    # Create operator namespace
-    ${COMMAND} create ns "${NAMESPACE}" || echo "Creation of namespace ${NAMESPACE} failed with the message: $?"
-    # Deploy the operator using OLM
+    ${COMMAND} create ns "${NAMESPACE}" || true
     ${OPERATOR_SDK} run bundle "${BUNDLE_IMG}" -n "${NAMESPACE}" --skip-tls --timeout 5m || {
       echo "****** run bundle failed, running debug information"
       # Get all the pods in the namespace


### PR DESCRIPTION
This is needed to be able to enable OLM to deploy true in all the midstream jobs. With this, we will test both installation methods on upstream, and only OLM deployment on midstream repo. Note: I still need to complete the midstream configuration on this [PR](https://github.com/openshift/release/pull/77163)

## Summary

Manual cherry-pick of #1765 onto `release-1.0`, as requested in #1786.

The automated cherry-pick failed due to merge conflicts in `tests/e2e/common-operator-integ-suite.sh`. Conflicts were resolved by:
- Accepting the incoming `USE_INTERNAL_REGISTRY` and `FIPS_CLUSTER` variable default initializations
- Applying the platform-aware OLM logic (kind clusters install OLM + wait for `operatorhubio-catalog`; OCP clusters wait for `redhat-operators` in `openshift-marketplace`) while preserving the `release-1.0` verbose error handler for `run bundle`

Additionally, a fix was applied on top to address a scorecard test failure introduced by the cherry-pick: the rename of `OPENSHIFT_PLATFORM` → `OCP` in the Makefile `bundle` target collided with the `OCP` variable used by `test.scorecard`, causing OCP prow runners to attempt connecting to an OCP cluster that wasn't available. The fix reverts the Makefile variable name to `OPENSHIFT_PLATFORM` and maps `OCP` → `OPENSHIFT_PLATFORM` in `common-operator-integ-suite.sh` when calling `make bundle`.

Closes #1786


🤖 Generated with [Claude Code](https://claude.com/claude-code)