### PR TITLE
Fix nil pointer panic in TLS adherence e2e test when Values.Pilot is uninitialized

### DIFF
--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -375,7 +375,11 @@ spec:
 				g.Expect(ciphers).To(BeEmpty(), "IstioRevision should not have cipher suites")
 
 				// assert that pilot.extraContainerArgs does not contain --tls-cipher-suites
-				g.Expect(rev.Spec.Values.Pilot.ExtraContainerArgs).To(Not(ContainElement(ContainSubstring("--tls-cipher-suites="))))
+				var pilotExtraArgs []string
+				if rev.Spec.Values != nil && rev.Spec.Values.Pilot != nil {
+					pilotExtraArgs = rev.Spec.Values.Pilot.ExtraContainerArgs
+				}
+				g.Expect(pilotExtraArgs).To(Not(ContainElement(ContainSubstring("--tls-cipher-suites="))))
 			}).Should(Succeed(), "IstioRevision is syncing TLS settings but should NOT be")
 
 			ensureTLSAdherence(ctx, cl, configv1.TLSAdherencePolicyStrictAllComponents)


### PR DESCRIPTION
Fix nil pointer panic in TLS adherence test when `Values.Pilot` is uninitialized; it's exactly failing when we try to get the extra arguments to validate that does not contains `--tls-cipher-suites=`, so if the arguments are not defined the test is succesfull also. This test only affects when the test run on OCP version > 4.21