### PR TITLE
Ensure base validator is created for default rev

### DIFF
--- a/pkg/istiovalues/overrides.go
+++ b/pkg/istiovalues/overrides.go
@@ -16,8 +16,6 @@ package istiovalues
 
 import (
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
-
-	"istio.io/istio/pkg/ptr"
 )
 
 func ApplyOverrides(revisionName string, namespace string, values *v1.Values) {
@@ -35,7 +33,9 @@ func ApplyOverrides(revisionName string, namespace string, values *v1.Values) {
 	}
 	values.Global.IstioNamespace = &namespace
 
-	// Force defaultRevision to be empty to prevent creation of the default validator webhook.
-	// This field is deprecated and should be ignored by the operator.
-	values.DefaultRevision = ptr.Of("")
+	// Clear the defaultRevision field to prevent users from creating the default validator webhook.
+	// This field is deprecated and should be ignored by the operator when set by the user.
+	// The validating webhook should still be created when an `Istio` or `IstioRevisionTag` has a
+	// revision name of "default".
+	values.DefaultRevision = nil
 }

--- a/pkg/istiovalues/overrides_test.go
+++ b/pkg/istiovalues/overrides_test.go
@@ -41,7 +41,7 @@ func TestApplyOverrides(t *testing.T) {
 				Global: &v1.GlobalConfig{
 					IstioNamespace: ptr.Of("ns1"),
 				},
-				DefaultRevision: ptr.Of(""),
+				DefaultRevision: nil,
 			},
 		},
 		{
@@ -54,7 +54,7 @@ func TestApplyOverrides(t *testing.T) {
 				Global: &v1.GlobalConfig{
 					IstioNamespace: ptr.Of("ns1"),
 				},
-				DefaultRevision: ptr.Of(""),
+				DefaultRevision: nil,
 			},
 		},
 		{
@@ -69,7 +69,7 @@ func TestApplyOverrides(t *testing.T) {
 				Global: &v1.GlobalConfig{
 					IstioNamespace: ptr.Of("ns1"),
 				},
-				DefaultRevision: ptr.Of(""),
+				DefaultRevision: nil,
 			},
 		},
 		{
@@ -86,7 +86,7 @@ func TestApplyOverrides(t *testing.T) {
 				Global: &v1.GlobalConfig{
 					IstioNamespace: ptr.Of("ns1"),
 				},
-				DefaultRevision: ptr.Of(""),
+				DefaultRevision: nil,
 			},
 		},
 		{
@@ -101,7 +101,7 @@ func TestApplyOverrides(t *testing.T) {
 				Global: &v1.GlobalConfig{
 					IstioNamespace: ptr.Of("ns1"),
 				},
-				DefaultRevision: ptr.Of(""),
+				DefaultRevision: nil,
 			},
 		},
 	}

--- a/pkg/revision/values_test.go
+++ b/pkg/revision/values_test.go
@@ -84,7 +84,7 @@ spec:
 			IstioNamespace: ptr.Of(namespace), // this value is always added/overridden based on IstioRevision.spec.namespace
 		},
 		Revision:        ptr.Of(revisionName),
-		DefaultRevision: ptr.Of(""),
+		DefaultRevision: nil,
 	}
 
 	if !reflect.DeepEqual(result, expected) {
@@ -127,7 +127,7 @@ spec:`)), 0o644))
 			IstioNamespace: ptr.Of(namespace), // this value is always added/overridden based on IstioRevision.spec.namespace
 		},
 		Revision:        ptr.Of(revisionName),
-		DefaultRevision: ptr.Of(""),
+		DefaultRevision: nil,
 	}
 
 	if !reflect.DeepEqual(result, expected) {

--- a/tests/integration/api/istio_test.go
+++ b/tests/integration/api/istio_test.go
@@ -32,6 +32,7 @@ import (
 	"helm.sh/helm/v4/pkg/release"
 	releasecommon "helm.sh/helm/v4/pkg/release/common"
 	releasev1 "helm.sh/helm/v4/pkg/release/v1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -159,7 +160,7 @@ var _ = Describe("Istio resource", Ordered, func() {
 						},
 					},
 					Revision:        &revKey.Name,
-					DefaultRevision: ptr.Of(""), // set in the default profile
+					DefaultRevision: nil,
 				},
 			}))
 		})
@@ -241,7 +242,7 @@ var _ = Describe("Istio resource", Ordered, func() {
 							},
 						},
 						Revision:        &revKey.Name,
-						DefaultRevision: ptr.Of(""), // set in the default profile
+						DefaultRevision: nil,
 					},
 				}))
 			})
@@ -652,6 +653,28 @@ var _ = Describe("Istio resource", Ordered, func() {
 				g.Expect(rev.Spec.Values.Pilot.ExtraContainerArgs).To(ContainElement(userExtraArg))
 				g.Expect(rev.Spec.Values.Pilot.ExtraContainerArgs).NotTo(ContainElement("--tls-cipher-suites=" + tlsConfigCipherName))
 			}).Should(Succeed())
+		})
+	})
+
+	Describe("ValidatingWebhookConfiguration", func() {
+		It("creates istiod-default-validator when the Istio is named 'default' with InPlace strategy", func() {
+			istio = &v1.Istio{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: v1.IstioSpec{
+					Version:   istioversion.Default,
+					Namespace: istioNamespace,
+					UpdateStrategy: &v1.IstioUpdateStrategy{
+						Type: v1.UpdateStrategyTypeInPlace,
+					},
+				},
+			}
+			createIstioWithCleanup(ctx, istio)
+
+			webhookKey := client.ObjectKey{Name: "istiod-default-validator"}
+			webhook := &admissionv1.ValidatingWebhookConfiguration{}
+			Eventually(k8sClient.Get).WithArguments(ctx, webhookKey, webhook).Should(Succeed())
 		})
 	})
 })

--- a/tests/integration/api/istio_test.go
+++ b/tests/integration/api/istio_test.go
@@ -692,6 +692,9 @@ var _ = Describe("Istio resource", Ordered, func() {
 			createIstioWithCleanup(ctx, istio)
 
 			Consistently(k8sClient.Get).WithArguments(ctx, validatorWebhookKey, &admissionv1.ValidatingWebhookConfiguration{}).Should(ReturnNotFoundError())
+
+			revisionedWebhookKey := client.ObjectKey{Name: "istio-validator-custom-" + istioNamespace}
+			Eventually(k8sClient.Get).WithArguments(ctx, revisionedWebhookKey, &admissionv1.ValidatingWebhookConfiguration{}).Should(Succeed())
 		})
 
 		It("does not create istiod-default-validator with RevisionBased strategy", func() {

--- a/tests/integration/api/istio_test.go
+++ b/tests/integration/api/istio_test.go
@@ -657,6 +657,7 @@ var _ = Describe("Istio resource", Ordered, func() {
 	})
 
 	Describe("ValidatingWebhookConfiguration", func() {
+		validatorWebhookKey := client.ObjectKey{Name: "istiod-default-validator"}
 		It("creates istiod-default-validator when the Istio is named 'default' with InPlace strategy", func() {
 			istio = &v1.Istio{
 				ObjectMeta: metav1.ObjectMeta{
@@ -672,9 +673,43 @@ var _ = Describe("Istio resource", Ordered, func() {
 			}
 			createIstioWithCleanup(ctx, istio)
 
-			webhookKey := client.ObjectKey{Name: "istiod-default-validator"}
-			webhook := &admissionv1.ValidatingWebhookConfiguration{}
-			Eventually(k8sClient.Get).WithArguments(ctx, webhookKey, webhook).Should(Succeed())
+			Eventually(k8sClient.Get).WithArguments(ctx, validatorWebhookKey, &admissionv1.ValidatingWebhookConfiguration{}).Should(Succeed())
+		})
+
+		It("does not create istiod-default-validator when the Istio name is not 'default' with InPlace strategy", func() {
+			istio = &v1.Istio{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "custom",
+				},
+				Spec: v1.IstioSpec{
+					Version:   istioversion.Default,
+					Namespace: istioNamespace,
+					UpdateStrategy: &v1.IstioUpdateStrategy{
+						Type: v1.UpdateStrategyTypeInPlace,
+					},
+				},
+			}
+			createIstioWithCleanup(ctx, istio)
+
+			Consistently(k8sClient.Get).WithArguments(ctx, validatorWebhookKey, &admissionv1.ValidatingWebhookConfiguration{}).Should(ReturnNotFoundError())
+		})
+
+		It("does not create istiod-default-validator with RevisionBased strategy", func() {
+			istio = &v1.Istio{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: v1.IstioSpec{
+					Version:   istioversion.Default,
+					Namespace: istioNamespace,
+					UpdateStrategy: &v1.IstioUpdateStrategy{
+						Type: v1.UpdateStrategyTypeRevisionBased,
+					},
+				},
+			}
+			createIstioWithCleanup(ctx, istio)
+
+			Consistently(k8sClient.Get).WithArguments(ctx, validatorWebhookKey, &admissionv1.ValidatingWebhookConfiguration{}).Should(ReturnNotFoundError())
 		})
 	})
 })

--- a/tests/integration/api/istiorevisiontag_test.go
+++ b/tests/integration/api/istiorevisiontag_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -149,6 +150,11 @@ var _ = Describe("IstioRevisionTag resource", Label("istiorevisiontag"), Ordered
 					})
 					It("updates IstioRevisionTag status", func() {
 						expectTagInUse(ctx, metav1.ConditionFalse, getRevisionName(istio, istioversion.Base))
+					})
+					It("creates the istiod-default-validator ValidatingWebhookConfiguration", func() {
+						webhookKey := client.ObjectKey{Name: "istiod-default-validator"}
+						webhook := &admissionv1.ValidatingWebhookConfiguration{}
+						Eventually(k8sClient.Get).WithArguments(ctx, webhookKey, webhook).Should(Succeed())
 					})
 				})
 				When("workload ns is labeled with istio-injection label", func() {


### PR DESCRIPTION
Clears the `defaultRevision` field in case a user sets this but does not set it to `""` which will cause the webhook to not be created. The validator should be created when the default rev exists. Adds some integration tests for these cases.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
