### PR TITLE
[release-1.30] Set DEPLOYMENT_NAME to csv name when OLM is true

### DIFF
--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -226,8 +226,19 @@ install_operator() {
 }
 
 await_operator() {
-  echo "Awaiting sail-operator deployment on (KUBECONFIG=${KUBECONFIG})"
-  "${COMMAND}" wait --for=condition=available deployment/"${DEPLOYMENT_NAME}" -n "${NAMESPACE}" --timeout=5m
+  echo "Awaiting operator deployment on (KUBECONFIG=${KUBECONFIG})"
+  local name="${DEPLOYMENT_NAME}"
+  if [ "${OLM}" == "true" ]; then
+    local csv_name
+    local csv_file
+    csv_file=$(find "${WD}/../../bundle/manifests/" -name "*.clusterserviceversion.yaml" | head -1)
+    csv_name=$(yq eval '.spec.install.spec.deployments[0].name' "${csv_file}" 2>/dev/null || true)
+    if [ -n "${csv_name}" ]; then
+      echo "OLM mode: using deployment name from bundle CSV: ${csv_name}"
+      name="${csv_name}"
+    fi
+  fi
+  "${COMMAND}" wait --for=condition=available deployment/"${name}" -n "${NAMESPACE}" --timeout=5m
 }
 
 # shellcheck disable=SC2329  # Function is invoked indirectly via trap

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -236,6 +236,7 @@ await_operator() {
     if [ -n "${csv_name}" ]; then
       echo "OLM mode: using deployment name from bundle CSV: ${csv_name}"
       name="${csv_name}"
+      DEPLOYMENT_NAME="${csv_name}"
     fi
   fi
   "${COMMAND}" wait --for=condition=available deployment/"${name}" -n "${NAMESPACE}" --timeout=5m


### PR DESCRIPTION
Manual cherry-pick for #1920.

The automatic cherry-pick of #1918 failed on `release-1.30` because the prerequisite commit from #1874 had not been cherry-picked to this branch (it was cherry-picked to release-1.26 through release-1.29 but missed release-1.30).

This PR cherry-picks both commits in order:
1. `ca09f5fb` — test: Modify await_operator to dynamically get deployment name from csv when OLM is true (#1874)
2. `9a08acd3` — Set DEPLOYMENT_NAME to csv name when OLM is true (#1918)

#### What type of PR is this?
- [x] Test

#### What this PR does / why we need it:
`await_operator` now dynamically gets the deployment name from the bundle CSV when OLM is true, and also sets `DEPLOYMENT_NAME` to that value. This avoids test failures when the bundle name differs from `sail-operator`.

#### Which issue(s) this PR fixes:
Fixes #1920

Related Issue/PR #1918 #1874