### PR TITLE
Using crane instead of skopeo which is not available in the build-tools

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,11 +38,6 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Install skopeo
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y skopeo
-
     # this should avoid ERROR: failed to build: failed to read GITHUB_EVENT_PATH "/home/runner/work/_temp/_github_workflow/event.json"
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -318,8 +318,8 @@ endif
 docker-buildx: build-all ## Build and push docker image with cross-platform support.
 ifeq ($(PREVENT_IMAGE_OVERWRITE),true)
 	@echo "Checking if image ${IMAGE} already exists..."
-	@if command -v skopeo >/dev/null 2>&1; then \
-		if skopeo inspect docker://${IMAGE} >/dev/null 2>&1; then \
+	@if command -v crane >/dev/null 2>&1; then \
+		if crane manifest ${IMAGE} >/dev/null 2>&1; then \
 			echo "ERROR: Image tag ${IMAGE} already exists in the registry!"; \
 			echo "Please ensure you are releasing a new version."; \
 			exit 1; \
@@ -327,8 +327,8 @@ ifeq ($(PREVENT_IMAGE_OVERWRITE),true)
 			echo "Image tag ${IMAGE} does not exist. Proceeding with build and push."; \
 		fi; \
 	else \
-		echo "ERROR: skopeo is not installed. Cannot verify if image already exists."; \
-		echo "Install skopeo or set PREVENT_IMAGE_OVERWRITE=false to skip this check."; \
+		echo "ERROR: crane is not installed. Cannot verify if image already exists."; \
+		echo "Install crane or set PREVENT_IMAGE_OVERWRITE=false to skip this check."; \
 		exit 1; \
 	fi
 endif

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -319,12 +319,19 @@ docker-buildx: build-all ## Build and push docker image with cross-platform supp
 ifeq ($(PREVENT_IMAGE_OVERWRITE),true)
 	@echo "Checking if image ${IMAGE} already exists..."
 	@if command -v crane >/dev/null 2>&1; then \
-		if crane manifest ${IMAGE} >/dev/null 2>&1; then \
+		set +e; \
+		OUTPUT=$$(crane manifest ${IMAGE} 2>&1); \
+		EXIT_CODE=$$?; \
+		set -e; \
+		if echo "$$OUTPUT" | grep -q "MANIFEST_UNKNOWN"; then \
+			echo "Image tag ${IMAGE} does not exist. Proceeding with build and push."; \
+		elif [ $$EXIT_CODE -eq 0 ]; then \
 			echo "ERROR: Image tag ${IMAGE} already exists in the registry!"; \
 			echo "Please ensure you are releasing a new version."; \
 			exit 1; \
 		else \
-			echo "Image tag ${IMAGE} does not exist. Proceeding with build and push."; \
+			echo "ERROR: Failed to check if image exists: $$OUTPUT"; \
+			exit 1; \
 		fi; \
 	else \
 		echo "ERROR: crane is not installed. Cannot verify if image already exists."; \


### PR DESCRIPTION
image

Skopeo is not available in the build-tools image so the check was failing because of that. It will work with crane



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #1869


