### PR TITLE
Sail library crds fixes

### DIFF
--- a/pkg/install/README.md
+++ b/pkg/install/README.md
@@ -81,8 +81,10 @@ The library delegates heavily to existing Sail Operator infrastructure:
 ## CRD management
 
 The Library manages Istio CRDs when `ManageCRDs` is true (the default in PR #721; explicit on this branch).
-CRDs are loaded from the embedded `chart/crds/` filesystem, rendered via the base Helm chart,
-and filtered by `PILOT_INCLUDE_RESOURCES` / `PILOT_IGNORE_RESOURCES` when `IncludeAllCRDs` is false.
+CRDs are loaded from the embedded `chart/crds/` filesystem, but only `*.istio.io` API groups are
+managed. `sailoperator.io` CRDs are excluded — they are installed separately by the Sail Operator
+Helm chart. When `IncludeAllCRDs` is false, `PILOT_INCLUDE_RESOURCES` further narrows which
+Istio CRDs are installed.
 
 When an existing CRD has OLM labels (`olm.managed`), it is left alone unless `OverwriteOLMManagedCRD`
 is set to true.

--- a/pkg/install/README.md
+++ b/pkg/install/README.md
@@ -7,7 +7,9 @@ to install and maintain Istio as an internal dependency.
 ## Usage
 
 ```go
-lib, err := install.New(kubeConfig, resourceFS, crdFS)  // defaults: QPS=50, Burst=100
+lib, err := install.New(kubeConfig, resourceFS, crdFS,
+    install.WithCRDOwnershipLabel("ingress.operator.openshift.io/owned", "true"), // optional
+)
 notifyCh, err := lib.Start(ctx)
 
 // In controller reconcile:
@@ -47,7 +49,7 @@ The library delegates heavily to existing Sail Operator infrastructure:
 
 ### Constructor
 
-- `New(kubeConfig, resourceFS, crdFS, opts...)` -- creates a Library with Kubernetes clients, Helm chart manager, and CRD manager (defaults: QPS=50, Burst=100; override with `WithQPS()` / `WithBurst()`)
+- `New(kubeConfig, resourceFS, crdFS, opts...)` -- creates a Library with Kubernetes clients, Helm chart manager, and CRD manager (defaults: QPS=50, Burst=100; override with `WithQPS()` / `WithBurst()` / `WithCRDOwnershipLabel()`)
 - `FromDirectory(path)` -- creates an `fs.FS` from a filesystem path (alternative to embedded resources)
 
 ### Library methods
@@ -84,6 +86,13 @@ and filtered by `PILOT_INCLUDE_RESOURCES` / `PILOT_IGNORE_RESOURCES` when `Inclu
 
 When an existing CRD has OLM labels (`olm.managed`), it is left alone unless `OverwriteOLMManagedCRD`
 is set to true.
+
+CRD ownership is determined by a configurable label (default: `app.kubernetes.io/managed-by=sail-library`).
+Use `WithCRDOwnershipLabel(key, value)` at library construction time to match labels already present
+on cluster CRDs. For example, OpenShift Ingress can pass
+`WithCRDOwnershipLabel("ingress.operator.openshift.io/owned", "true")` to continue managing CRDs
+installed by a previous version. The embedder must configure the label to match existing CRDs;
+the library does not migrate ownership labels automatically.
 
 ## Design: delegation over reimplementation
 

--- a/pkg/install/crds.go
+++ b/pkg/install/crds.go
@@ -163,6 +163,9 @@ func (m *crdManager) loadCRDs(opts Options) ([]*apiextensionsv1.CustomResourceDe
 			if crd.Kind != "CustomResourceDefinition" {
 				continue
 			}
+			if !istioCRD(&crd) {
+				continue
+			}
 			if opts.IncludeAllCRDs || matchesCRDFilter(&crd, targetKinds) {
 				crds = append(crds, &crd)
 			}
@@ -191,6 +194,10 @@ func AggregateState(infos []CRDInfo) (CRDManagementState, string) {
 		return CRDManagementStateReady, ""
 	}
 	return CRDManagementStateNotReady, "not all CRDs are ready"
+}
+
+func istioCRD(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	return strings.HasSuffix(crd.Spec.Group, ".istio.io")
 }
 
 func matchesCRDFilter(crd *apiextensionsv1.CustomResourceDefinition, targetKinds map[string]bool) bool {

--- a/pkg/install/crds.go
+++ b/pkg/install/crds.go
@@ -30,8 +30,7 @@ import (
 )
 
 const (
-	kubeManagedByLabel = "app.kubernetes.io/managed-by"
-	OLMManagedLabel    = "olm.managed"
+	OLMManagedLabel = "olm.managed"
 )
 
 type crdOwnership int
@@ -43,8 +42,10 @@ const (
 )
 
 type crdManager struct {
-	cl    client.Client
-	crdFS fs.FS
+	cl                  client.Client
+	crdFS               fs.FS
+	ownershipLabelKey   string
+	ownershipLabelValue string
 }
 
 // Reconcile installs or updates CRDs based on the provided options.
@@ -76,7 +77,7 @@ func (m *crdManager) applyCRD(ctx context.Context, crd *apiextensionsv1.CustomRe
 	existing := &apiextensionsv1.CustomResourceDefinition{}
 	err := m.cl.Get(ctx, types.NamespacedName{Name: name}, existing)
 	if apierrors.IsNotFound(err) {
-		setManagedByLabel(crd)
+		m.setManagedByLabel(crd)
 		if err := m.cl.Create(ctx, crd); err != nil {
 			return info, fmt.Errorf("failed to create CRD %s: %w", name, err)
 		}
@@ -100,7 +101,7 @@ func (m *crdManager) applyCRD(ctx context.Context, crd *apiextensionsv1.CustomRe
 	}
 
 	crd.SetResourceVersion(existing.ResourceVersion)
-	setManagedByLabel(crd)
+	m.setManagedByLabel(crd)
 	if err := m.cl.Update(ctx, crd); err != nil {
 		return info, fmt.Errorf("failed to update CRD %s: %w", name, err)
 	}
@@ -108,12 +109,12 @@ func (m *crdManager) applyCRD(ctx context.Context, crd *apiextensionsv1.CustomRe
 	return info, nil
 }
 
-func setManagedByLabel(crd *apiextensionsv1.CustomResourceDefinition) {
+func (m *crdManager) setManagedByLabel(crd *apiextensionsv1.CustomResourceDefinition) {
 	labels := crd.GetLabels()
 	if labels == nil {
 		labels = map[string]string{}
 	}
-	labels[kubeManagedByLabel] = managedByValue
+	labels[m.ownershipLabelKey] = m.ownershipLabelValue
 	crd.SetLabels(labels)
 }
 
@@ -121,7 +122,7 @@ func (m *crdManager) classifyCRD(crd *apiextensionsv1.CustomResourceDefinition) 
 	if _, ok := crd.Labels[OLMManagedLabel]; ok {
 		return crdManagedByOLM
 	}
-	if crd.Labels != nil && crd.Labels[kubeManagedByLabel] == managedByValue {
+	if crd.Labels != nil && crd.Labels[m.ownershipLabelKey] == m.ownershipLabelValue {
 		return crdManagedByLibrary
 	}
 	return crdUnmanaged

--- a/pkg/install/crds_test.go
+++ b/pkg/install/crds_test.go
@@ -28,6 +28,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func defaultCRDManager() *crdManager {
+	return &crdManager{
+		ownershipLabelKey:   defaultCRDOwnershipLabelKey,
+		ownershipLabelValue: defaultCRDOwnershipLabelValue,
+	}
+}
+
 func TestAggregateState(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -72,7 +79,7 @@ func TestAggregateState(t *testing.T) {
 }
 
 func TestClassifyCRD(t *testing.T) {
-	m := &crdManager{}
+	m := defaultCRDManager()
 
 	tests := []struct {
 		name   string
@@ -92,7 +99,7 @@ func TestClassifyCRD(t *testing.T) {
 			name: "library managed",
 			crd: &apiextensionsv1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app.kubernetes.io/managed-by": managedByValue},
+					Labels: map[string]string{defaultCRDOwnershipLabelKey: defaultCRDOwnershipLabelValue},
 				},
 			},
 			expect: crdManagedByLibrary,
@@ -119,6 +126,32 @@ func TestClassifyCRD(t *testing.T) {
 			g.Expect(m.classifyCRD(tc.crd)).To(Equal(tc.expect))
 		})
 	}
+}
+
+func TestClassifyCRDCustomOwnershipLabel(t *testing.T) {
+	const (
+		customKey   = "ingress.operator.openshift.io/owned"
+		customValue = "true"
+	)
+	m := &crdManager{
+		ownershipLabelKey:   customKey,
+		ownershipLabelValue: customValue,
+	}
+
+	g := NewWithT(t)
+	owned := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{customKey: customValue},
+		},
+	}
+	g.Expect(m.classifyCRD(owned)).To(Equal(crdManagedByLibrary))
+
+	wrongValue := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{customKey: "false"},
+		},
+	}
+	g.Expect(m.classifyCRD(wrongValue)).To(Equal(crdUnmanaged))
 }
 
 func TestIsCRDReady(t *testing.T) {
@@ -342,8 +375,10 @@ func TestUnmanagedCRDNotTakenOver(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(existingVS, existingGW).Build()
 
 	m := &crdManager{
-		cl:    cl,
-		crdFS: chart.CRDsFS,
+		cl:                  cl,
+		crdFS:               chart.CRDsFS,
+		ownershipLabelKey:   defaultCRDOwnershipLabelKey,
+		ownershipLabelValue: defaultCRDOwnershipLabelValue,
 	}
 
 	ctx := t.Context()
@@ -355,13 +390,71 @@ func TestUnmanagedCRDNotTakenOver(t *testing.T) {
 		g.Expect(cl.Get(ctx, types.NamespacedName{Name: info.Name}, &updated)).To(Succeed())
 		if info.Name == "virtualservices.networking.istio.io" || info.Name == "gateways.networking.istio.io" {
 			g.Expect(info.Managed).To(BeFalse(), "unmanaged CRD %s should not be taken over", info.Name)
-			g.Expect(updated.Labels).NotTo(HaveKey(kubeManagedByLabel), "managed-by label should not be added to unmanaged CRD")
+			g.Expect(updated.Labels).NotTo(HaveKey(defaultCRDOwnershipLabelKey), "managed-by label should not be added to unmanaged CRD")
 			g.Expect(updated.Labels).To(Equal(existingGW.Labels), "existing labels should not be modified")
 			g.Expect(updated.Annotations).To(Equal(existingGW.Annotations), "existing annotations should not be modified")
 		} else {
 			g.Expect(info.Managed).To(BeTrue(), "CRD %s should be managed by the library", info.Name)
-			g.Expect(updated.Labels).To(HaveKey(kubeManagedByLabel))
-			g.Expect(updated.Labels[kubeManagedByLabel]).To(Equal(managedByValue))
+			g.Expect(updated.Labels).To(HaveKey(defaultCRDOwnershipLabelKey))
+			g.Expect(updated.Labels[defaultCRDOwnershipLabelKey]).To(Equal(defaultCRDOwnershipLabelValue))
+		}
+	}
+}
+
+func TestCRDOwnershipLabelCustom(t *testing.T) {
+	const (
+		customKey   = "ingress.operator.openshift.io/owned"
+		customValue = "true"
+	)
+
+	g := NewWithT(t)
+
+	existingOwned := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "virtualservices.networking.istio.io",
+			Labels: map[string]string{customKey: customValue},
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+				{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue},
+			},
+		},
+	}
+	existingUnmanaged := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "gateways.networking.istio.io",
+			Labels: map[string]string{"some-label": "some-value"},
+		},
+	}
+
+	s := runtime.NewScheme()
+	g.Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(existingOwned, existingUnmanaged).Build()
+
+	m := &crdManager{
+		cl:                  cl,
+		crdFS:               chart.CRDsFS,
+		ownershipLabelKey:   customKey,
+		ownershipLabelValue: customValue,
+	}
+
+	ctx := t.Context()
+	infos, err := m.Reconcile(ctx, Options{ManageCRDs: true, IncludeAllCRDs: true})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	for _, info := range infos {
+		var updated apiextensionsv1.CustomResourceDefinition
+		g.Expect(cl.Get(ctx, types.NamespacedName{Name: info.Name}, &updated)).To(Succeed())
+		switch info.Name {
+		case "gateways.networking.istio.io":
+			g.Expect(info.Managed).To(BeFalse())
+			g.Expect(updated.Labels).NotTo(HaveKey(customKey))
+		case "virtualservices.networking.istio.io":
+			g.Expect(info.Managed).To(BeTrue())
+			g.Expect(updated.Labels[customKey]).To(Equal(customValue))
+		default:
+			g.Expect(info.Managed).To(BeTrue(), "CRD %s should be managed", info.Name)
+			g.Expect(updated.Labels[customKey]).To(Equal(customValue))
 		}
 	}
 }

--- a/pkg/install/crds_test.go
+++ b/pkg/install/crds_test.go
@@ -224,6 +224,54 @@ metadata:
   name: istio
 `
 
+const testManifestsWithSailOperator = testManifests + `
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: istios.sailoperator.io
+spec:
+  group: sailoperator.io
+  names:
+    kind: Istio
+`
+
+func TestIstioCRD(t *testing.T) {
+	tests := []struct {
+		name   string
+		group  string
+		expect bool
+	}{
+		{name: "networking.istio.io", group: "networking.istio.io", expect: true},
+		{name: "extensions.istio.io", group: "extensions.istio.io", expect: true},
+		{name: "sailoperator.io", group: "sailoperator.io", expect: false},
+		{name: "empty group", group: "", expect: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{Group: tc.group},
+			}
+			g.Expect(istioCRD(crd)).To(Equal(tc.expect))
+		})
+	}
+}
+
+func TestLoadCRDs_excludesSailOperatorCRDs(t *testing.T) {
+	g := NewWithT(t)
+	m := &crdManager{crdFS: fstest.MapFS{
+		"crds.yaml": &fstest.MapFile{Data: []byte(testManifestsWithSailOperator)},
+	}}
+	crds, err := m.loadCRDs(Options{ManageCRDs: true, IncludeAllCRDs: true})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(crds).To(HaveLen(2))
+	for _, crd := range crds {
+		g.Expect(crd.Name).NotTo(HaveSuffix(".sailoperator.io"))
+	}
+}
+
 func TestLoadCRDs_filterByPilotInclude(t *testing.T) {
 	g := NewWithT(t)
 	vals := &v1.Values{
@@ -386,6 +434,10 @@ func TestUnmanagedCRDNotTakenOver(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	for _, info := range infos {
+		g.Expect(info.Name).NotTo(HaveSuffix(".sailoperator.io"))
+	}
+
+	for _, info := range infos {
 		var updated apiextensionsv1.CustomResourceDefinition
 		g.Expect(cl.Get(ctx, types.NamespacedName{Name: info.Name}, &updated)).To(Succeed())
 		if info.Name == "virtualservices.networking.istio.io" || info.Name == "gateways.networking.istio.io" {
@@ -441,6 +493,10 @@ func TestCRDOwnershipLabelCustom(t *testing.T) {
 	ctx := t.Context()
 	infos, err := m.Reconcile(ctx, Options{ManageCRDs: true, IncludeAllCRDs: true})
 	g.Expect(err).NotTo(HaveOccurred())
+
+	for _, info := range infos {
+		g.Expect(info.Name).NotTo(HaveSuffix(".sailoperator.io"))
+	}
 
 	for _, info := range infos {
 		var updated apiextensionsv1.CustomResourceDefinition

--- a/pkg/install/library.go
+++ b/pkg/install/library.go
@@ -40,6 +40,9 @@ const (
 
 	defaultQPS   float32 = 50
 	defaultBurst int     = 100
+
+	defaultCRDOwnershipLabelKey   = "app.kubernetes.io/managed-by"
+	defaultCRDOwnershipLabelValue = "sail-library"
 )
 
 // OverwriteOLMManagedCRDFunc is called when a CRD is detected with OLM
@@ -52,8 +55,10 @@ type OverwriteOLMManagedCRDFunc func(ctx context.Context, crd *apiextensionsv1.C
 type LibraryOption func(*libraryOptions)
 
 type libraryOptions struct {
-	qps   float32
-	burst int
+	qps                    float32
+	burst                  int
+	crdOwnershipLabelKey   string
+	crdOwnershipLabelValue string
 }
 
 // WithQPS sets the maximum sustained queries-per-second to the API server.
@@ -64,6 +69,16 @@ func WithQPS(qps float32) LibraryOption {
 // WithBurst sets the maximum burst of requests to the API server.
 func WithBurst(burst int) LibraryOption {
 	return func(o *libraryOptions) { o.burst = burst }
+}
+
+// WithCRDOwnershipLabel sets the label key and value used to identify CRDs
+// owned by the library. Existing CRDs must already carry this label for the
+// library to manage them. Defaults: app.kubernetes.io/managed-by=sail-library.
+func WithCRDOwnershipLabel(key, value string) LibraryOption {
+	return func(o *libraryOptions) {
+		o.crdOwnershipLabelKey = key
+		o.crdOwnershipLabelValue = value
+	}
 }
 
 // Options specifies the desired state for the istiod installation.
@@ -142,12 +157,14 @@ type Library struct {
 	mu       sync.Mutex
 	statusMu sync.RWMutex
 
-	kubeConfig   *rest.Config
-	resourceFS   fs.FS
-	crdFS        fs.FS
-	cl           client.Client
-	chartManager *helm.ChartManager
-	platform     config.Platform
+	kubeConfig             *rest.Config
+	resourceFS             fs.FS
+	crdFS                  fs.FS
+	cl                     client.Client
+	chartManager           *helm.ChartManager
+	platform               config.Platform
+	crdOwnershipLabelKey   string
+	crdOwnershipLabelValue string
 
 	triggerCh chan event.GenericEvent
 	notifyCh  chan struct{}
@@ -167,13 +184,31 @@ func ValidateOptions(opts Options) error {
 	return istioversion.ValidateVersion(opts.Version)
 }
 
+func validateCRDOwnershipLabel(key, value string) error {
+	if key == "" {
+		return fmt.Errorf("CRD ownership label key must not be empty")
+	}
+	if value == "" {
+		return fmt.Errorf("CRD ownership label value must not be empty")
+	}
+	return nil
+}
+
 // New creates a new Library instance. The resourceFS should contain Helm chart
 // resources (typically from resources/ directory or FromDirectory()).
 // The crdFS should contain CRD YAML files (typically from chart/crds/).
 func New(kubeConfig *rest.Config, resourceFS, crdFS fs.FS, opts ...LibraryOption) (*Library, error) {
-	o := libraryOptions{qps: defaultQPS, burst: defaultBurst}
+	o := libraryOptions{
+		qps:                    defaultQPS,
+		burst:                  defaultBurst,
+		crdOwnershipLabelKey:   defaultCRDOwnershipLabelKey,
+		crdOwnershipLabelValue: defaultCRDOwnershipLabelValue,
+	}
 	for _, fn := range opts {
 		fn(&o)
+	}
+	if err := validateCRDOwnershipLabel(o.crdOwnershipLabelKey, o.crdOwnershipLabelValue); err != nil {
+		return nil, err
 	}
 
 	cfg := rest.CopyConfig(kubeConfig)
@@ -196,14 +231,16 @@ func New(kubeConfig *rest.Config, resourceFS, crdFS fs.FS, opts ...LibraryOption
 	setupLog.Info("detected platform", "platform", platform)
 
 	return &Library{
-		kubeConfig:   cfg,
-		resourceFS:   resourceFS,
-		crdFS:        crdFS,
-		cl:           cl,
-		chartManager: chartManager,
-		platform:     platform,
-		triggerCh:    make(chan event.GenericEvent, 1),
-		notifyCh:     make(chan struct{}, 1),
+		kubeConfig:             cfg,
+		resourceFS:             resourceFS,
+		crdFS:                  crdFS,
+		cl:                     cl,
+		chartManager:           chartManager,
+		platform:               platform,
+		crdOwnershipLabelKey:   o.crdOwnershipLabelKey,
+		crdOwnershipLabelValue: o.crdOwnershipLabelValue,
+		triggerCh:              make(chan event.GenericEvent, 1),
+		notifyCh:               make(chan struct{}, 1),
 	}, nil
 }
 

--- a/pkg/install/library_test.go
+++ b/pkg/install/library_test.go
@@ -25,6 +25,39 @@ import (
 	"istio.io/istio/pkg/ptr"
 )
 
+func TestWithCRDOwnershipLabel(t *testing.T) {
+	g := NewWithT(t)
+
+	o := libraryOptions{
+		crdOwnershipLabelKey:   defaultCRDOwnershipLabelKey,
+		crdOwnershipLabelValue: defaultCRDOwnershipLabelValue,
+	}
+	WithCRDOwnershipLabel("ingress.operator.openshift.io/owned", "true")(&o)
+	g.Expect(o.crdOwnershipLabelKey).To(Equal("ingress.operator.openshift.io/owned"))
+	g.Expect(o.crdOwnershipLabelValue).To(Equal("true"))
+}
+
+func TestCRDOwnershipLabelEmptyValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		value   string
+		wantErr string
+	}{
+		{name: "empty key", key: "", value: "true", wantErr: "CRD ownership label key must not be empty"},
+		{name: "empty value", key: defaultCRDOwnershipLabelKey, value: "", wantErr: "CRD ownership label value must not be empty"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := validateCRDOwnershipLabel(tc.key, tc.value)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(Equal(tc.wantErr))
+		})
+	}
+}
+
 func TestValidateOptions(t *testing.T) {
 	savedMap := istioversion.Map
 	savedEOL := istioversion.EOL

--- a/pkg/install/reconciler.go
+++ b/pkg/install/reconciler.go
@@ -160,9 +160,14 @@ func (l *Library) newInstaller(namespace string) *installer {
 	}
 	return &installer{
 		istiodReconciler: sharedreconcile.NewIstiodReconciler(cfg, l.cl),
-		crdManager:       &crdManager{cl: l.cl, crdFS: l.crdFS},
-		cfg:              cfg,
-		platform:         l.platform,
+		crdManager: &crdManager{
+			cl:                  l.cl,
+			crdFS:               l.crdFS,
+			ownershipLabelKey:   l.crdOwnershipLabelKey,
+			ownershipLabelValue: l.crdOwnershipLabelValue,
+		},
+		cfg:      cfg,
+		platform: l.platform,
 	}
 }
 

--- a/tests/e2e/library/library_crd_ownership_test.go
+++ b/tests/e2e/library/library_crd_ownership_test.go
@@ -97,6 +97,10 @@ func forEachChartCRD(fn func(obj *unstructured.Unstructured)) {
 		if obj.GetName() == "" {
 			continue
 		}
+		group, _, _ := unstructured.NestedString(obj.Object, "spec", "group")
+		if !strings.HasSuffix(group, ".istio.io") {
+			continue
+		}
 		fn(&obj)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

* Filter the list of CRDs that the Sail Library is trying to manage.  Only ever try to manage the *.istio.io group CRDs. The Sail CRDs are for the Sail Operator. 
* Allow the user to define the label to use as CRD Ownership indicator. Default  app.kubernetes.io/managed-by=sail-library

#### Which issue(s) this PR fixes:

#### Additional information:
