### PR TITLE
Add E2E migration test

### DIFF
--- a/pkg/istioversion/version.go
+++ b/pkg/istioversion/version.go
@@ -227,3 +227,24 @@ func GetTwoConsecutiveMinorVersions(minVersion *semver.Version) (baseVer, newVer
 	// filtered[1] = second newest (previous minor)
 	return filtered[1], filtered[0], nil
 }
+
+// GetLatestAmbientVersion returns the latest supported version for ambient mode
+// Ambient mode requires Istio 1.24+, and FIPS clusters require 1.28+
+func GetLatestAmbientVersion() VersionInfo {
+	versions := GetLatestPatchVersions()
+	fipsCluster := env.GetBool("FIPS_CLUSTER", false)
+
+	for _, version := range versions {
+		// Minimum supported version is 1.24
+		if version.Version.LessThan(semver.MustParse("1.24.0")) {
+			continue
+		}
+		// FIPS clusters require v1.28+
+		if fipsCluster && version.Version.LessThan(semver.MustParse("1.28.0")) {
+			continue
+		}
+		return version
+	}
+	// Fallback to the last version if no suitable version found
+	return versions[len(versions)-1]
+}

--- a/pkg/istioversion/version_test.go
+++ b/pkg/istioversion/version_test.go
@@ -216,3 +216,166 @@ func TestGetLatestPatchVersions_Valid(t *testing.T) {
 		assert.Len(t, versions, 0)
 	})
 }
+
+func TestGetTwoConsecutiveMinorVersions(t *testing.T) {
+	t.Run("valid consecutive versions", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.24.2", Version: semver.MustParse("1.24.2")},
+			{Name: "v1.24.1", Version: semver.MustParse("1.24.1")},
+			{Name: "v1.23.5", Version: semver.MustParse("1.23.5")},
+			{Name: "v1.23.4", Version: semver.MustParse("1.23.4")},
+		}
+
+		baseVer, newVer, err := GetTwoConsecutiveMinorVersions(semver.MustParse("1.23.0"))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "v1.24.2", baseVer.Name)
+		assert.Equal(t, "v1.25.0", newVer.Name)
+	})
+
+	t.Run("min version filters out older versions", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.24.2", Version: semver.MustParse("1.24.2")},
+			{Name: "v1.23.5", Version: semver.MustParse("1.23.5")},
+			{Name: "v1.22.0", Version: semver.MustParse("1.22.0")},
+		}
+
+		baseVer, newVer, err := GetTwoConsecutiveMinorVersions(semver.MustParse("1.24.0"))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "v1.24.2", baseVer.Name)
+		assert.Equal(t, "v1.25.0", newVer.Name)
+	})
+
+	t.Run("insufficient versions returns error", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.24.2", Version: semver.MustParse("1.24.2")},
+		}
+
+		_, _, err := GetTwoConsecutiveMinorVersions(semver.MustParse("1.25.0"))
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "insufficient versions available")
+	})
+
+	t.Run("empty list returns error", func(t *testing.T) {
+		List = []VersionInfo{}
+
+		_, _, err := GetTwoConsecutiveMinorVersions(semver.MustParse("1.23.0"))
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "insufficient versions available")
+	})
+
+	t.Run("only one version returns error", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.25.1", Version: semver.MustParse("1.25.1")},
+		}
+
+		_, _, err := GetTwoConsecutiveMinorVersions(semver.MustParse("1.24.0"))
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "insufficient versions available")
+	})
+}
+
+func TestGetLatestAmbientVersion(t *testing.T) {
+	t.Run("returns latest version >= 1.24", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.26.0", Version: semver.MustParse("1.26.0")},
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.24.2", Version: semver.MustParse("1.24.2")},
+			{Name: "v1.23.5", Version: semver.MustParse("1.23.5")},
+		}
+		t.Setenv("FIPS_CLUSTER", "false")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.26.0", version.Name)
+	})
+
+	t.Run("skips versions < 1.24", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.23.5", Version: semver.MustParse("1.23.5")},
+			{Name: "v1.22.0", Version: semver.MustParse("1.22.0")},
+		}
+		t.Setenv("FIPS_CLUSTER", "false")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.25.0", version.Name)
+	})
+
+	t.Run("FIPS cluster requires >= 1.28", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.29.0", Version: semver.MustParse("1.29.0")},
+			{Name: "v1.28.2", Version: semver.MustParse("1.28.2")},
+			{Name: "v1.27.5", Version: semver.MustParse("1.27.5")},
+			{Name: "v1.26.0", Version: semver.MustParse("1.26.0")},
+		}
+		t.Setenv("FIPS_CLUSTER", "true")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.29.0", version.Name)
+	})
+
+	t.Run("FIPS cluster skips versions < 1.28", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.28.0", Version: semver.MustParse("1.28.0")},
+			{Name: "v1.27.5", Version: semver.MustParse("1.27.5")},
+			{Name: "v1.26.0", Version: semver.MustParse("1.26.0")},
+		}
+		t.Setenv("FIPS_CLUSTER", "true")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.28.0", version.Name)
+	})
+
+	t.Run("returns last version when all < 1.24", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.23.5", Version: semver.MustParse("1.23.5")},
+			{Name: "v1.22.0", Version: semver.MustParse("1.22.0")},
+			{Name: "v1.21.0", Version: semver.MustParse("1.21.0")},
+		}
+		t.Setenv("FIPS_CLUSTER", "false")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.21.0", version.Name)
+	})
+
+	t.Run("FIPS returns last version when all < 1.28", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.27.5", Version: semver.MustParse("1.27.5")},
+			{Name: "v1.26.0", Version: semver.MustParse("1.26.0")},
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+		}
+		t.Setenv("FIPS_CLUSTER", "true")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.25.0", version.Name)
+	})
+
+	t.Run("handles multiple patch versions", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.3", Version: semver.MustParse("1.25.3")},
+			{Name: "v1.25.2", Version: semver.MustParse("1.25.2")},
+			{Name: "v1.24.5", Version: semver.MustParse("1.24.5")},
+			{Name: "v1.24.4", Version: semver.MustParse("1.24.4")},
+		}
+		t.Setenv("FIPS_CLUSTER", "false")
+
+		version := GetLatestAmbientVersion()
+
+		// Should return latest patch of latest minor version
+		assert.Equal(t, "v1.25.3", version.Name)
+	})
+}

--- a/tests/e2e/migration/migration_coexistence_test.go
+++ b/tests/e2e/migration/migration_coexistence_test.go
@@ -1,0 +1,420 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
+	"github.com/istio-ecosystem/sail-operator/pkg/kube"
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// expectedPodRestartError is the expected HTTP 503 error during pod restart in migration
+	expectedPodRestartError = "unexpected status code: 503"
+)
+
+var _ = Describe("Migration Sidecar-Ambient Coexistence Validation", Ordered,
+	Label("migration", "migration-coexistence", "slow"), func() {
+		// Tests sidecar-ambient coexistence during migration with continuous traffic.
+		// Uses a stable external client (sidecar mode, never migrates) to send traffic
+		// to a server that transitions from sidecar → HBONE → ambient while traffic flows.
+		// This validates cross-mode communication and verifies traffic resilience during migration.
+		// Validates:
+		//   1. Cross-mode communication works (sidecar client → ambient server)
+		//   2. Limited disruption during pod restart (≤10 503 errors - brief, acceptable)
+		//   3. Traffic RECOVERS after disruption (≥9/10 consecutive successes post-migration)
+		SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
+		SetDefaultEventuallyPollingInterval(time.Second)
+
+		version := istioversion.GetLatestAmbientVersion()
+
+		Context(fmt.Sprintf("Migration testing with Istio %s", version.Version), func() {
+			var clr cleaner.Cleaner
+			workloadNamespace := "workload-traffic"
+			stableClientNamespace := "stable-client"
+
+			BeforeAll(func(ctx SpecContext) {
+				clr = cleaner.New(cl)
+				clr.Record(ctx)
+
+				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+
+				common.CreateIstioCNI(k, version.Name)
+				common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
+				Success("IstioCNI created (no profile - sidecar mode)")
+
+				common.CreateIstio(k, version.Name)
+				common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl)
+				Success("Istio created (default profile - sidecar mode)")
+
+				// Wait for sidecar injector webhook to be ready
+				Eventually(func(g Gomega) {
+					webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
+					g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
+				}).Should(Succeed())
+				Success("Sidecar injector webhook is ready")
+			})
+
+			AfterAll(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.Ambient, k)
+					if keepOnFailure {
+						return
+					}
+				}
+				clr.Cleanup(ctx)
+			})
+
+			Context("Sidecar-Ambient Coexistence with Continuous Traffic", Ordered,
+				Label("migration-coexistence-traffic"), func() {
+					BeforeAll(func(ctx SpecContext) {
+						// Create and deploy stable client (never migrates, always stays in sidecar mode)
+						Expect(k.CreateNamespace(stableClientNamespace)).To(Succeed())
+						Expect(k.Label("namespace", stableClientNamespace, "istio-injection", "enabled")).To(Succeed())
+						Expect(k.WithNamespace(stableClientNamespace).ApplyKustomize("sleep")).To(Succeed())
+						Success("Stable sleep client deployed with sidecar injection")
+
+						Eventually(func(g Gomega) {
+							pods := &corev1.PodList{}
+							g.Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace))).To(Succeed())
+							g.Expect(pods.Items).To(HaveLen(1))
+
+							pod := pods.Items[0]
+							g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+
+							for _, containerStatus := range pod.Status.ContainerStatuses {
+								g.Expect(containerStatus.Ready).To(BeTrue(),
+									"Container %s should be ready", containerStatus.Name)
+							}
+
+							g.Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
+								"Stable client pod should have sidecar injected")
+						}).Should(Succeed())
+						Success("Stable client ready with sidecar")
+					})
+
+					When("server workloads are deployed in sidecar mode", func() {
+						It("creates and labels namespace for sidecar injection", func(ctx SpecContext) {
+							Expect(k.CreateNamespace(workloadNamespace)).To(Succeed())
+							Expect(k.Label("namespace", workloadNamespace, "istio-injection", "enabled")).To(Succeed())
+							Success(fmt.Sprintf("Namespace %s created and labeled for sidecar injection", workloadNamespace))
+						})
+
+						It("deploys httpbin server in sidecar mode", func(ctx SpecContext) {
+							// Only deploy httpbin - client is in stable-client namespace
+							Expect(k.WithNamespace(workloadNamespace).ApplyKustomize("httpbin")).To(Succeed())
+							Success("Httpbin server deployed in sidecar mode")
+						})
+
+						It("waits for httpbin pod to be ready with sidecar", func(ctx SpecContext) {
+							Eventually(func(g Gomega) {
+								pods := &corev1.PodList{}
+								g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+								g.Expect(pods.Items).To(HaveLen(1), "Expected 1 pod (httpbin)")
+
+								pod := pods.Items[0]
+								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+								g.Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
+									"Pod %s should have istio-proxy in either containers or init containers", pod.Name)
+							}).Should(Succeed())
+							Success("Httpbin running with sidecar")
+						})
+
+						It("verifies initial traffic works from stable client", func(ctx SpecContext) {
+							// Get stable client pod (never migrated)
+							pods := &corev1.PodList{}
+							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+							Expect(pods.Items).To(HaveLen(1))
+
+							clientPod := pods.Items[0].Name
+							GinkgoWriter.Printf("Using stable client: %s (in namespace %s)\n", clientPod, stableClientNamespace)
+
+							Eventually(func() error {
+								// Stable client (sidecar mode) → httpbin (sidecar mode)
+								targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+								return common.CheckHTTPConnectivity(k, stableClientNamespace, clientPod, "sleep", targetURL, 5, "200")
+							}).Should(Succeed())
+							Success("Traffic flows from stable client to httpbin (both sidecar mode)")
+						})
+					})
+
+					When("namespace is switched to ambient mode during traffic", func() {
+						var (
+							stats      *common.HTTPTrafficStats
+							cancelFunc context.CancelFunc
+						)
+
+						// Ensure continuous traffic is stopped when this When block completes
+						AfterAll(func() {
+							if cancelFunc != nil {
+								GinkgoWriter.Printf("Cleaning up: stopping any remaining continuous traffic...\n")
+								cancelFunc()
+								time.Sleep(500 * time.Millisecond)
+							}
+						})
+
+						It("starts continuous traffic from stable client", func(ctx SpecContext) {
+							pods := &corev1.PodList{}
+							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+							Expect(pods.Items).To(HaveLen(1))
+							clientPod := pods.Items[0].Name
+							GinkgoWriter.Printf("Using stable client pod: %s (in namespace %s)\n", clientPod, stableClientNamespace)
+
+							// Start continuous traffic from stable client → httpbin server
+							// Client stays in sidecar mode, server will migrate to ambient
+							// Background context is used so traffic continues
+							// across multiple It blocks until we explicitly stop it
+							targetService := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+							stats, cancelFunc = common.StartContinuousHTTPTraffic(
+								context.Background(), k, stableClientNamespace, clientPod, "sleep",
+								targetService, 100*time.Millisecond, nil)
+
+							// Wait for baseline traffic to establish (use Eventually to handle slower OCP clusters)
+							GinkgoWriter.Printf("Waiting for baseline traffic to establish (target: >=5 successful requests)...\n")
+							var total, success, failed int64
+							var errors []string
+
+							Eventually(func(g Gomega) {
+								total, success, failed, errors = stats.GetStats()
+								GinkgoWriter.Printf("[Baseline check] %d total, %d success, %d failed\n", total, success, failed)
+								g.Expect(success).To(BeNumerically(">=", 5), "Should have at least 5 successful requests for baseline")
+							}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+							total, success, failed, errors = stats.GetStats()
+							GinkgoWriter.Printf("Baseline traffic established: %d total, %d success, %d failed\n", total, success, failed)
+
+							if failed > 0 && len(errors) > 0 {
+								GinkgoWriter.Printf("Baseline errors (showing first 5):\n")
+								for i, errMsg := range errors {
+									if i >= 5 {
+										break
+									}
+									GinkgoWriter.Printf("  [%d] %s\n", i+1, errMsg)
+								}
+							}
+							Success("Continuous traffic started from stable client")
+						})
+
+						It("migrates Istio to ambient profile while traffic is running", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Updating Istio to ambient profile...\n")
+							patch := fmt.Sprintf(`{"spec":{"profile":"ambient","values":{"pilot":{"trustedZtunnelNamespace":"%s"}}}}`, ztunnelNamespace)
+							Expect(k.Patch("istio", istioName, "merge", patch)).To(Succeed())
+							common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl)
+							Success("Istio updated to ambient profile")
+						})
+
+						It("migrates IstioCNI to ambient profile while traffic is running", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Updating IstioCNI to ambient profile...\n")
+							Expect(k.Patch("istiocni", istioCniName, "merge", `{"spec":{"profile":"ambient"}}`)).To(Succeed())
+							common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
+							Success("IstioCNI updated to ambient profile")
+						})
+
+						It("deploys ZTunnel while traffic is running", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Deploying ZTunnel...\n")
+							common.CreateZTunnel(k, version.Name)
+							common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl)
+							Success("ZTunnel deployed and ready")
+						})
+
+						It("updates server namespace to revision-based injection for HBONE-aware sidecars", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Waiting for sidecar injector webhook to be recreated...\n")
+							Eventually(func(g Gomega) {
+								webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
+								g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
+							}).Should(Succeed())
+							Success("Sidecar injector webhook is ready")
+
+							// Update namespace to use revision-based injection (HBONE-aware sidecars)
+							ns := &corev1.Namespace{}
+							Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
+							delete(ns.Labels, "istio-injection")
+							ns.Labels["istio.io/rev"] = "default"
+							Expect(cl.Update(ctx, ns)).To(Succeed())
+							Success("Namespace updated to revision-based injection for HBONE-aware sidecars")
+						})
+
+						It("restarts httpbin to get HBONE-aware sidecars while traffic is running", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Restarting httpbin to get HBONE-aware sidecars...\n")
+							_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(func(g Gomega) {
+								_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
+								g.Expect(err).NotTo(HaveOccurred())
+							}).Should(Succeed())
+							Success("Httpbin restarted with HBONE-aware sidecars")
+						})
+
+						It("removes revision label and adds ambient label while traffic is running", func(ctx SpecContext) {
+							// Remove revision-based injection and add ambient label
+							// This is the final step to pure ambient mode
+							ns := &corev1.Namespace{}
+							Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
+							delete(ns.Labels, "istio.io/rev")
+							ns.Labels["istio.io/dataplane-mode"] = "ambient"
+							Expect(cl.Update(ctx, ns)).To(Succeed())
+							Success("Namespace switched to ambient mode (client stays in sidecar mode, traffic still running)")
+						})
+
+						It("restarts httpbin server to apply pure ambient mode while traffic is running", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Restarting httpbin server (stable client stays running)...\n")
+
+							// Only restart httpbin server - stable client pod stays running in different namespace
+							_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
+							Expect(err).NotTo(HaveOccurred(), "Failed to restart httpbin")
+
+							Eventually(func(g Gomega) {
+								_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
+								g.Expect(err).NotTo(HaveOccurred())
+							}).Should(Succeed())
+
+							Success("Httpbin restarted in ambient mode (client never restarted, traffic continuous)")
+						})
+
+						It("waits for httpbin server to be ready in ambient mode", func(ctx SpecContext) {
+							Eventually(func(g Gomega) {
+								pods := &corev1.PodList{}
+								g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+								g.Expect(pods.Items).To(HaveLen(1), "Expected only httpbin pod in server namespace")
+
+								pod := pods.Items[0]
+								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+								g.Expect(pod.Spec.Containers).To(HaveLen(1), "Httpbin should not have sidecar in ambient mode")
+								g.Expect(pod.Annotations).To(HaveKey("ambient.istio.io/redirection"))
+							}).Should(Succeed())
+							Success("Httpbin server running in ambient mode without sidecar")
+
+							// Verify stable client still has sidecar (never migrated)
+							Eventually(func(g Gomega) {
+								pods := &corev1.PodList{}
+								g.Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace))).To(Succeed())
+								g.Expect(pods.Items).To(HaveLen(1))
+
+								clientPod := pods.Items[0]
+								g.Expect(clientPod.Status.Phase).To(Equal(corev1.PodRunning))
+								g.Expect(common.HasSidecarInjected(clientPod)).To(BeTrue(), "Stable client should still have sidecar")
+							}).Should(Succeed())
+							Success("Stable client still running in sidecar mode (never migrated)")
+						})
+
+						It("verifies traffic recovers after brief disruption during migration", func(ctx SpecContext) {
+							// Key insight: During pod restart, we expect:
+							// 1. Some 503 errors (pod terminating/starting) - ACCEPTABLE
+							// 2. Then traffic RESUMES successfully - CRITICAL
+							// 3. Sustained success after recovery - PROVES STABILITY
+
+							GinkgoWriter.Printf("Letting continuous traffic run for 5 more seconds during ambient mode...\n")
+							time.Sleep(5 * time.Second)
+
+							GinkgoWriter.Printf("Stopping continuous traffic and analyzing recovery pattern...\n")
+							if cancelFunc != nil {
+								cancelFunc()
+							}
+							time.Sleep(500 * time.Millisecond) // Allow final requests to complete
+
+							// Analyze the traffic pattern
+							total, success, failed, errors := stats.GetStats()
+							GinkgoWriter.Printf("Total traffic: %d requests, %d success, %d failed\n", total, success, failed)
+
+							// Ensure we actually sent meaningful traffic
+							Expect(total).To(BeNumerically(">=", 10), "Should have sent at least 10 requests during test")
+
+							// Verify 503 errors are bounded (not unlimited failures)
+							count503 := 0
+							for _, err := range errors {
+								if err == expectedPodRestartError {
+									count503++
+								}
+							}
+
+							GinkgoWriter.Printf("503 errors during pod restart: %d\n", count503)
+							if count503 > 0 {
+								GinkgoWriter.Printf("First few 503 errors (expected during pod restart):\n")
+								shown := 0
+								for _, err := range errors {
+									if err == expectedPodRestartError && shown < 3 {
+										GinkgoWriter.Printf("  - %s\n", err)
+										shown++
+									}
+								}
+							}
+
+							// Assert: 503 errors should be limited (pod restart is brief)
+							// Allow up to 10 503s (generous for slow OCP pod restart)
+							Expect(count503).To(BeNumerically("<=", 10),
+								"503 errors should be limited to pod restart window (≤10), got %d", count503)
+
+							// Critical assertion: Verify traffic RECOVERED after 503s
+							// Look for consecutive successes AFTER the disruption
+							pods := &corev1.PodList{}
+							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+							Expect(pods.Items).To(HaveLen(1))
+							clientPod := pods.Items[0].Name
+							targetService := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+
+							GinkgoWriter.Printf("Verifying sustained recovery (10 consecutive requests)...\n")
+
+							// Verify sustained recovery using MustPassRepeatedly
+							// All 10 attempts must succeed (200ms interval between attempts)
+							Eventually(func() error {
+								return common.CheckHTTPConnectivity(
+									k, stableClientNamespace, clientPod, "sleep", targetService, 5, "200")
+							}).WithPolling(200*time.Millisecond).MustPassRepeatedly(10).Should(Succeed(),
+								"Traffic should be stable after recovery (all 10 consecutive requests must succeed)")
+
+							// Summary
+							GinkgoWriter.Printf("\n=== Migration Traffic Pattern Summary ===\n")
+							GinkgoWriter.Printf("Total requests during migration: %d\n", total)
+							GinkgoWriter.Printf("503 errors (pod restart): %d (≤10 acceptable)\n", count503)
+							GinkgoWriter.Printf("Recovery stability: 10/10 consecutive successes (verified with MustPassRepeatedly)\n")
+							GinkgoWriter.Printf("========================================\n")
+
+							Success(fmt.Sprintf("Traffic recovered successfully after %d 503 errors during pod restart", count503))
+						})
+
+						It("verifies cross-mode communication works", func(ctx SpecContext) {
+							// Final verification: stable client (sidecar) can communicate with httpbin (ambient)
+							pods := &corev1.PodList{}
+							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+							Expect(pods.Items).To(HaveLen(1))
+
+							clientPod := pods.Items[0].Name
+							Eventually(func() error {
+								targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+								return common.CheckHTTPConnectivity(k, stableClientNamespace, clientPod, "sleep", targetURL, 5, "200")
+							}).Should(Succeed())
+							Success("Cross-mode communication verified: sidecar client → ambient server")
+						})
+					})
+				})
+		})
+	})

--- a/tests/e2e/migration/migration_procedure_test.go
+++ b/tests/e2e/migration/migration_procedure_test.go
@@ -1,0 +1,586 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"fmt"
+	"time"
+
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
+	"github.com/istio-ecosystem/sail-operator/pkg/kube"
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Migration Procedure Validation", Ordered,
+	Label("migration", "migration-procedure", "slow"), func() {
+		// Tests the complete migration workflow from sidecar to ambient mode.
+		// Validates L4 connectivity via ztunnel and L7 policy enforcement via waypoint in a single namespace.
+		// Migration flow: sidecar → HBONE coexistence → pure ambient → waypoint activation
+		SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
+		SetDefaultEventuallyPollingInterval(time.Second)
+
+		version := istioversion.GetLatestAmbientVersion()
+
+		Context(fmt.Sprintf("Migration from sidecar to ambient with Istio %s version", version.Version), func() {
+			var clr cleaner.Cleaner
+			workloadNamespace := "workload-migration"
+
+			BeforeAll(func(ctx SpecContext) {
+				clr = cleaner.New(cl)
+				clr.Record(ctx)
+
+				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(workloadNamespace)).To(Succeed())
+
+				common.CreateIstioCNI(k, version.Name)
+				common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
+				Success("IstioCNI created (no profile - sidecar mode)")
+
+				Eventually(func(g Gomega) {
+					daemonset := &appsv1.DaemonSet{}
+					g.Expect(cl.Get(ctx, kube.Key("istio-cni-node", istioCniNamespace), daemonset)).To(Succeed(), "Error getting IstioCNI DaemonSet")
+					g.Expect(daemonset.Status.NumberAvailable).
+						To(Equal(daemonset.Status.CurrentNumberScheduled), "CNI DaemonSet Pods not Available")
+				}).Should(Succeed(), "CNI DaemonSet Pods are not Available")
+				Success("CNI DaemonSet is running")
+
+				common.CreateIstio(k, version.Name)
+				common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl)
+				Success("Istio created (default profile - sidecar mode)")
+
+				common.AwaitDeployment(ctx, "istiod", k, cl)
+				Success("Istiod deployment is ready")
+
+				// Wait for sidecar injector webhook to be ready (required for injection to work)
+				Eventually(func(g Gomega) {
+					webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
+					g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed(), "Sidecar injector webhook should exist")
+				}).Should(Succeed(), "Waiting for istio-sidecar-injector webhook to be created")
+				Success("Sidecar injector webhook is ready")
+			})
+
+			AfterAll(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.Ambient, k)
+					if keepOnFailure {
+						return
+					}
+				}
+				clr.Cleanup(ctx)
+			})
+
+			Context("Sidecar to Ambient Migration", Ordered, func() {
+				// Tests the complete migration workflow from sidecar to ambient mode.
+				// Migration is performed without active traffic, and connectivity is verified after completion.
+				// Validates: migration procedure correctness, coexistence mode (HBONE-aware sidecars),
+				// L4 connectivity via ztunnel, and L7 policy enforcement via waypoint.
+
+				When("workloads are deployed with sidecar injection", func() {
+					BeforeAll(func(ctx SpecContext) {
+						Expect(k.Label("namespace", workloadNamespace, "istio-injection", "enabled")).To(Succeed(), "Error labeling namespace for sidecar injection")
+						Expect(k.WithNamespace(workloadNamespace).ApplyKustomize("httpbin")).To(Succeed(), "Error deploying httpbin")
+						Expect(k.WithNamespace(workloadNamespace).ApplyKustomize("sleep")).To(Succeed(), "Error deploying sleep")
+						Success("Httpbin and sleep workloads deployed with sidecar injection enabled")
+					})
+
+					samplePods := &corev1.PodList{}
+					It("updates the pods status to Running", func(ctx SpecContext) {
+						Eventually(common.CheckPodsReady).WithArguments(ctx, cl, workloadNamespace).Should(Succeed(), "Error checking status of sample pods")
+						Expect(cl.List(ctx, samplePods, client.InNamespace(workloadNamespace))).To(Succeed(), "Error getting pods in workload namespace")
+						Success("Workload pods are ready")
+					})
+
+					It("has sidecars injected", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed(), "Error getting pods in workload namespace")
+						Expect(pods.Items).NotTo(BeEmpty(), "Expected at least one pod")
+
+						for _, pod := range pods.Items {
+							Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
+								"Pod %s should have istio-proxy in either containers or init containers", pod.Name)
+						}
+						Success("All pods have istio-proxy sidecar injected")
+					})
+
+					It("verifies L4 connectivity in sidecar mode", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						Expect(pods.Items).To(HaveLen(1))
+						sleepPod := pods.Items[0].Name
+
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/get", 5, "200")
+						}).Should(Succeed())
+						Success("L4 connectivity verified in sidecar mode")
+					})
+				})
+
+				When("L7 policies are deployed for sidecar mode", func() {
+					It("deploys VirtualService for httpbin", func(ctx SpecContext) {
+						// VirtualService configures L7 traffic routing for httpbin service:
+						// - Routes all requests matching prefix "/" to httpbin:8000
+						// - Sets request timeout to 10 seconds
+						// - Configures retry policy: up to 3 attempts with 2-second per-try timeout
+						// This validates that L7 routing works correctly in both sidecar and waypoint modes.
+						// Expected behavior:
+						//   - In sidecar mode: Envoy sidecar processes the VirtualService rules
+						//   - In waypoint mode: Waypoint gateway processes the VirtualService rules
+						virtualServiceYAML := fmt.Sprintf(`
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: httpbin
+  namespace: %s
+spec:
+  hosts:
+  - httpbin
+  http:
+  - match:
+    - uri:
+        prefix: "/"
+    route:
+    - destination:
+        host: httpbin
+        port:
+          number: 8000
+    timeout: 10s
+    retries:
+      attempts: 3
+      perTryTimeout: 2s`, workloadNamespace)
+
+						Expect(k.CreateFromString(virtualServiceYAML)).To(Succeed())
+						Success("VirtualService created for sidecar mode")
+					})
+
+					It("deploys AuthorizationPolicy for httpbin", func(ctx SpecContext) {
+						authzPolicyYAML := fmt.Sprintf(`
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-authz
+  namespace: %s
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: ["/deny"]`, workloadNamespace)
+
+						Expect(k.CreateFromString(authzPolicyYAML)).To(Succeed())
+						Success("AuthorizationPolicy created for sidecar mode")
+					})
+
+					It("verifies L7 traffic routing works in sidecar mode", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						sleepPod := pods.Items[0].Name
+
+						// Test that VirtualService routes traffic correctly
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/get", 5, "200")
+						}).Should(Succeed())
+						Success("VirtualService routing verified in sidecar mode")
+					})
+
+					It("verifies L7 AuthorizationPolicy is enforced in sidecar mode", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						sleepPod := pods.Items[0].Name
+
+						// Test allowed path
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/get", 5, "200")
+						}).Should(Succeed())
+
+						// Test denied path
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/deny", 5, "403")
+						}).Should(Succeed())
+
+						Success("AuthorizationPolicy enforcement verified in sidecar mode")
+					})
+				})
+
+				When("configures Istio and IstioCNI in ambient mode", func() {
+					It("updates Istio to ambient profile", func(ctx SpecContext) {
+						patch := fmt.Sprintf(`{"spec":{"profile":"ambient","values":{"pilot":{"trustedZtunnelNamespace":"%s"}}}}`, ztunnelNamespace)
+						Expect(k.Patch("istio", istioName, "merge", patch)).To(Succeed())
+						Success("Istio updated to ambient profile with trustedZtunnelNamespace")
+					})
+
+					It("waits for Istio to reconcile with ambient profile", func(ctx SpecContext) {
+						istio := &v1.Istio{}
+						Eventually(func(g Gomega) {
+							g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+							g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReconciled, metav1.ConditionTrue))
+							g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+						}).Should(Succeed())
+						Success("Istio reconciled with ambient profile")
+					})
+
+					It("updates IstioCNI to ambient profile", func(ctx SpecContext) {
+						patch := `{"spec":{"profile":"ambient"}}`
+						Expect(k.Patch("istiocni", istioCniName, "merge", patch)).To(Succeed())
+						Success("IstioCNI updated to ambient profile")
+					})
+
+					It("waits for IstioCNI to reconcile with ambient profile", func(ctx SpecContext) {
+						istioCNI := &v1.IstioCNI{}
+						Eventually(func(g Gomega) {
+							g.Expect(cl.Get(ctx, kube.Key(istioCniName), istioCNI)).To(Succeed())
+							g.Expect(istioCNI).To(HaveConditionStatus(v1.IstioCNIConditionReconciled, metav1.ConditionTrue))
+							g.Expect(istioCNI).To(HaveConditionStatus(v1.IstioCNIConditionReady, metav1.ConditionTrue))
+						}).Should(Succeed())
+						Success("IstioCNI reconciled with ambient profile")
+					})
+
+					It("creates ZTunnel CR", func(ctx SpecContext) {
+						common.CreateZTunnel(k, version.Name)
+						Success("ZTunnel CR created")
+					})
+
+					It("waits for ZTunnel to be Ready", func(ctx SpecContext) {
+						ztunnel := &v1.ZTunnel{}
+						Eventually(func(g Gomega) {
+							g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+							g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReconciled, metav1.ConditionTrue))
+							g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+						}).Should(Succeed())
+						Success("ZTunnel is Ready")
+					})
+
+					It("verifies ZTunnel DaemonSet is running", func(ctx SpecContext) {
+						Eventually(func(g Gomega) {
+							daemonset := &appsv1.DaemonSet{}
+							g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+							g.Expect(daemonset.Status.NumberAvailable).To(Equal(daemonset.Status.CurrentNumberScheduled))
+						}).Should(Succeed())
+						Success("ZTunnel DaemonSet is running")
+					})
+				})
+
+				When("workloads are restarted to get HBONE-aware sidecars", func() {
+					It("waits for sidecar injector webhook to be recreated", func(ctx SpecContext) {
+						// After switching to ambient profile, the webhook is recreated
+						// Wait for it to exist before restarting pods
+						Eventually(func(g Gomega) {
+							webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
+							g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed(), "Sidecar injector webhook should exist in coexistence mode")
+						}).Should(Succeed(), "Waiting for istio-sidecar-injector webhook to be recreated")
+						Success("Sidecar injector webhook is ready")
+					})
+
+					It("restarts deployments to get HBONE-aware sidecars", func(ctx SpecContext) {
+						// Restart pods with existing istio-injection=enabled label
+						// The ambient-configured webhook will inject HBONE-aware sidecars
+						_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
+						Expect(err).NotTo(HaveOccurred(), "Failed to restart deployment")
+						Success("Deployment restart initiated")
+
+						Eventually(func(g Gomega) {
+							_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
+							g.Expect(err).NotTo(HaveOccurred(), "Rollout status check failed")
+						}).Should(Succeed(), "Waiting for deployment rollout to complete")
+						Success("Deployment rollout completed")
+					})
+
+					It("waits for pods to be ready after restart", func(ctx SpecContext) {
+						Eventually(func(g Gomega) {
+							pods := &corev1.PodList{}
+							g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+							g.Expect(pods.Items).NotTo(BeEmpty())
+
+							for _, pod := range pods.Items {
+								g.Expect(pod.DeletionTimestamp).To(BeNil(), "Pod %s should not be terminating", pod.Name)
+							}
+
+							for _, pod := range pods.Items {
+								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "Pod %s should be running", pod.Name)
+
+								readyCount := 0
+								for _, condition := range pod.Status.Conditions {
+									if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+										readyCount++
+									}
+								}
+								g.Expect(readyCount).To(Equal(1), "Pod %s should have Ready condition", pod.Name)
+							}
+						}).Should(Succeed(), "Waiting for pods to be fully ready without any terminating")
+						Success("Pods are ready after restart")
+					})
+
+					It("verifies sidecars are present after switching to ambient profile", func(ctx SpecContext) {
+						// After switching to ambient profile and restarting pods, verify istio-proxy still exists
+						// Use the same check as the initial sidecar verification
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed(), "Error getting pods in workload namespace")
+						Expect(pods.Items).NotTo(BeEmpty(), "Expected at least one pod")
+
+						for _, pod := range pods.Items {
+							Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
+								"Pod %s should have istio-proxy in either containers or init containers", pod.Name)
+						}
+						Success("All pods still have istio-proxy after switching to ambient profile")
+					})
+
+					It("verifies HBONE capability is enabled in sidecars", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+						Expect(pods.Items).NotTo(BeEmpty())
+
+						pod := pods.Items[0]
+						Expect(common.HasSidecarInjected(pod)).To(BeTrue(), "istio-proxy container not found in pod %s", pod.Name)
+						Expect(common.HasHBONEEnabled(pod)).To(BeTrue(), "ISTIO_META_ENABLE_HBONE env var not set to 'true' in istio-proxy container")
+						Success("HBONE capability verified in sidecar (ISTIO_META_ENABLE_HBONE=true)")
+					})
+
+					It("verifies L4 connectivity works with HBONE-aware sidecars", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						Expect(pods.Items).To(HaveLen(1))
+						sleepPod := pods.Items[0].Name
+
+						Eventually(func() error {
+							targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", targetURL, 5, "200")
+						}).Should(Succeed())
+						Success("L4 connectivity verified with HBONE-aware sidecars in coexistence mode")
+					})
+				})
+
+				When("namespace is switched to ambient mode", func() {
+					It("removes sidecar injection label and adds ambient label", func(ctx SpecContext) {
+						// Remove istio-injection label and add ambient dataplane mode
+						ns := &corev1.Namespace{}
+						Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
+						delete(ns.Labels, "istio-injection")
+						ns.Labels["istio.io/dataplane-mode"] = "ambient"
+						Expect(cl.Update(ctx, ns)).To(Succeed())
+						Success(fmt.Sprintf("Namespace %s switched to ambient mode", workloadNamespace))
+					})
+
+					It("restarts httpbin pods to remove sidecars", func(ctx SpecContext) {
+						_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
+						Expect(err).NotTo(HaveOccurred(), "Failed to restart deployment")
+						Success("Deployment restart initiated")
+
+						Eventually(func(g Gomega) {
+							_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
+							g.Expect(err).NotTo(HaveOccurred(), "Rollout status check failed")
+						}).Should(Succeed(), "Waiting for deployment rollout to complete")
+						Success("Deployment rollout completed")
+					})
+
+					It("restarts sleep deployment to remove sidecars", func(ctx SpecContext) {
+						_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/sleep")
+						Expect(err).NotTo(HaveOccurred(), "Failed to restart sleep deployment")
+
+						Eventually(func(g Gomega) {
+							_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/sleep")
+							g.Expect(err).NotTo(HaveOccurred(), "Rollout status check failed")
+						}).Should(Succeed(), "Waiting for sleep deployment rollout to complete")
+						Success("Sleep deployment rollout completed")
+					})
+
+					It("waits for pods to be ready in ambient mode without sidecar", func(ctx SpecContext) {
+						Eventually(func(g Gomega) {
+							pods := &corev1.PodList{}
+							g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+
+							// Filter out waypoint pods
+							workloadPods := []corev1.Pod{}
+							for _, pod := range pods.Items {
+								if pod.DeletionTimestamp == nil {
+									isWaypoint := false
+									for key := range pod.Labels {
+										if key == "gateway.istio.io/managed" || key == "gateway.networking.k8s.io/gateway-name" {
+											isWaypoint = true
+											break
+										}
+									}
+									if !isWaypoint {
+										workloadPods = append(workloadPods, pod)
+									}
+								}
+							}
+
+							g.Expect(workloadPods).NotTo(BeEmpty(), "Expected at least one workload pod")
+
+							for _, pod := range workloadPods {
+								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "Pod %s should be running", pod.Name)
+								g.Expect(pod.Spec.Containers).To(HaveLen(1), "Pod %s should have 1 container (no sidecar in ambient mode)", pod.Name)
+								g.Expect(pod.Annotations).To(HaveKey("ambient.istio.io/redirection"), "Ambient redirection annotation should be present")
+							}
+						}).Should(Succeed())
+						Success("Pods running in ambient mode without sidecars")
+					})
+
+					It("verifies workloads are registered with ztunnel", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+						Expect(pods.Items).NotTo(BeEmpty())
+
+						// Verify pods are detected by ztunnel
+						Eventually(func(g Gomega) {
+							for _, pod := range pods.Items {
+								// Check pod annotations indicate ambient mode
+								g.Expect(pod.Annotations).To(HaveKey("ambient.istio.io/redirection"))
+							}
+						}).Should(Succeed())
+						Success("Workloads registered with ztunnel")
+					})
+
+					It("verifies L4 connectivity in ambient mode", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						Expect(pods.Items).To(HaveLen(1))
+
+						clientPod := pods.Items[0].Name
+						Eventually(func() error {
+							// Test connectivity to httpbin service (should go through ztunnel)
+							targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+							return common.CheckHTTPConnectivity(k, workloadNamespace, clientPod, "sleep", targetURL, 5, "200")
+						}).Should(Succeed())
+						Success("L4 connectivity verified in ambient mode via ztunnel")
+					})
+				})
+
+				When("waypoint is deployed for L7 processing", func() {
+					It("deploys waypoint Gateway", func(ctx SpecContext) {
+						waypointYAML := fmt.Sprintf(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  namespace: %s
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE`, workloadNamespace)
+
+						Expect(k.CreateFromString(waypointYAML)).To(Succeed())
+						Success("Waypoint Gateway created")
+					})
+
+					It("waits for waypoint deployment to be ready", func(ctx SpecContext) {
+						Eventually(func(g Gomega) {
+							deployment := &appsv1.Deployment{}
+							g.Expect(cl.Get(ctx, kube.Key("waypoint", workloadNamespace), deployment)).To(Succeed())
+							g.Expect(deployment.Status.ReadyReplicas).To(BeNumerically(">", 0))
+						}).Should(Succeed())
+						Success("Waypoint deployment is ready")
+					})
+
+					It("updates AuthorizationPolicy to target waypoint", func(ctx SpecContext) {
+						// Delete the old sidecar-mode AuthorizationPolicy
+						Expect(k.WithNamespace(workloadNamespace).Delete("authorizationpolicy", "httpbin-authz")).To(Succeed())
+
+						// Create new AuthorizationPolicy targeting waypoint
+						authzPolicyYAML := fmt.Sprintf(`
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-authz
+  namespace: %s
+spec:
+  targetRefs:
+  - kind: Gateway
+    group: gateway.networking.k8s.io
+    name: waypoint
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: ["/deny"]`, workloadNamespace)
+
+						Expect(k.CreateFromString(authzPolicyYAML)).To(Succeed())
+						Success("AuthorizationPolicy updated to target waypoint")
+					})
+
+					It("verifies waypoint is not yet processing traffic (dormant)", func(ctx SpecContext) {
+						ns := &corev1.Namespace{}
+						Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
+						Expect(ns.Labels).NotTo(HaveKey("istio.io/use-waypoint"))
+						Success("Waypoint is dormant (not activated yet)")
+					})
+				})
+
+				When("waypoint is activated for L7 processing", func() {
+					It("labels namespace to activate waypoint", func(ctx SpecContext) {
+						Expect(k.Label("namespace", workloadNamespace, "istio.io/use-waypoint", "waypoint")).To(Succeed())
+						Success("Waypoint activated")
+					})
+
+					It("verifies VirtualService routing works via waypoint", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						sleepPod := pods.Items[0].Name
+
+						// VirtualService should continue to work (routes traffic through waypoint now)
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/get", 5, "200")
+						}).Should(Succeed())
+						Success("VirtualService routing verified via waypoint")
+					})
+
+					It("verifies L7 AuthorizationPolicy is enforced via waypoint", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						sleepPod := pods.Items[0].Name
+
+						// Test allowed path
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/get", 5, "200")
+						}).Should(Succeed())
+
+						// Test denied path (L7 policy enforcement)
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/deny", 5, "403")
+						}).Should(Succeed())
+
+						Success("L7 AuthorizationPolicy successfully enforced via waypoint")
+					})
+				})
+			})
+		})
+	})

--- a/tests/e2e/migration/migration_suite_test.go
+++ b/tests/e2e/migration/migration_suite_test.go
@@ -1,0 +1,79 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
+	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	cl                    client.Client
+	err                   error
+	controlPlaneNamespace = common.ControlPlaneNamespace
+	istioName             = env.Get("ISTIO_NAME", "default")
+	istioCniNamespace     = common.IstioCniNamespace
+	ztunnelNamespace      = common.ZtunnelNamespace
+	istioCniName          = env.Get("ISTIOCNI_NAME", "default")
+	multicluster          = env.GetBool("MULTICLUSTER", false)
+	keepOnFailure         = env.GetBool("KEEP_ON_FAILURE", false)
+	defaultTimeout        = env.GetInt("DEFAULT_TEST_TIMEOUT", 180)
+
+	k kubectl.Kubectl
+)
+
+func TestMigration(t *testing.T) {
+	if multicluster {
+		t.Skip("Skipping the Migration tests in multicluster environment")
+	}
+
+	RegisterFailHandler(Fail)
+	setup()
+	RunSpecs(t, "Migration Test Suite")
+}
+
+func setup() {
+	GinkgoWriter.Println("************ Running Setup ************")
+
+	GinkgoWriter.Println("Initializing k8s client")
+	cl, err = k8sclient.InitK8sClient("")
+	Expect(err).NotTo(HaveOccurred())
+
+	k = kubectl.New()
+
+	// Install Gateway API CRDs if not already present (needed for waypoint)
+	ctx := context.Background()
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	err = cl.Get(ctx, client.ObjectKey{Name: "gateways.gateway.networking.k8s.io"}, crd)
+	if err != nil {
+		GinkgoWriter.Println("Gateway API CRDs not found, installing from upstream")
+		Expect(k.Apply("https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml")).
+			To(Succeed(), "Failed to install Gateway API CRDs")
+		GinkgoWriter.Println("Gateway API CRDs installed (standard channel v1.2.0)")
+	} else {
+		GinkgoWriter.Println("Gateway API CRDs already present in cluster")
+	}
+}

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -503,12 +503,11 @@ spec:
 
 func CreateZTunnel(k kubectl.Kubectl, version string, specs ...string) {
 	yaml := `
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: ZTunnel
 metadata:
   name: default
 spec:
-  profile: ambient
   version: %s
   namespace: %s`
 	yaml = fmt.Sprintf(yaml, version, ZtunnelNamespace)
@@ -640,4 +639,47 @@ func GetProxyVersion(podName, namespace string) (*semver.Version, error) {
 		return version, fmt.Errorf("error parsing proxy version %q: %w", versionStr, err)
 	}
 	return version, err
+}
+
+// GetIstioProxyContainer finds and returns the istio-proxy container from a pod
+// It checks both regular containers and init containers (for persistent init containers in K8s 1.28+)
+// Returns the container if found, nil otherwise
+func GetIstioProxyContainer(pod corev1.Pod) *corev1.Container {
+	// Check regular containers
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == "istio-proxy" {
+			return &pod.Spec.Containers[i]
+		}
+	}
+
+	// Check init containers
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == "istio-proxy" {
+			return &pod.Spec.InitContainers[i]
+		}
+	}
+
+	return nil
+}
+
+// HasSidecarInjected checks if a pod has the istio-proxy sidecar injected
+func HasSidecarInjected(pod corev1.Pod) bool {
+	return GetIstioProxyContainer(pod) != nil
+}
+
+// HasHBONEEnabled checks if the istio-proxy sidecar has HBONE capability enabled
+// by verifying the ISTIO_META_ENABLE_HBONE environment variable is set to "true"
+func HasHBONEEnabled(pod corev1.Pod) bool {
+	container := GetIstioProxyContainer(pod)
+	if container == nil {
+		return false
+	}
+
+	for _, env := range container.Env {
+		if env.Name == "ISTIO_META_ENABLE_HBONE" && env.Value == "true" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/tests/e2e/util/common/http_traffic.go
+++ b/tests/e2e/util/common/http_traffic.go
@@ -1,0 +1,159 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// CheckHTTPConnectivity performs an HTTP GET request from a source pod to a target URL
+// and verifies that the response matches the expected HTTP status code.
+// The targetURL can be a short name (e.g., "httpbin:8000/get") or a fully qualified URL.
+// The expectedStatus should be the expected HTTP status code (e.g., "200", "403", "503").
+// Returns nil if the check succeeds, or an error describing what failed.
+// Designed for use with Eventually: Eventually(func() error { return CheckHTTPConnectivity(...) }).Should(Succeed())
+func CheckHTTPConnectivity(
+	k kubectl.Kubectl,
+	namespace string,
+	podName string,
+	containerName string,
+	targetURL string,
+	timeoutSeconds int,
+	expectedStatus string,
+) error {
+	cmd := fmt.Sprintf("curl -s -o /dev/null -w '%%{http_code}' %s --max-time %d", targetURL, timeoutSeconds)
+	status, err := k.WithNamespace(namespace).Exec(podName, containerName, cmd)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	if status != expectedStatus {
+		return fmt.Errorf("expected HTTP status %s, got %s", expectedStatus, status)
+	}
+	return nil
+}
+
+// HTTPTrafficStats tracks continuous HTTP traffic statistics with thread-safe counters
+type HTTPTrafficStats struct {
+	totalRequests   atomic.Int64
+	failedRequests  atomic.Int64
+	successRequests atomic.Int64
+	mu              sync.Mutex
+	errors          []string
+}
+
+// RecordSuccess increments the success counter
+func (ts *HTTPTrafficStats) RecordSuccess() {
+	ts.totalRequests.Add(1)
+	ts.successRequests.Add(1)
+}
+
+// RecordFailure increments the failure counter and stores the error message
+func (ts *HTTPTrafficStats) RecordFailure(errMsg string) {
+	ts.totalRequests.Add(1)
+	ts.failedRequests.Add(1)
+	ts.mu.Lock()
+	ts.errors = append(ts.errors, errMsg)
+	ts.mu.Unlock()
+}
+
+// GetStats returns the current statistics (total, success, failed, errors)
+func (ts *HTTPTrafficStats) GetStats() (total, success, failed int64, errors []string) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.totalRequests.Load(), ts.successRequests.Load(), ts.failedRequests.Load(), append([]string{}, ts.errors...)
+}
+
+// StartContinuousHTTPTraffic starts sending continuous HTTP GET requests in the background.
+// If existingStats is nil, creates a new stats object. Otherwise reuses the existing one.
+// Returns the stats tracker and a cancel function to stop the traffic.
+// The kubectl instance k must be accessible (typically via closure in test context).
+func StartContinuousHTTPTraffic(
+	ctx context.Context,
+	k kubectl.Kubectl,
+	namespace string,
+	clientPod string,
+	containerName string,
+	targetURL string,
+	interval time.Duration,
+	existingStats *HTTPTrafficStats,
+) (*HTTPTrafficStats, context.CancelFunc) {
+	stats := existingStats
+	if stats == nil {
+		stats = &HTTPTrafficStats{}
+	}
+
+	trafficCtx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Log(fmt.Sprintf("[Traffic] Starting continuous traffic from %s to %s (interval: %v)", clientPod, targetURL, interval))
+
+		// sendRequest spawns a goroutine to send a request without blocking the ticker
+		sendRequest := func() {
+			go func() {
+				defer GinkgoRecover()
+				defer func() {
+					if r := recover(); r != nil {
+						errMsg := fmt.Sprintf("panic in sendRequest: %v", r)
+						stats.RecordFailure(errMsg)
+						Log(fmt.Sprintf("[Traffic] %s", errMsg))
+					}
+				}()
+
+				cmd := fmt.Sprintf("curl -s -o /dev/null -w '%%{http_code}' %s --max-time 2", targetURL)
+				output, err := k.WithNamespace(namespace).Exec(clientPod, containerName, cmd)
+				if err != nil {
+					errMsg := fmt.Sprintf("request failed: %v", err)
+					stats.RecordFailure(errMsg)
+					Log(fmt.Sprintf("[Traffic] %s", errMsg))
+				} else if output != "200" {
+					errMsg := fmt.Sprintf("unexpected status code: %s", output)
+					stats.RecordFailure(errMsg)
+					Log(fmt.Sprintf("[Traffic] %s", errMsg))
+				} else {
+					stats.RecordSuccess()
+				}
+			}()
+		}
+
+		// Send first request immediately
+		sendRequest()
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-trafficCtx.Done():
+				Log("[Traffic] Stopping continuous traffic (context cancelled)")
+				return
+			case <-ticker.C:
+				sendRequest()
+			}
+		}
+	}()
+
+	return stats, cancel
+}

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -343,6 +343,26 @@ func (k Kubectl) LabelNamespaced(kind, namespace, name, labelKey, labelValue str
 	return err
 }
 
+// RolloutRestart restarts a deployment using kubectl rollout restart
+func (k Kubectl) RolloutRestart(resource string) (string, error) {
+	cmd := k.build(fmt.Sprintf(" rollout restart %s", resource))
+	output, err := k.executeCommand(cmd)
+	if err != nil {
+		return "", fmt.Errorf("error restarting rollout: %w, output: %s", err, output)
+	}
+	return output, nil
+}
+
+// RolloutStatus waits for a rollout to complete
+func (k Kubectl) RolloutStatus(resource string) (string, error) {
+	cmd := k.build(fmt.Sprintf(" rollout status %s", resource))
+	output, err := k.executeCommand(cmd)
+	if err != nil {
+		return "", fmt.Errorf("error checking rollout status: %w, output: %s", err, output)
+	}
+	return output, nil
+}
+
 // executeCommand handles running the command and then resets the namespace automatically
 func (k Kubectl) executeCommand(cmd string) (string, error) {
 	return shell.ExecuteCommand(cmd)


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Add the following migration test scenarios from sidecar to ambient mode:
- Tests the complete migration workflow from sidecar to ambient mode.
  - Validates L4 connectivity via ztunnel and L7 policy enforcement
    via waypoint in a single namespace.
  - Migration flow:
    sidecar → HBONE coexistence → pure ambient → waypoint activation

- Tests migration resilience from sidecar to ambient mode with
  continuous traffic.
  - Uses a stable external client (sidecar mode, never migrates)
    to send continuous traffic to a server that migrates from
    sidecar → ambient while traffic flows.
  - Validates:
    - Limited disruption during pod restart
      (≤10 503 errors - brief, acceptable)
    - Traffic RECOVERS after disruption
      (≥9/10 consecutive successes post-migration)
    - Cross-mode communication works
      (sidecar client → ambient server)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
