### PR TITLE
test: Fix PodSecurity error on gateway test while running on OCP clusters

### DIFF
--- a/tests/e2e/gatewaycontroller/gateway_controller_test.go
+++ b/tests/e2e/gatewaycontroller/gateway_controller_test.go
@@ -175,10 +175,19 @@ metadata:
   labels:
     sidecar.istio.io/inject: "false"
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: curl
     image: curlimages/curl
-    command: ["sleep", "3600"]`, gatewayNamespace)
+    command: ["sleep", "3600"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL`, gatewayNamespace)
 			Expect(k.ApplyString(curlPodYAML)).To(Succeed())
 		})
 

--- a/tests/e2e/gatewaycontroller/gateway_controller_test.go
+++ b/tests/e2e/gatewaycontroller/gateway_controller_test.go
@@ -165,6 +165,19 @@ spec:
 			Expect(k.ApplyString(gatewayYAML)).To(Succeed())
 			Success("Gateway created")
 
+			// Define the platform specific security context snippets
+			var securityContextFields string
+			if env.GetBool("OCP", true) {
+				// OpenShift handles UID allocation dynamically via SCC
+				securityContextFields = `seccompProfile:
+      type: RuntimeDefault`
+			} else {
+				// Kind/Vanilla K8s requires explicit non-root enforcement
+				securityContextFields = `runAsNonRoot: true
+    runAsUser: 100
+    seccompProfile:
+      type: RuntimeDefault`
+			}
 			// Deploy a curl client pod for traffic testing
 			curlPodYAML := fmt.Sprintf(`
 apiVersion: v1
@@ -176,9 +189,7 @@ metadata:
     sidecar.istio.io/inject: "false"
 spec:
   securityContext:
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
+    %s
   containers:
   - name: curl
     image: curlimages/curl
@@ -187,7 +198,7 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - ALL`, gatewayNamespace)
+        - ALL`, gatewayNamespace, securityContextFields)
 			Expect(k.ApplyString(curlPodYAML)).To(Succeed())
 		})
 


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
While running the test on OCP versions 4.23 or higher the gateway test using a curl pod hit some issues while trying to apply the yaml


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
