### PR TITLE
fix: add retry logic to download-charts.sh for transient network errors

### DIFF
--- a/hack/download-charts.sh
+++ b/hack/download-charts.sh
@@ -72,7 +72,20 @@ function downloadIstioManifests() {
   echo "${ISTIO_COMMIT}" > "${commit_file}"
 
   echo "downloading Git archive from ${ISTIO_URL}"
-  curl -sSLfO "${ISTIO_URL}"
+  # Retry up to 3 times with exponential backoff on failures (network errors, 5xx responses)
+  for i in 1 2 3; do
+    if curl -sSLfO --retry 2 --retry-delay 2 --retry-max-time 120 "${ISTIO_URL}"; then
+      break
+    else
+      if [ "$i" -lt 3 ]; then
+        echo "Download failed (attempt $i/3), retrying in $((2**i)) seconds..."
+        sleep $((2**i))
+      else
+        echo "Download failed after 3 attempts"
+        exit 1
+      fi
+    fi
+  done
 
   ISTIO_FILE="${ISTIO_URL##*/}"
   EXTRACT_DIR="${ISTIO_REPO##*/}-${ISTIO_COMMIT}"
@@ -82,7 +95,20 @@ function downloadIstioManifests() {
       file="${url##*/}"
       etag_file="${MANIFEST_DIR}/$file.etag"
       echo "downloading chart from $url"
-      curl -LfO -D - "$url" 2>/dev/null | awk -F': ' '/^etag:/ {print $2}' | tr -d "\"" > "$etag_file"
+      # Retry up to 3 times with exponential backoff on failures
+      for i in 1 2 3; do
+        if curl -LfO -D - --retry 2 --retry-delay 2 --retry-max-time 120 "$url" 2>/dev/null | awk -F': ' '/^etag:/ {print $2}' | tr -d "\"" > "$etag_file"; then
+          break
+        else
+          if [ "$i" -lt 3 ]; then
+            echo "Chart download failed (attempt $i/3), retrying in $((2**i)) seconds..."
+            sleep $((2**i))
+          else
+            echo "Chart download failed after 3 attempts"
+            exit 1
+          fi
+        fi
+      done
 
       echo "extracting charts from $file to ${CHARTS_DIR}"
       tar zxf "$file" -C "${CHARTS_DIR}"


### PR DESCRIPTION
## Problem

The `update-deps` GitHub Actions workflow failed on run #27120118278 due to a transient 504 Gateway Timeout error when downloading Istio charts from GitHub:

```
curl: (22) The requested URL returned error: 504
make: *** [Makefile.core.mk:485: download-istio-charts] Error 22
```

## Solution

This PR adds retry logic with exponential backoff to `hack/download-charts.sh` to handle transient network errors gracefully.

### Changes Made

1. **Git archive download (line 75)**: Added a retry loop with:
   - Up to 3 manual retry attempts
   - curl's built-in `--retry 2` for additional resilience
   - Exponential backoff between attempts (2, 4 seconds)
   - Maximum retry time of 120 seconds per curl attempt

2. **Chart downloads (line 85)**: Applied the same retry logic for consistency

### Retry Strategy

- **First layer**: curl's `--retry 2` handles immediate retryable failures
- **Second layer**: Manual retry loop (3 attempts) handles cases where curl gives up
- **Backoff**: 2 seconds after first failure, 4 seconds after second failure
- **Total max time**: ~6 minutes (3 attempts × 120s max per curl + backoff time)

This should significantly reduce the likelihood of transient network errors causing CI failures.

## Testing

The changes are backward compatible and will only activate on download failures. Successful downloads complete immediately as before.

## Related

- Fixes GitHub Actions run: https://github.com/istio-ecosystem/sail-operator/actions/runs/27120118278