### PR TITLE
Fix update-deps workflow: use jq instead of yq for JSON parsing

### DIFF
--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -58,7 +58,7 @@ fi
 # getLatestVersion gets the latest released version of a github project
 # $1 = org/repo
 function getLatestVersion() {
-  curl -sL "https://api.github.com/repos/${1}/releases/latest" | yq '.tag_name'
+  curl -sL "https://api.github.com/repos/${1}/releases/latest" | jq -r '.tag_name'
 }
 
 # getLatestVersionByPrefix gets the latest released version of a github project with a specific version prefix
@@ -66,7 +66,7 @@ function getLatestVersion() {
 # $2 = version prefix
 function getLatestVersionByPrefix() {
   curl -sL "https://api.github.com/repos/${1}/releases?per_page=100" | \
-    yq -r '.[].tag_name' | \
+    jq -r '.[].tag_name' | \
     grep -E "^v?${2}[.0-9]*$" | \
     sort -V | \
     tail -n 1


### PR DESCRIPTION
## Summary

Fixes the `update-deps` GitHub Actions workflow failure by replacing `yq` with `jq` for parsing JSON responses from the GitHub API.

## Problem

The workflow was failing with:
```
Error: bad file '-': yaml: line 15: mapping values are not allowed in this context
```

This occurred because the `getLatestVersion()` and `getLatestVersionByPrefix()` functions in `tools/update_deps.sh` were using `yq` to parse JSON responses from the GitHub API. While `yq` can handle JSON in some cases, it was failing on the GitHub API's JSON output.

## Solution

Changed both functions to use `jq -r` instead of `yq` for parsing JSON responses from:
- `https://api.github.com/repos/.../releases/latest`
- `https://api.github.com/repos/.../releases?per_page=100`

This aligns with the existing `getLatestVersionFromDockerHub()` function which already correctly uses `jq` for JSON parsing.

## Testing

The fix has been validated against the error logs from workflow run ID 27528930569.

Closes: Run ID 27528930569