### PR TITLE
Add a monitoring resources integration

### DIFF
--- a/chart/samples/monitoring/istio_proxies_monitor.yaml
+++ b/chart/samples/monitoring/istio_proxies_monitor.yaml
@@ -1,0 +1,46 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: istio-proxies-monitor
+spec:
+  selector:
+    matchExpressions:
+    - key: istio-prometheus-ignore
+      operator: DoesNotExist
+  podMetricsEndpoints:
+  - path: /stats/prometheus
+    interval: 30s
+    relabelings:
+    - action: keep
+      sourceLabels: ["__meta_kubernetes_pod_container_name"]
+      regex: "istio-proxy"
+    - action: keep
+      sourceLabels: ["__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape"]
+    - action: replace
+      regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+      replacement: '[$2]:$1'
+      sourceLabels: ["__meta_kubernetes_pod_annotation_prometheus_io_port","__meta_kubernetes_pod_ip"]
+      targetLabel: "__address__"
+    - action: replace
+      regex: (\d+);((([0-9]+?)(\.|$)){4})
+      replacement: '$2:$1'
+      sourceLabels: ["__meta_kubernetes_pod_annotation_prometheus_io_port","__meta_kubernetes_pod_ip"]
+      targetLabel: "__address__"
+    - sourceLabels: ["__meta_kubernetes_pod_label_app_kubernetes_io_name","__meta_kubernetes_pod_label_app"]
+      separator: ";"
+      targetLabel: "app"
+      action: replace
+      regex: "(.+);.*|.*;(.+)"
+      replacement: "${1}${2}"
+    - sourceLabels: ["__meta_kubernetes_pod_label_app_kubernetes_io_version","__meta_kubernetes_pod_label_version"]
+      separator: ";"
+      targetLabel: "version"
+      action: replace
+      regex: "(.+);.*|.*;(.+)"
+      replacement: "${1}${2}"
+    - sourceLabels: ["__meta_kubernetes_namespace"]
+      action: replace
+      targetLabel: namespace
+    - action: replace
+      replacement: "mesh1"
+      targetLabel: mesh_id

--- a/chart/samples/monitoring/istiod_service_monitor.yaml
+++ b/chart/samples/monitoring/istiod_service_monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod-monitor
+  namespace: istio-system
+spec:
+  targetLabels:
+  - app
+  selector:
+    matchLabels:
+      istio: pilot
+  endpoints:
+  - port: http-monitoring
+    interval: 30s

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/openshift/api v0.0.0-20260320151444-324a1bcb9f55
 	github.com/openshift/controller-runtime-common v0.0.0-20260318085703-1812aed6dbd2
 	github.com/openshift/library-go v0.0.0-20260318142011-72bf34f474bc
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.89.0
+	github.com/prometheus-operator/prometheus-operator/pkg/client v0.89.0
 	github.com/prometheus/common v0.67.5
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -285,6 +285,10 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.89.0 h1:nZ9Ov2SbA8pWcyWKpf6AbQipG5Negg5CfDKWOEtnnwc=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.89.0/go.mod h1:IJwk1oNs212afqGbNnE84GAB95OHtJR/BuI1rKESiYk=
+github.com/prometheus-operator/prometheus-operator/pkg/client v0.89.0 h1:1vM3LYUbixaCObAhWj2JaDXVgq13laYGLVncKCQPjn4=
+github.com/prometheus-operator/prometheus-operator/pkg/client v0.89.0/go.mod h1:SdM9A8pyN23e5KAPumIqCPjCG075srdLJCemqr3bV6w=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/pkg/reconcile/monitoring.go
+++ b/pkg/reconcile/monitoring.go
@@ -1,0 +1,246 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcile
+
+import (
+	"context"
+	"fmt"
+
+	"istio.io/istio/pkg/ptr"
+	"k8s.io/client-go/discovery"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	v1client "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	coreosGroupVersion = "monitoring.coreos.com/v1" // default API group used by Prometheus Operator
+	rhobsGroupVersion  = "monitoring.rhobs/v1"      // latest API group used by OpenShift Cluster Observability Operator
+	serviceMonitorKind = "ServiceMonitor"
+	podMonitorKind     = "PodMonitor"
+)
+
+var (
+	serviceMonitorExists = false
+	podMonitorExists     = false
+)
+
+// MonitorReconciler handles reconciliation of the ServiceMonitor and PodMonitor resources.
+type MonitorReconciler struct {
+	discoveryClient  *discovery.DiscoveryClient
+	monitoringClient *v1client.MonitoringV1Client
+	endpointConfigs  []monitoringv1.PodMetricsEndpoint
+}
+
+// defaultPodMetricRelabelConfig defines the default configuration of Istio proxies metrics path and relabelings.
+func defaultPodMetricRelabelConfig() []monitoringv1.PodMetricsEndpoint {
+	return []monitoringv1.PodMetricsEndpoint{
+		{
+			Path:     "/stats/prometheus",
+			Interval: "30s",
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					Action:       "keep",
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_container_name"},
+					Regex:        "istio-proxy",
+				},
+				{
+					Action:       "keep",
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape"},
+				},
+				{
+					Action:       "replace",
+					Regex:        `(\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})`,
+					Replacement:  ptr.Of("[$2]:$1"),
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_annotation_prometheus_io_port", "__meta_kubernetes_pod_ip"},
+					TargetLabel:  "__address__",
+				},
+				{
+					Action:       "replace",
+					Regex:        `(\d+);((([0-9]+?)(\.|$)){4})`,
+					Replacement:  ptr.Of("$2:$1"),
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_annotation_prometheus_io_port", "__meta_kubernetes_pod_ip"},
+					TargetLabel:  "__address__",
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_label_app_kubernetes_io_name", "__meta_kubernetes_pod_label_app"},
+					Separator:    ptr.Of(";"),
+					TargetLabel:  "app",
+					Action:       "replace",
+					Regex:        `(.+);.*|.*;(.+)`,
+					Replacement:  ptr.Of("${1}${2}"),
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_label_app_kubernetes_io_version", "__meta_kubernetes_pod_label_version"},
+					Separator:    ptr.Of(";"),
+					TargetLabel:  "version",
+					Action:       "replace",
+					Regex:        `(.+);.*|.*;(.+)`,
+					Replacement:  ptr.Of("${1}${2}"),
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_namespace"},
+					Action:       "replace",
+					TargetLabel:  "namespace",
+				},
+				{
+					Action:      "replace",
+					Replacement: ptr.Of("mesh1"),
+					TargetLabel: "mesh_id",
+				},
+			},
+		},
+	}
+}
+
+// NewMonitorReconciler creates a new MonitorReconciler.
+func NewMonitorReconciler(configs []monitoringv1.PodMetricsEndpoint) (*MonitorReconciler, error) {
+	// Running in cluster and use the cluster provided kubeconfig.
+	cfg := ctrl.GetConfigOrDie()
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating discovery client: %w", err)
+	}
+
+	if configs == nil {
+		configs = defaultPodMetricRelabelConfig()
+	}
+
+	return &MonitorReconciler{
+		discoveryClient:  discoveryClient,
+		monitoringClient: v1client.New(discoveryClient.RESTClient()),
+		endpointConfigs:  configs,
+	}, nil
+}
+
+// Validate checks custom resource definitions ServiceMonitor and PodMonitor exist in the cluster.
+func (r *MonitorReconciler) Validate(ctx context.Context) error {
+	// Get all resources from API server.
+	resources, err := r.discoveryClient.ServerPreferredResources()
+	if err != nil {
+		return fmt.Errorf("Error getting all resources: %w", err)
+	}
+
+	for _, list := range resources {
+		if list.GroupVersion == coreosGroupVersion || list.GroupVersion == rhobsGroupVersion {
+			for _, resource := range list.APIResources {
+				if resource.Kind == serviceMonitorKind {
+					serviceMonitorExists = true
+					break
+				}
+			}
+		}
+	}
+
+	for _, list := range resources {
+		if list.GroupVersion == coreosGroupVersion || list.GroupVersion == rhobsGroupVersion {
+			for _, resource := range list.APIResources {
+				if resource.Kind == podMonitorKind {
+					podMonitorExists = true
+					break
+				}
+			}
+		}
+	}
+
+	if serviceMonitorExists && podMonitorExists {
+		fmt.Printf("Monitoring CRD ServiceMonitor and PodMonitor exist")
+	} else {
+		if !serviceMonitorExists {
+			return fmt.Errorf("Monitoring CRD ServiceMonitor does not exist.")
+		}
+		if !podMonitorExists {
+			return fmt.Errorf("Monitoring CRD PodMonitor does not exist.")
+		}
+	}
+	return nil
+}
+
+// InstallServiceMonitor installs or upgrades the ServiceMonitor object.
+func (r *MonitorReconciler) InstallServiceMonitor(ctx context.Context, namespace string) error {
+	serviceMonitor := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istiod-monitor",
+			Namespace: namespace,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			TargetLabels: []string{"app"},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"istio": "pilot"},
+			},
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port:     "http-monitoring",
+					Path:     "/metrics",
+					Interval: "30s",
+				},
+			},
+		},
+	}
+
+	_, err := r.monitoringClient.ServiceMonitors("istio-system").Create(context.TODO(), serviceMonitor, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("Failed to create istiod-monitor: %w", err)
+	}
+	return nil
+}
+
+// InstallPodMonitor installs or upgrades the PodMonitor objects.
+func (r *MonitorReconciler) InstallPodMonitor(ctx context.Context, namespaces []string) error {
+	for _, ns := range namespaces {
+		podMonitor := &monitoringv1.PodMonitor{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-proxies-monitor",
+				Namespace: ns,
+			},
+			Spec: monitoringv1.PodMonitorSpec{
+				Selector: metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "istio-prometheus-ignore", Operator: metav1.LabelSelectorOpDoesNotExist},
+					},
+				},
+				PodMetricsEndpoints: r.endpointConfigs,
+			},
+		}
+
+		_, err := r.monitoringClient.PodMonitors(ns).Create(context.TODO(), podMonitor, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("Failed to create istio-proxies-monitor in namespace %s: %w", ns, err)
+		}
+	}
+	return nil
+}
+
+// UninstallServiceMonitor removes the ServiceMonitor object.
+func (r *MonitorReconciler) UninstallServiceMonitor(ctx context.Context) error {
+	err := r.monitoringClient.ServiceMonitors("istio-system").Delete(context.TODO(), "istiod-monitor", metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("Failed to delete istiod-monitor: %w", err)
+	}
+	return nil
+}
+
+// UninstallPodMonitor removes the PodMonitor objects.
+func (r *MonitorReconciler) UninstallPodMonitor(ctx context.Context, namespaces []string) error {
+	for _, ns := range namespaces {
+		err := r.monitoringClient.PodMonitors(ns).Delete(context.TODO(), "istio-proxies-monitor", metav1.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("Failed to delete istio-proxies-monitor in namespace %s: %w", ns, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds an integration of monitoring resources such as Prometheus operator's `ServiceMonitor` and `PodMonitor` in Sail operator.
It implements new reconcilers for configuring OpenShift default User Managed workload Prometheus and Cluster Observability Operator (COO) monitoring stack. 

- [X] Enhancement / New Feature