### PR TITLE
test(revision): fix flaky TestPruneInactive requeueAfter assertion

### DIFF
--- a/pkg/revision/prune_test.go
+++ b/pkg/revision/prune_test.go
@@ -56,157 +56,113 @@ func TestPruneInactive(t *testing.T) {
 		BlockOwnerDeletion: ptr.Of(true),
 	}
 
-	tenSecondsAgo := metav1.Time{Time: time.Now().Add(-10 * time.Second)}
-	oneMinuteAgo := metav1.Time{Time: time.Now().Add(-1 * time.Minute)}
+	inUseFalse := v1.StatusCondition{
+		Type:   v1.IstioRevisionConditionInUse,
+		Status: metav1.ConditionFalse,
+		Reason: v1.ConditionReason(v1.IstioRevisionConditionInUse),
+	}
+
+	type additionalRevision struct {
+		name           string
+		inUseCondition v1.StatusCondition
+		transitionAge  time.Duration
+	}
+
 	testCases := []struct {
-		name                string
-		revName             string
-		ownerReference      metav1.OwnerReference
-		inUseCondition      *v1.StatusCondition
-		rev                 *v1.IstioRevision
-		expectDeletion      bool
-		expectRequeueAfter  *time.Duration
-		additionalRevisions []*v1.IstioRevision
+		name                  string
+		revName               string
+		ownerReference        metav1.OwnerReference
+		inUseCondition        *v1.StatusCondition
+		inUseTransitionAge    time.Duration
+		expectDeletion        bool
+		expectRequeueAfterAge *time.Duration
+		additionalRevisions   []additionalRevision
 	}{
 		{
-			name:           "preserves active IstioRevision even if not in use",
-			revName:        istioName,
-			ownerReference: ownedByIstio,
-			inUseCondition: &v1.StatusCondition{
-				Type:               v1.IstioRevisionConditionInUse,
-				Status:             metav1.ConditionFalse,
-				Reason:             v1.ConditionReason(v1.IstioRevisionConditionInUse),
-				LastTransitionTime: oneMinuteAgo,
-			},
+			name:               "preserves active IstioRevision even if not in use",
+			revName:            istioName,
+			ownerReference:     ownedByIstio,
+			inUseCondition:     &inUseFalse,
+			inUseTransitionAge: time.Minute,
 			expectDeletion:     false,
-			expectRequeueAfter: nil,
 		},
 		{
 			name:           "preserves non-active IstioRevision that's in use",
 			revName:        istioName + "-non-active",
 			ownerReference: ownedByIstio,
 			inUseCondition: &v1.StatusCondition{
-				Type:               v1.IstioRevisionConditionInUse,
-				Status:             metav1.ConditionTrue,
-				Reason:             v1.ConditionReason(v1.IstioRevisionConditionInUse),
-				LastTransitionTime: tenSecondsAgo,
+				Type:   v1.IstioRevisionConditionInUse,
+				Status: metav1.ConditionTrue,
+				Reason: v1.ConditionReason(v1.IstioRevisionConditionInUse),
 			},
+			inUseTransitionAge: 10 * time.Second,
 			expectDeletion:     false,
-			expectRequeueAfter: nil,
 		},
 		{
-			name:           "preserves unused non-active IstioRevision during grace period",
-			revName:        istioName + "-non-active",
-			ownerReference: ownedByIstio,
-			inUseCondition: &v1.StatusCondition{
-				Type:               v1.IstioRevisionConditionInUse,
-				Status:             metav1.ConditionFalse,
-				Reason:             v1.ConditionReason(v1.IstioRevisionConditionInUse),
-				LastTransitionTime: tenSecondsAgo,
-			},
-			expectDeletion:     false,
-			expectRequeueAfter: ptr.Of((v1.DefaultRevisionDeletionGracePeriodSeconds - 10) * time.Second),
+			name:                  "preserves unused non-active IstioRevision during grace period",
+			revName:               istioName + "-non-active",
+			ownerReference:        ownedByIstio,
+			inUseCondition:        &inUseFalse,
+			inUseTransitionAge:    10 * time.Second,
+			expectDeletion:        false,
+			expectRequeueAfterAge: ptr.Of(10 * time.Second),
 		},
 		{
-			name:           "preserves IstioRevision owned by a different Istio",
-			revName:        "other-istio-non-active",
-			ownerReference: ownedByAnotherIstio,
-			inUseCondition: &v1.StatusCondition{
-				Type:               v1.IstioRevisionConditionInUse,
-				Status:             metav1.ConditionFalse,
-				Reason:             v1.ConditionReason(v1.IstioRevisionConditionInUse),
-				LastTransitionTime: oneMinuteAgo,
-			},
+			name:               "preserves IstioRevision owned by a different Istio",
+			revName:            "other-istio-non-active",
+			ownerReference:     ownedByAnotherIstio,
+			inUseCondition:     &inUseFalse,
+			inUseTransitionAge: time.Minute,
 			expectDeletion:     false,
-			expectRequeueAfter: nil,
 		},
 		{
-			name:           "deletes non-active IstioRevision that's not in use",
-			revName:        istioName + "-non-active",
-			ownerReference: ownedByIstio,
-			inUseCondition: &v1.StatusCondition{
-				Type:               v1.IstioRevisionConditionInUse,
-				Status:             metav1.ConditionFalse,
-				Reason:             v1.ConditionReason(v1.IstioRevisionConditionInUse),
-				LastTransitionTime: oneMinuteAgo,
-			},
+			name:               "deletes non-active IstioRevision that's not in use",
+			revName:            istioName + "-non-active",
+			ownerReference:     ownedByIstio,
+			inUseCondition:     &inUseFalse,
+			inUseTransitionAge: time.Minute,
 			expectDeletion:     true,
-			expectRequeueAfter: nil,
 		},
 		{
-			name:           "returns requeueAfter of earliest IstioRevision requiring pruning",
-			revName:        istioName + "-non-active",
-			ownerReference: ownedByIstio,
-			inUseCondition: &v1.StatusCondition{
-				Type:               v1.IstioRevisionConditionInUse,
-				Status:             metav1.ConditionFalse,
-				Reason:             v1.ConditionReason(v1.IstioRevisionConditionInUse),
-				LastTransitionTime: oneMinuteAgo,
+			name:               "returns requeueAfter of earliest IstioRevision requiring pruning",
+			revName:            istioName + "-non-active",
+			ownerReference:     ownedByIstio,
+			inUseCondition:     &inUseFalse,
+			inUseTransitionAge: time.Minute,
+			additionalRevisions: []additionalRevision{
+				{name: istioName + "-non-active2", inUseCondition: inUseFalse, transitionAge: 25 * time.Second},
+				{name: istioName + "-non-active3", inUseCondition: inUseFalse, transitionAge: 20 * time.Second},
 			},
-			additionalRevisions: []*v1.IstioRevision{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            istioName + "-non-active2",
-						OwnerReferences: []metav1.OwnerReference{ownedByIstio},
-					},
-					Status: v1.IstioRevisionStatus{
-						Conditions: []v1.StatusCondition{
-							{
-								Type:               v1.IstioRevisionConditionInUse,
-								Status:             metav1.ConditionFalse,
-								Reason:             v1.ConditionReason(v1.IstioRevisionConditionInUse),
-								LastTransitionTime: metav1.Time{Time: time.Now().Add(-25 * time.Second)},
-							},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            istioName + "-non-active3",
-						OwnerReferences: []metav1.OwnerReference{ownedByIstio},
-					},
-					Status: v1.IstioRevisionStatus{
-						Conditions: []v1.StatusCondition{
-							{
-								Type:               v1.IstioRevisionConditionInUse,
-								Status:             metav1.ConditionFalse,
-								Reason:             v1.ConditionReason(v1.IstioRevisionConditionInUse),
-								LastTransitionTime: metav1.Time{Time: time.Now().Add(-20 * time.Second)},
-							},
-						},
-					},
-				},
-			},
-			expectDeletion:     true,
-			expectRequeueAfter: ptr.Of((v1.DefaultRevisionDeletionGracePeriodSeconds - 25) * time.Second),
+			expectDeletion:        true,
+			expectRequeueAfterAge: ptr.Of(25 * time.Second),
 		},
 		{
 			name:           "preserves non-active IstioRevision with unknown usage status",
 			revName:        istioName + "-non-active",
 			ownerReference: ownedByIstio,
 			inUseCondition: &v1.StatusCondition{
-				Type:               v1.IstioRevisionConditionInUse,
-				Status:             metav1.ConditionUnknown,
-				Reason:             v1.IstioRevisionReasonUsageCheckFailed,
-				Message:            "failed to determine if revision is in use",
-				LastTransitionTime: oneMinuteAgo,
+				Type:    v1.IstioRevisionConditionInUse,
+				Status:  metav1.ConditionUnknown,
+				Reason:  v1.IstioRevisionReasonUsageCheckFailed,
+				Message: "failed to determine if revision is in use",
 			},
+			inUseTransitionAge: time.Minute,
 			expectDeletion:     false,
-			expectRequeueAfter: nil,
 		},
 		{
 			name:           "preserves non-active IstioRevision with missing InUse condition",
 			revName:        istioName + "-non-active",
 			ownerReference: ownedByIstio,
-			// No InUse condition is set to simulate GetCondition returning ConditionUnknown
-			inUseCondition:     nil,
-			expectDeletion:     false,
-			expectRequeueAfter: nil,
+			// inUseCondition nil simulates GetCondition returning ConditionUnknown
+			expectDeletion: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			now := time.Now()
+			gracePeriod := v1.DefaultRevisionDeletionGracePeriodSeconds * time.Second
+
 			istio := &v1.Istio{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: istioName,
@@ -225,22 +181,31 @@ func TestPruneInactive(t *testing.T) {
 			}
 
 			if tc.inUseCondition != nil {
+				cond := *tc.inUseCondition
+				cond.LastTransitionTime = metav1.Time{Time: now.Add(-tc.inUseTransitionAge)}
 				rev.Status = v1.IstioRevisionStatus{
-					Conditions: []v1.StatusCondition{*tc.inUseCondition},
+					Conditions: []v1.StatusCondition{cond},
 				}
 			}
 
 			initObjs := []client.Object{istio, rev}
 			for _, additionalRev := range tc.additionalRevisions {
-				initObjs = append(initObjs, additionalRev)
+				cond := additionalRev.inUseCondition
+				cond.LastTransitionTime = metav1.Time{Time: now.Add(-additionalRev.transitionAge)}
+				initObjs = append(initObjs, &v1.IstioRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            additionalRev.name,
+						OwnerReferences: []metav1.OwnerReference{tc.ownerReference},
+					},
+					Status: v1.IstioRevisionStatus{
+						Conditions: []v1.StatusCondition{cond},
+					},
+				})
 			}
 
 			cl := newFakeClientBuilder().WithObjects(initObjs...).Build()
 
-			activeRevisionName := istioName
-			gracePeriod := v1.DefaultRevisionDeletionGracePeriodSeconds * time.Second
-
-			result, err := PruneInactive(ctx, cl, istio.UID, activeRevisionName, gracePeriod)
+			result, err := PruneInactive(ctx, cl, istio.UID, istioName, gracePeriod)
 			if err != nil {
 				t.Errorf("Expected no error, but got: %v", err)
 			}
@@ -252,7 +217,7 @@ func TestPruneInactive(t *testing.T) {
 				t.Error("Expected IstioRevision to be preserved, but it was deleted")
 			}
 
-			if tc.expectRequeueAfter == nil {
+			if tc.expectRequeueAfterAge == nil {
 				if result.RequeueAfter != 0 {
 					t.Errorf("Didn't expect Istio to be requeued, but it was; requeueAfter: %v", result.RequeueAfter)
 				}
@@ -260,9 +225,10 @@ func TestPruneInactive(t *testing.T) {
 				if result.RequeueAfter == 0 {
 					t.Error("Expected Istio to be requeued, but it wasn't")
 				} else {
-					diff := abs(result.RequeueAfter - *tc.expectRequeueAfter)
+					expected := gracePeriod - *tc.expectRequeueAfterAge
+					diff := abs(result.RequeueAfter - expected)
 					if diff > time.Second {
-						t.Errorf("Expected result.RequeueAfter to be around %v, but got %v", *tc.expectRequeueAfter, result.RequeueAfter)
+						t.Errorf("Expected result.RequeueAfter to be around %v, but got %v", expected, result.RequeueAfter)
 					}
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

Compute LastTransitionTime from a single time.Now() per subtest instead of freezing timestamps at test table init, which caused drift under CI coverage and failed the 5s RequeueAfter expectation.

#### Which issue(s) this PR fixes:

#### Additional information:

```
2026-06-16T10:01:13.4383717Z --- FAIL: TestPruneInactive (0.03s)
2026-06-16T10:01:13.4384210Z     --- PASS: TestPruneInactive/preserves_active_IstioRevision_even_if_not_in_use (0.00s)
2026-06-16T10:01:13.4384939Z     --- PASS: TestPruneInactive/preserves_non-active_IstioRevision_that's_in_use (0.00s)
2026-06-16T10:01:13.4385532Z     --- PASS: TestPruneInactive/preserves_unused_non-active_IstioRevision_during_grace_period (0.00s)
2026-06-16T10:01:13.4386205Z     --- PASS: TestPruneInactive/preserves_IstioRevision_owned_by_a_different_Istio (0.01s)
2026-06-16T10:01:13.4386759Z     --- PASS: TestPruneInactive/deletes_non-active_IstioRevision_that's_not_in_use (0.00s)
2026-06-16T10:01:13.4387357Z     --- FAIL: TestPruneInactive/returns_requeueAfter_of_earliest_IstioRevision_requiring_pruning (0.01s)
2026-06-16T10:01:13.4387979Z     --- PASS: TestPruneInactive/preserves_non-active_IstioRevision_with_unknown_usage_status (0.00s)
2026-06-16T10:01:13.4388601Z     --- PASS: TestPruneInactive/preserves_non-active_IstioRevision_with_missing_InUse_condition (0.00s)
```
