### PR TITLE
Fix race condition in `ToDiscoveryClient`

### DIFF
--- a/pkg/helm/restclientgetter.go
+++ b/pkg/helm/restclientgetter.go
@@ -43,13 +43,13 @@ func (c *restClientGetter) ToRESTConfig() (*rest.Config, error) {
 
 func (c *restClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
 	if c.discoveryClient == nil {
-		oldBurst := c.config.Burst
+		// Copy the config to avoid mutating the original config.
+		// Otherwise calling ToDiscoveryClient can cause a race condition.
+		cfg := rest.CopyConfig(c.config)
 		// use the default (high) burst for discovery
-		c.config.Burst = 0
-		// write back the old burst value after it has been copied for discovery client creation
-		defer func() { c.config.Burst = oldBurst }()
+		cfg.Burst = 0
 
-		discoveryClient, err := discovery.NewDiscoveryClientForConfig(c.config)
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION


 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Calling this method concurrently can lead to a race condition. Copying the config for the discovery client eliminates this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:

[Example of race condition failure](https://prow.istio.io/view/s3/istio-prow/pr-logs/pull/istio-ecosystem_sail-operator/2002/integ-tests-arm64_sail-operator_main/2064374352635236352#1:build-log.txt%3A1997)
