### PR TITLE
Fix update-deps workflow: Load version variables regardless of PIN_MINOR setting

### DIFF
--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -40,19 +40,17 @@ function getVersionFromMakefile() {
 }
 
 # Get current versions from Makefile and set as variables
-# Only needed when PIN_MINOR is true (for patch version updates)
-if [[ "${PIN_MINOR}" == "true" ]]; then
-  OPERATOR_SDK_VERSION=$(getVersionFromMakefile "OPERATOR_SDK_VERSION")
-  # shellcheck disable=SC2034
-  HELM_VERSION=$(getVersionFromMakefile "HELM_VERSION")
-  CONTROLLER_TOOLS_VERSION=$(getVersionFromMakefile "CONTROLLER_TOOLS_VERSION")
-  CONTROLLER_RUNTIME_BRANCH=$(getVersionFromMakefile "CONTROLLER_RUNTIME_BRANCH")
-  OPM_VERSION=$(getVersionFromMakefile "OPM_VERSION")
-  OLM_VERSION=$(getVersionFromMakefile "OLM_VERSION")
-  GITLEAKS_VERSION=$(getVersionFromMakefile "GITLEAKS_VERSION")
-  RUNME_VERSION=$(getVersionFromMakefile "RUNME_VERSION")
-  MISSPELL_VERSION=$(getVersionFromMakefile "MISSPELL_VERSION")
-fi
+# These are always needed for getVersionForUpdate function
+OPERATOR_SDK_VERSION=$(getVersionFromMakefile "OPERATOR_SDK_VERSION")
+# shellcheck disable=SC2034
+HELM_VERSION=$(getVersionFromMakefile "HELM_VERSION")
+CONTROLLER_TOOLS_VERSION=$(getVersionFromMakefile "CONTROLLER_TOOLS_VERSION")
+CONTROLLER_RUNTIME_BRANCH=$(getVersionFromMakefile "CONTROLLER_RUNTIME_BRANCH")
+OPM_VERSION=$(getVersionFromMakefile "OPM_VERSION")
+OLM_VERSION=$(getVersionFromMakefile "OLM_VERSION")
+GITLEAKS_VERSION=$(getVersionFromMakefile "GITLEAKS_VERSION")
+RUNME_VERSION=$(getVersionFromMakefile "RUNME_VERSION")
+MISSPELL_VERSION=$(getVersionFromMakefile "MISSPELL_VERSION")
 
 
 # getLatestVersion gets the latest released version of a github project


### PR DESCRIPTION
## Summary

Fixes the `update-deps` workflow failure in run [26435891142](https://github.com/istio-ecosystem/sail-operator/actions/runs/26435891142).

## Root Cause

The `tools/update_deps.sh` script was failing because version variables (`GITLEAKS_VERSION`, `OPERATOR_SDK_VERSION`, etc.) were only loaded from `Makefile.core.mk` when `PIN_MINOR=true`. When `PIN_MINOR=false` (the default), these variables remained undefined, causing `getVersionForUpdate()` to fail with empty version strings.

Specifically, the failure occurred at line 219:
```bash
GITLEAKS_LATEST_VERSION=$(getVersionForUpdate gitleaks/gitleaks "${GITLEAKS_VERSION}")
```

Since `GITLEAKS_VERSION` was empty, the function couldn't determine whether to fetch the latest version or the latest patch version, resulting in an empty return value and subsequent script failure.

## Changes

- Removed the `if [[ "${PIN_MINOR}" == "true" ]]` conditional wrapper around version variable loading
- Now all version variables are always loaded from the Makefile, regardless of the `PIN_MINOR` setting
- This ensures `getVersionForUpdate()` receives valid current version values in all cases

## Testing

Verified that:
- `getVersionFromMakefile` correctly extracts `GITLEAKS_VERSION=v8.30.1` from Makefile.core.mk
- The script now has access to all required version variables regardless of `PIN_MINOR` value
- The logic in `getVersionForUpdate()` can now properly determine which version to fetch

🤖 Generated with Claude Code