### PR TITLE
fix(e2e): initialize controller-runtime logger in ambient suite

### DIFF
--- a/tests/e2e/ambient/ambient_suite_test.go
+++ b/tests/e2e/ambient/ambient_suite_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var (
@@ -56,6 +58,7 @@ func TestAmbient(t *testing.T) {
 
 func setup() {
 	GinkgoWriter.Println("************ Running Setup ************")
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	GinkgoWriter.Println("Initializing k8s client")
 	cl, err = k8sclient.InitK8sClient("")


### PR DESCRIPTION
Fixes #2027

The ambient test suite was missing a call to `ctrl.SetLogger(...)`, causing controller-runtime to emit a noisy warning in CI logs whenever a Kubernetes API warning header was received.

Assisted by @claude.