### PR TITLE
Fix Ambient E2E targetref test cleanup steps

### DIFF
--- a/tests/e2e/ambient/ambient_targetref_test.go
+++ b/tests/e2e/ambient/ambient_targetref_test.go
@@ -69,6 +69,12 @@ profile: ambient`)
 
 	Context("Value Propagation from TargetRef", Ordered, func() {
 		networkValue := "test-network"
+		var contextCleaner cleaner.Cleaner
+
+		BeforeAll(func(ctx SpecContext) {
+			contextCleaner = cleaner.New(cl)
+			contextCleaner.Record(ctx)
+		})
 
 		When("Istio CR is created with custom global.network value", func() {
 			It("creates Istio with custom network configuration", func(ctx SpecContext) {
@@ -182,21 +188,20 @@ spec:
 				Success(fmt.Sprintf("ZTunnel DaemonSet inherited updated NETWORK=%s", newNetworkValue))
 			})
 		})
+
+		AfterAll(func(ctx SpecContext) {
+			contextCleaner.Cleanup(ctx)
+			Success("Context cleanup completed")
+		})
 	})
 
 	Context("MeshConfig Propagation from TargetRef", Ordered, func() {
 		customTrustDomain := "custom-trust.local"
+		var contextCleaner cleaner.Cleaner
 
 		BeforeAll(func(ctx SpecContext) {
-			// Delete the ZTunnel from the previous context
-			_ = k.Delete("ztunnel", "default")
-			Eventually(func(g Gomega) {
-				ztunnel := &v1.ZTunnel{}
-				err := cl.Get(ctx, kube.Key("default"), ztunnel)
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(ContainSubstring("not found"))
-			}).Should(Succeed())
-			Success("Previous ZTunnel deleted and verified gone")
+			contextCleaner = cleaner.New(cl)
+			contextCleaner.Record(ctx)
 		})
 
 		When("Istio CR is created with custom meshConfig", func() {
@@ -317,6 +322,11 @@ spec:
 				Success("ZTunnel DaemonSet healthy after meshConfig update")
 			})
 		})
+
+		AfterAll(func(ctx SpecContext) {
+			contextCleaner.Cleanup(ctx)
+			Success("Context cleanup completed")
+		})
 	})
 
 	Context("User Value Override Precedence", Ordered, func() {
@@ -324,18 +334,11 @@ spec:
 		overrideNetwork := "override-net"
 		customEnvVar := "CUSTOM_TEST_VAR"
 		customEnvValue := "custom-value"
+		var contextCleaner cleaner.Cleaner
 
 		BeforeAll(func(ctx SpecContext) {
-			// Delete the ZTunnel from the previous context since only one ZTunnel named 'default' can exist
-			// Wait for deletion to complete to avoid conflicts
-			_ = k.Delete("ztunnel", "default")
-			Eventually(func(g Gomega) {
-				ztunnel := &v1.ZTunnel{}
-				err := cl.Get(ctx, kube.Key("default"), ztunnel)
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(ContainSubstring("not found"))
-			}).Should(Succeed())
-			Success("Previous ZTunnel deleted and verified gone")
+			contextCleaner = cleaner.New(cl)
+			contextCleaner.Record(ctx)
 		})
 
 		When("Istio is created with a network value", func() {
@@ -459,36 +462,21 @@ spec:
 				Success(fmt.Sprintf("ZTunnel now uses inherited NETWORK=%s", inheritedNetwork))
 			})
 		})
+
+		AfterAll(func(ctx SpecContext) {
+			contextCleaner.Cleanup(ctx)
+			Success("Context cleanup completed")
+		})
 	})
 
 	Context("Invalid TargetRef Handling", Ordered, func() {
-		BeforeAll(func(ctx SpecContext) {
-			// Delete the ZTunnel from the previous context since only one ZTunnel named 'default' can exist
-			// Wait for deletion to complete to avoid conflicts
-			_ = k.Delete("ztunnel", "default")
-			Eventually(func(g Gomega) {
-				ztunnel := &v1.ZTunnel{}
-				err := cl.Get(ctx, kube.Key("default"), ztunnel)
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(ContainSubstring("not found"))
-			}).Should(Succeed())
-			Success("Previous ZTunnel deleted and verified gone")
-		})
-
 		When("ZTunnel targetRef points to non-existent Istio resource", func() {
 			missingIstioName := "missing-istio"
+			var whenCleaner cleaner.Cleaner
 
 			BeforeAll(func(ctx SpecContext) {
-				// Delete the ZTunnel from the previous When block
-				// Wait for deletion to complete to avoid conflicts
-				_ = k.Delete("ztunnel", "default")
-				Eventually(func(g Gomega) {
-					ztunnel := &v1.ZTunnel{}
-					err := cl.Get(ctx, kube.Key("default"), ztunnel)
-					g.Expect(err).To(HaveOccurred())
-					g.Expect(err.Error()).To(ContainSubstring("not found"))
-				}).Should(Succeed())
-				Success("Previous ZTunnel deleted and verified gone")
+				whenCleaner = cleaner.New(cl)
+				whenCleaner.Record(ctx)
 			})
 
 			It("creates ZTunnel with targetRef to non-existent Istio", func(ctx SpecContext) {
@@ -581,6 +569,11 @@ spec:
 					g.Expect(daemonset.Status.NumberAvailable).To(BeNumerically(">", 0))
 				}).Should(Succeed())
 				Success("Value propagation working - ZTunnel DaemonSet is deployed")
+			})
+
+			AfterAll(func(ctx SpecContext) {
+				whenCleaner.Cleanup(ctx)
+				Success("Cleanup completed")
 			})
 		})
 	})


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
The targetref ambient test, makes a cleanup of istiod instance after all the tests being executed, at the end of the test.
During the test, 4 Istiod instances are being created. This flow leads to a failure of the test in envs, where there is a memory limit up to 8Gb.

Modify the cleanup steps to use the common "cleaner.Cleaner" flow, used across all the tests.
It would take a snapshot at the beginning of the test, before resource screation, and then cleanup then after each test by a call. It would significally decrease the amount of memory usage during the test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
