### PR TITLE
tests: Skip TLS profile change test when is executed on Hosted clusters

### DIFF
--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -230,6 +230,14 @@ spec:
 				Skip("Skipping OpenShift-specific tests on non-OpenShift cluster")
 			}
 
+			Step("Checking if this is a Hosted Cluster")
+			infra := &configv1.Infrastructure{}
+			infraErr := cl.Get(ctx, client.ObjectKey{Name: "cluster"}, infra)
+			Expect(infraErr).NotTo(HaveOccurred(), "Failed to get Infrastructure resource")
+			if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+				Skip("Skipping TLS profile tests on hosted cluster: APIServer resource is read-only on hosted clusters")
+			}
+
 			Step("Determining OpenShift version")
 			cv := &configv1.ClusterVersion{}
 			err := cl.Get(ctx, client.ObjectKey{Name: "version"}, cv)

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -230,6 +230,8 @@ spec:
 				Skip("Skipping OpenShift-specific tests on non-OpenShift cluster")
 			}
 
+			// On hosted clusters, the APIServer resource is read-only and TLS settings cannot be changed,
+			// so skip all TLS profile tests. If the test run in a regular cluster, the APIServer resource is writable and the tests can run as normal.
 			Step("Checking if this is a Hosted Cluster")
 			infra := &configv1.Infrastructure{}
 			infraErr := cl.Get(ctx, client.ObjectKey{Name: "cluster"}, infra)


### PR DESCRIPTION
There are failures when the test is executed on hosted cluster because by default changing the TLS profile

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
