### PR TITLE
Fix serves metrics securely test

### DIFF
--- a/tests/e2e/cleanup-ocp.sh
+++ b/tests/e2e/cleanup-ocp.sh
@@ -183,10 +183,10 @@ cleanup_cluster_resources() {
   echo "=== Cleaning up cluster-level resources ==="
 
   echo "Removing cluster role bindings..."
-  ${COMMAND} delete clusterrolebinding sailoperator-metrics-reader-rolebinding --ignore-not-found
+  ${COMMAND} delete clusterrolebinding metrics-reader-test-rolebinding --ignore-not-found
 
   echo "Removing cluster roles..."
-  ${COMMAND} delete clusterrole sailoperator-metrics-reader --ignore-not-found
+  ${COMMAND} delete clusterrole "${OPERATOR_NAME}-metrics-reader" --ignore-not-found
 }
 
 # Main cleanup flow following official documentation order

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
@@ -125,15 +126,18 @@ var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
 		})
 
 		It("serves metrics securely", func(ctx SpecContext) {
-			metricsReaderRoleName := "sailoperator-metrics-reader"
+			By("discovering the metrics reader ClusterRole installed on the cluster")
+			metricsReaderRoleName, err := discoverMetricsReaderClusterRole()
+			Expect(err).NotTo(HaveOccurred(), "metrics reader ClusterRole must exist")
+
 			metricsServiceName := deploymentName + "-metrics-service"
 
 			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			err := k.CreateFromString(fmt.Sprintf(`
+			err = k.CreateFromString(fmt.Sprintf(`
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: sailoperator-metrics-reader-rolebinding
+  name: metrics-reader-test-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -428,6 +432,39 @@ func extractCRDNames(crdList *apiextensionsv1.CustomResourceDefinitionList) []st
 		names = append(names, crd.ObjectMeta.Name)
 	}
 	return names
+}
+
+const metricsReaderClusterRoleLabel = "app.kubernetes.io/component=kube-rbac-proxy"
+
+// discoverMetricsReaderClusterRole lists ClusterRoles with the kube-rbac-proxy component label
+// (same as chart/bundle), then picks the one whose name ends with "-metrics-reader".
+func discoverMetricsReaderClusterRole() (string, error) {
+	out, err := k.GetClusterRoleNamesByLabel(metricsReaderClusterRoleLabel)
+	if err != nil {
+		return "", err
+	}
+	var matches []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		name := line
+		if i := strings.LastIndex(line, "/"); i >= 0 {
+			name = line[i+1:]
+		}
+		if strings.HasSuffix(name, "-metrics-reader") {
+			matches = append(matches, name)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no *-metrics-reader ClusterRole under label %s", metricsReaderClusterRoleLabel)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("ambiguous *-metrics-reader ClusterRoles: %v", matches)
+	}
 }
 
 // serviceAccountToken returns a token for the specified service account in the given namespace.

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -214,6 +214,17 @@ func (k Kubectl) GetYAML(kind, name string) (string, error) {
 	return output, nil
 }
 
+// GetClusterRoleNamesByLabel runs `kubectl|oc get clusterrole -l <selector> -o name` (cluster-scoped; no namespace).
+func (k Kubectl) GetClusterRoleNamesByLabel(labelSelector string) (string, error) {
+	cmd := k.build(fmt.Sprintf(" get clusterrole -l %q -o name", labelSelector))
+	output, err := k.executeCommand(cmd)
+	if err != nil {
+		return "", fmt.Errorf("error listing clusterroles: %w, output: %s", err, output)
+	}
+
+	return output, nil
+}
+
 // GetPods returns the pods of a namespace
 func (k Kubectl) GetPods(args ...string) (string, error) {
 	cmd := k.build(fmt.Sprintf(" get pods %s", strings.Join(args, " ")))


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
It fixes the hard-coded cluster role name `sailoperator-metrics-reader` in `serves metrics securely` test. The cluster role name may vary since it is dynamically created `{{ .Values.name }}-metrics-reader`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes: https://github.com/istio-ecosystem/sail-operator/issues/1858

Related Issue/PR #

#### Additional information:
