### PR TITLE
Remove `TLS12_ENABLED` from ZTunnel istio 1.31+

### DIFF
--- a/pkg/istiovalues/fips.go
+++ b/pkg/istiovalues/fips.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 
 	"istio.io/istio/pkg/log"
@@ -27,6 +28,8 @@ var (
 	FipsEnabled        bool
 	FipsEnableFilePath = "/proc/sys/crypto/fips_enabled"
 )
+
+var istio1_30 = semver.MustParse("1.30.0")
 
 // detectFipsMode checks if FIPS mode is enabled in the system.
 func init() {
@@ -66,16 +69,31 @@ func ApplyFipsValues(values *v1.Values) {
 }
 
 // ApplyZTunnelFipsValues sets ztunnel.env.TLS12_ENABLED if FIPS mode is enabled in the system.
-func ApplyZTunnelFipsValues(values *v1.ZTunnelValues) {
+// For versions >= 1.30, TLS12_ENABLED is removed because ztunnel
+// defaults to using only FIPS 140-3 approved ciphers.
+func ApplyZTunnelFipsValues(values *v1.ZTunnelValues, version string) {
 	if !FipsEnabled || values == nil {
 		return
 	}
+
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		log.Warnf("failed to parse ztunnel version %q: %v", version, err)
+	}
+	if v != nil && v.GreaterThanEqual(istio1_30) {
+		if values.ZTunnel != nil && values.ZTunnel.Env != nil {
+			delete(values.ZTunnel.Env, "TLS12_ENABLED")
+		}
+		return
+	}
+
 	if values.ZTunnel == nil {
 		values.ZTunnel = &v1.ZTunnelConfig{}
 	}
 	if values.ZTunnel.Env == nil {
 		values.ZTunnel.Env = make(map[string]string)
 	}
+	// TODO: Remove this after 1.29 is no longer supported.
 	if _, found := values.ZTunnel.Env["TLS12_ENABLED"]; !found {
 		values.ZTunnel.Env["TLS12_ENABLED"] = "true"
 	}

--- a/pkg/istiovalues/fips.go
+++ b/pkg/istiovalues/fips.go
@@ -69,7 +69,7 @@ func ApplyFipsValues(values *v1.Values) {
 }
 
 // ApplyZTunnelFipsValues sets ztunnel.env.TLS12_ENABLED if FIPS mode is enabled in the system.
-// For versions >= 1.30, TLS12_ENABLED is removed because ztunnel
+// For versions > 1.30, TLS12_ENABLED is removed because ztunnel
 // defaults to using only FIPS 140-3 approved ciphers.
 func ApplyZTunnelFipsValues(values *v1.ZTunnelValues, version string) {
 	if !FipsEnabled || values == nil {
@@ -80,7 +80,7 @@ func ApplyZTunnelFipsValues(values *v1.ZTunnelValues, version string) {
 	if err != nil {
 		log.Warnf("failed to parse ztunnel version %q: %v", version, err)
 	}
-	if v != nil && v.GreaterThanEqual(istio1_30) {
+	if v != nil && v.GreaterThan(istio1_30) {
 		if values.ZTunnel != nil && values.ZTunnel.Env != nil {
 			delete(values.ZTunnel.Env, "TLS12_ENABLED")
 		}

--- a/pkg/istiovalues/fips_test.go
+++ b/pkg/istiovalues/fips_test.go
@@ -25,8 +25,8 @@ import (
 
 func TestDetectFipsMode(t *testing.T) {
 	resourceDir := t.TempDir()
-	os.WriteFile(path.Join(resourceDir, "fips_enabled"), []byte(("1\n")), 0o644)
-	os.WriteFile(path.Join(resourceDir, "fips_not_enabled"), []byte(("0\n")), 0o644)
+	os.WriteFile(path.Join(resourceDir, "fips_enabled"), []byte("1\n"), 0o644)
+	os.WriteFile(path.Join(resourceDir, "fips_not_enabled"), []byte("0\n"), 0o644)
 	tests := []struct {
 		name        string
 		filepath    string
@@ -141,18 +141,21 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 	tests := []struct {
 		name         string
 		fipsEnabled  bool
+		version      string
 		inputValues  *v1.ZTunnelValues
 		expectValues *v1.ZTunnelValues
 	}{
 		{
 			name:         "FIPS not enabled",
 			fipsEnabled:  false,
+			version:      "1.29.0",
 			inputValues:  &v1.ZTunnelValues{},
 			expectValues: &v1.ZTunnelValues{},
 		},
 		{
 			name:        "FIPS enabled",
 			fipsEnabled: true,
+			version:     "1.29.0",
 			inputValues: &v1.ZTunnelValues{},
 			expectValues: &v1.ZTunnelValues{
 				ZTunnel: &v1.ZTunnelConfig{
@@ -163,6 +166,7 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 		{
 			name:        "FIPS enabled with existing env",
 			fipsEnabled: true,
+			version:     "1.29.0",
 			inputValues: &v1.ZTunnelValues{
 				ZTunnel: &v1.ZTunnelConfig{
 					Env: map[string]string{"OTHER_VAR": "value"},
@@ -180,6 +184,7 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 		{
 			name:        "FIPS enabled but TLS12_ENABLED already set",
 			fipsEnabled: true,
+			version:     "1.29.0",
 			inputValues: &v1.ZTunnelValues{
 				ZTunnel: &v1.ZTunnelConfig{
 					Env: map[string]string{"TLS12_ENABLED": "false"},
@@ -194,8 +199,36 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 		{
 			name:         "nil values",
 			fipsEnabled:  false,
+			version:      "1.29.0",
 			inputValues:  nil,
 			expectValues: nil,
+		},
+		{
+			name:        "version >= 1.30 removes TLS12_ENABLED",
+			fipsEnabled: true,
+			version:     "1.30.0",
+			inputValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{
+						"TLS12_ENABLED": "true",
+						"OTHER_VAR":     "keep",
+					},
+				},
+			},
+			expectValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{
+						"OTHER_VAR": "keep",
+					},
+				},
+			},
+		},
+		{
+			name:         "version >= 1.30 does not set TLS12_ENABLED even with FIPS",
+			fipsEnabled:  true,
+			version:      "1.31.0",
+			inputValues:  &v1.ZTunnelValues{},
+			expectValues: &v1.ZTunnelValues{},
 		},
 	}
 
@@ -204,7 +237,7 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 			originalFipsEnabled := FipsEnabled
 			t.Cleanup(func() { FipsEnabled = originalFipsEnabled })
 			FipsEnabled = tt.fipsEnabled
-			ApplyZTunnelFipsValues(tt.inputValues)
+			ApplyZTunnelFipsValues(tt.inputValues, tt.version)
 
 			if diff := cmp.Diff(tt.expectValues, tt.inputValues); diff != "" {
 				t.Errorf("TLS12_ENABLED env wasn't applied properly; diff (-expected, +actual):\n%v", diff)

--- a/pkg/istiovalues/fips_test.go
+++ b/pkg/istiovalues/fips_test.go
@@ -204,9 +204,20 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 			expectValues: nil,
 		},
 		{
-			name:        "version >= 1.30 removes TLS12_ENABLED",
+			name:        "version 1.30 still sets TLS12_ENABLED",
 			fipsEnabled: true,
 			version:     "1.30.0",
+			inputValues: &v1.ZTunnelValues{},
+			expectValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{"TLS12_ENABLED": "true"},
+				},
+			},
+		},
+		{
+			name:        "version > 1.30 removes TLS12_ENABLED",
+			fipsEnabled: true,
+			version:     "1.31.0",
 			inputValues: &v1.ZTunnelValues{
 				ZTunnel: &v1.ZTunnelConfig{
 					Env: map[string]string{
@@ -224,9 +235,16 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 			},
 		},
 		{
-			name:         "version >= 1.30 does not set TLS12_ENABLED even with FIPS",
+			name:         "version > 1.30 does not set TLS12_ENABLED even with FIPS",
 			fipsEnabled:  true,
 			version:      "1.31.0",
+			inputValues:  &v1.ZTunnelValues{},
+			expectValues: &v1.ZTunnelValues{},
+		},
+		{
+			name:         "version 1.31-alpha does not set TLS12_ENABLED",
+			fipsEnabled:  true,
+			version:      "1.31.0-alpha.0",
 			inputValues:  &v1.ZTunnelValues{},
 			expectValues: &v1.ZTunnelValues{},
 		},

--- a/pkg/reconcile/ztunnel.go
+++ b/pkg/reconcile/ztunnel.go
@@ -87,7 +87,7 @@ func (r *ZTunnelReconciler) ComputeValues(version string, userValues *v1.ZTunnel
 	userValues = ApplyZTunnelImageDigests(resolvedVersion, userValues, config.Config)
 
 	// apply fips values
-	istiovalues.ApplyZTunnelFipsValues(userValues)
+	istiovalues.ApplyZTunnelFipsValues(userValues, resolvedVersion)
 
 	var mergedHelmValues helm.Values
 	if len(baseValues) > 0 && baseValues[0] != nil {

--- a/tests/integration/api/ztunnel_test.go
+++ b/tests/integration/api/ztunnel_test.go
@@ -233,7 +233,7 @@ var _ = Describe("ZTunnel FIPS", Label("ztunnel", "fips"), Ordered, func() {
 			"Expected TLS12_ENABLED to be set to true on ztunnel DaemonSet when FIPS is enabled")
 	})
 
-	It("removes TLS12_ENABLED from the ztunnel DaemonSet when version >= 1.30", func() {
+	It("removes TLS12_ENABLED from the ztunnel DaemonSet when version > 1.30", func() {
 		originalFipsEnabled := istiovalues.FipsEnabled
 		DeferCleanup(func() {
 			istiovalues.FipsEnabled = originalFipsEnabled
@@ -245,7 +245,7 @@ var _ = Describe("ZTunnel FIPS", Label("ztunnel", "fips"), Ordered, func() {
 				Name: ztunnelName,
 			},
 			Spec: v1.ZTunnelSpec{
-				Version:   istioversion.Default,
+				Version:   "master",
 				Namespace: fipsZTunnelNamespace,
 				Values: &v1.ZTunnelValues{
 					ZTunnel: &v1.ZTunnelConfig{
@@ -267,7 +267,7 @@ var _ = Describe("ZTunnel FIPS", Label("ztunnel", "fips"), Ordered, func() {
 
 		Expect(ds).To(HaveContainersThat(ContainElement(WithTransform(getEnvVars,
 			Not(ContainElement(corev1.EnvVar{Name: "TLS12_ENABLED", Value: "true"}))))),
-			"Expected TLS12_ENABLED to be removed from ztunnel DaemonSet when version >= 1.30")
+			"Expected TLS12_ENABLED to be removed from ztunnel DaemonSet when version > 1.30")
 	})
 })
 

--- a/tests/integration/api/ztunnel_test.go
+++ b/tests/integration/api/ztunnel_test.go
@@ -202,7 +202,8 @@ var _ = Describe("ZTunnel FIPS", Label("ztunnel", "fips"), Ordered, func() {
 		Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
 	})
 
-	It("sets TLS12_ENABLED on the ztunnel DaemonSet when FipsEnabled is true", func() {
+	// TODO: Remove this test when Istio 1.29 goes out of support
+	It("sets TLS12_ENABLED on the ztunnel DaemonSet when FipsEnabled is true and version < 1.30", func() {
 		originalFipsEnabled := istiovalues.FipsEnabled
 		DeferCleanup(func() {
 			istiovalues.FipsEnabled = originalFipsEnabled
@@ -214,7 +215,7 @@ var _ = Describe("ZTunnel FIPS", Label("ztunnel", "fips"), Ordered, func() {
 				Name: ztunnelName,
 			},
 			Spec: v1.ZTunnelSpec{
-				Version:   istioversion.Default,
+				Version:   "v1.29.3",
 				Namespace: fipsZTunnelNamespace,
 			},
 		}
@@ -230,6 +231,43 @@ var _ = Describe("ZTunnel FIPS", Label("ztunnel", "fips"), Ordered, func() {
 		Expect(ds).To(HaveContainersThat(ContainElement(WithTransform(getEnvVars,
 			ContainElement(corev1.EnvVar{Name: "TLS12_ENABLED", Value: "true"})))),
 			"Expected TLS12_ENABLED to be set to true on ztunnel DaemonSet when FIPS is enabled")
+	})
+
+	It("removes TLS12_ENABLED from the ztunnel DaemonSet when version >= 1.30", func() {
+		originalFipsEnabled := istiovalues.FipsEnabled
+		DeferCleanup(func() {
+			istiovalues.FipsEnabled = originalFipsEnabled
+		})
+		istiovalues.FipsEnabled = true
+
+		ztunnel := &v1.ZTunnel{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ztunnelName,
+			},
+			Spec: v1.ZTunnelSpec{
+				Version:   istioversion.Default,
+				Namespace: fipsZTunnelNamespace,
+				Values: &v1.ZTunnelValues{
+					ZTunnel: &v1.ZTunnelConfig{
+						Env: map[string]string{
+							"TLS12_ENABLED": "true",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ztunnel)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ztunnel)).To(Succeed())
+			Eventually(k8sClient.Get).WithArguments(ctx, fipsZTunnelKey, &v1.ZTunnel{}).Should(ReturnNotFoundError())
+		})
+
+		ds := &appsv1.DaemonSet{}
+		Eventually(k8sClient.Get).WithArguments(ctx, daemonsetKey, ds).Should(Succeed())
+
+		Expect(ds).To(HaveContainersThat(ContainElement(WithTransform(getEnvVars,
+			Not(ContainElement(corev1.EnvVar{Name: "TLS12_ENABLED", Value: "true"}))))),
+			"Expected TLS12_ENABLED to be removed from ztunnel DaemonSet when version >= 1.30")
 	})
 })
 


### PR DESCRIPTION


 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [x] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
In Istio 1.31+ the openssl backend supports FIPS 140-3.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
