### PR TITLE
Improve commit hash get for test running on Prow

### DIFF
--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -123,7 +123,17 @@ initialize_variables() {
   CI=${CI:-"false"}
   USE_INTERNAL_REGISTRY=${USE_INTERNAL_REGISTRY:-"false"}
   FIPS_CLUSTER=${FIPS_CLUSTER:-"false"}
-  COMMIT_HASH=$(git rev-parse --short HEAD)
+  # In Prow CI, HEAD is a temporary merge commit not visible in the PR history.
+  # PULL_PULL_SHA holds the actual PR head commit — use it when available.
+  if [ -n "${PULL_PULL_SHA:-}" ]; then
+    COMMIT_HASH="${PULL_PULL_SHA:0:8}"
+  else
+    COMMIT_HASH=$(git rev-parse --short HEAD)
+  fi
+  echo "DEBUG commit hash resolution:"
+  echo "  PULL_PULL_SHA: ${PULL_PULL_SHA:-not set}"
+  echo "  git HEAD (full): $(git rev-parse HEAD)"
+  echo "  COMMIT_HASH resolved to: ${COMMIT_HASH}"
 
   # Debug logging and fallback for GINKGO_FLAGS
   echo "CI environment: ${CI}"


### PR DESCRIPTION
When executing the test on Prow the commit hash used for the tag while building and pushing the image was setting wrong, we will use now a Prow available env var that set the latest commit hash from the PR

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
