### PR TITLE
Fix gateway class ConfigMap test to work with both Helm v4.1.4 and v4…

### DIFF
--- a/tests/integration/api/istiorevision_test.go
+++ b/tests/integration/api/istiorevision_test.go
@@ -19,6 +19,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
@@ -1017,9 +1018,8 @@ var _ = Describe("IstioRevision resource", Label("istiorevision"), Ordered, func
 			cm := &corev1.ConfigMap{}
 			Eventually(k8sClient.Get).WithArguments(ctx, cmKey, cm).Should(Succeed())
 			Expect(cm.Labels).To(HaveKeyWithValue("gateway.istio.io/defaults-for-class", "istio"))
-			Expect(cm.Data).To(HaveKeyWithValue("service", `spec:
-  type: ClusterIP
-`))
+			// Trim to handle Helm v4.1.4 (with trailing newline) vs v4.2.0 (without)
+			Expect(strings.TrimRight(cm.Data["service"], "\n")).To(Equal("spec:\n  type: ClusterIP"))
 		})
 	})
 })

--- a/tests/integration/api/istiorevision_test.go
+++ b/tests/integration/api/istiorevision_test.go
@@ -1018,8 +1018,9 @@ var _ = Describe("IstioRevision resource", Label("istiorevision"), Ordered, func
 			cm := &corev1.ConfigMap{}
 			Eventually(k8sClient.Get).WithArguments(ctx, cmKey, cm).Should(Succeed())
 			Expect(cm.Labels).To(HaveKeyWithValue("gateway.istio.io/defaults-for-class", "istio"))
-			// Trim to handle Helm v4.1.4 (with trailing newline) vs v4.2.0 (without)
-			Expect(strings.TrimRight(cm.Data["service"], "\n")).To(Equal("spec:\n  type: ClusterIP"))
+			// TrimSuffix allows Helm v4.1.4 (single trailing newline) and v4.2.0 (none)
+			Expect(cm.Data).To(HaveKey("service"))
+			Expect(strings.TrimSuffix(cm.Data["service"], "\n")).To(Equal("spec:\n  type: ClusterIP"))
 		})
 	})
 })


### PR DESCRIPTION
….2.0

The test was expecting a specific format for the ConfigMap data, but Helm v4.1.4 and v4.2.0 produce different output due to whitespace handling changes in v4.2.0.

- Helm v4.1.4 (main branch): produces trailing newline
- Helm v4.2.0 (dependency update): does not produce trailing newline

The fix trims trailing newlines before comparison to work with both versions.

 