### PR TITLE
fix: single-node cluster example in Istiod HA docs

### DIFF
--- a/docs/general/istiod-ha.adoc
+++ b/docs/general/istiod-ha.adoc
@@ -184,9 +184,10 @@ metadata:
   name: default
 spec:
   namespace: istio-system
-  global:
-    defaultPodDisruptionBudget:
-      enabled: false # <-- disable default Pod Disruption Budget
+  values:
+    global:
+      defaultPodDisruptionBudget:
+        enabled: false # <-- disable default Pod Disruption Budget
 ----
 
-`spec.global.defaultPodDisruptionBudget.enabled: false` disables the default Pod Disruption Budget for Istiod. In single-node clusters, a PDB can block operations such as node drains or pod evictions, as it prevents the number of available Istiod replicas from falling below the PDB's minimum desired count. Disabling it ensures smooth operations in this specific topology.
+`spec.values.global.defaultPodDisruptionBudget.enabled: false` disables the default Pod Disruption Budget for Istiod. In single-node clusters, a PDB can block operations such as node drains or pod evictions, as it prevents the number of available Istiod replicas from falling below the PDB's minimum desired count. Disabling it ensures smooth operations in this specific topology.


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [x] Documentation Update

#### What this PR does / why we need it:

Update the Considerations for Single-Node Clusters example in `docs/general/istiod-ha.adoc` to place `global.defaultPodDisruptionBudget` under `spec.values`, matching the API reference and the correct Istio resource structure.
