### PR TITLE
Add the correct ciphersuite and ECDH curves on Openshift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/magiconair/properties v1.8.9
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.41.0
-	github.com/openshift/api v0.0.0-20260501191448-a49973eaef53
-	github.com/openshift/controller-runtime-common v0.0.0-20260318085703-1812aed6dbd2
+	github.com/openshift/api v0.0.0-20260630164038-90cdc3bbde7f
+	github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e
 	github.com/openshift/library-go v0.0.0-20260318142011-72bf34f474bc
 	github.com/prometheus/common v0.67.5
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -271,10 +271,10 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openshift/api v0.0.0-20260501191448-a49973eaef53 h1:u5WEBNXUhL2ik6vzBREkYnk+cZqLMUXcSFa6STK/8Bs=
-github.com/openshift/api v0.0.0-20260501191448-a49973eaef53/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
-github.com/openshift/controller-runtime-common v0.0.0-20260318085703-1812aed6dbd2 h1:GrZlVichOCE/lz8fg1+eNrAtkM0VSlqa9buuzN0vnb0=
-github.com/openshift/controller-runtime-common v0.0.0-20260318085703-1812aed6dbd2/go.mod h1:XGabTMnNbz0M5Oa7IbscZp/jmcc7aHobvOCUWwkzKvM=
+github.com/openshift/api v0.0.0-20260630164038-90cdc3bbde7f h1:XVbZm6+tos469QuLh1dpLrKVP2NwoKDrA++G6fwXVyE=
+github.com/openshift/api v0.0.0-20260630164038-90cdc3bbde7f/go.mod h1:7WJ3IPaK6nmWT8bDcaNooHqd0H5WepjVqV/10VlkMEM=
+github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e h1:k89oIo2EjX0PRSdi1kesktCyWp50SC9WwKurvupvRGs=
+github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e/go.mod h1:XGabTMnNbz0M5Oa7IbscZp/jmcc7aHobvOCUWwkzKvM=
 github.com/openshift/library-go v0.0.0-20260318142011-72bf34f474bc h1:a+rVRzEdFIwgDQLTbhiG3MEVuBXjLb/6HJRikTob+nY=
 github.com/openshift/library-go v0.0.0-20260318142011-72bf34f474bc/go.mod h1:3bi4pLpYRdVd1aEhsHfRTJkwxwPLfRZ+ZePn3RmJd2k=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/pkg/istiovalues/tls.go
+++ b/pkg/istiovalues/tls.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/config"
+	configv1 "github.com/openshift/api/config/v1"
 
 	"istio.io/istio/pkg/log"
 )
@@ -63,6 +64,26 @@ func ApplyTLSConfig(tlsConfig *config.TLSConfig, istioVersion string, values *v1
 
 	if values.MeshConfig.MeshMTLS.MinProtocolVersion == "" {
 		values.MeshConfig.MeshMTLS.MinProtocolVersion = tlsProtocolVersion(tlsConfig.MinVersion)
+	}
+
+	// Envoy does not support setting TLS ciphers when minProtocolVersion is 1.3
+	if values.MeshConfig.TlsDefaults.MinProtocolVersion == v1.MeshConfigTLSConfigTLSProtocolTlsv13 {
+		values.MeshConfig.TlsDefaults.CipherSuites = nil
+	}
+
+	if values.MeshConfig.MeshMTLS.MinProtocolVersion == v1.MeshConfigTLSConfigTLSProtocolTlsv13 {
+		values.MeshConfig.MeshMTLS.CipherSuites = nil
+	}
+
+	// Configure the Ecdhcurves if they are available on Openshift configuration. Normalize before
+	// copying the names, given Openshift allows a different naming from NIST
+	if tlsConfig.OpenShift != nil && len(tlsConfig.OpenShift.TLSProfileSpec.Groups) > 0 {
+		ecdhCurves := copyECDHCurvesToConfig(tlsConfig.OpenShift.TLSProfileSpec.Groups)
+		if len(values.MeshConfig.TlsDefaults.EcdhCurves) == 0 {
+			values.MeshConfig.TlsDefaults.EcdhCurves = ecdhCurves
+		}
+		// TODO: MeshMTLS does not support setting ecdhCurves and this will break Gateway provisioning.
+		// we should take care of ecdhCurves for mesh as a second step
 	}
 
 	if values.Pilot == nil {
@@ -116,4 +137,28 @@ func addExtraContainerArg(pilot *v1.PilotConfig, argName, argValue string) {
 		}
 	}
 	pilot.ExtraContainerArgs = append(pilot.ExtraContainerArgs, argNameWithEquals+argValue)
+}
+
+// copyECDHCurvesToConfig creates a new slice containing the normalized ECDHCurves to be
+// used on meshConfig fields
+func copyECDHCurvesToConfig(groups []configv1.TLSGroup) []string {
+	values := make([]string, len(groups))
+	for i := range groups {
+		values[i] = normalizeECDHCurve(string(groups[i]))
+	}
+	return values
+}
+
+// normalizeECDHCurve maps common curve aliases to Envoy-supported names
+func normalizeECDHCurve(curve string) string {
+	switch strings.ToLower(strings.TrimSpace(curve)) {
+	case "secp256r1", "prime256v1", "p-256", "p256":
+		return "P-256"
+	case "secp384r1", "p-384", "p384":
+		return "P-384"
+	case "x25519":
+		return "X25519"
+	default:
+		return curve // Return as-is if unmapped
+	}
 }

--- a/pkg/istiovalues/tls_test.go
+++ b/pkg/istiovalues/tls_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/config"
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 func TestApplyTLSConfig(t *testing.T) {
@@ -186,7 +187,7 @@ func TestApplyTLSConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "adds tls-min-version TLS 1.3 for istio 1.29+",
+			name: "adds tls-min-version TLS 1.3 for istio 1.29+ and remove cipherSuites from meshConfig",
 			tlsConfig: &config.TLSConfig{
 				CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
 				MinVersion:   tls.VersionTLS13,
@@ -196,11 +197,11 @@ func TestApplyTLSConfig(t *testing.T) {
 			wantValues: &v1.Values{
 				MeshConfig: &v1.MeshConfig{
 					MeshMTLS: &v1.MeshConfigTLSConfig{
-						CipherSuites:       []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+						CipherSuites:       nil,
 						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
 					},
 					TlsDefaults: &v1.MeshConfigTLSConfig{
-						CipherSuites:       []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+						CipherSuites:       nil,
 						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
 					},
 				},
@@ -255,6 +256,45 @@ func TestApplyTLSConfig(t *testing.T) {
 				},
 				Pilot: &v1.PilotConfig{
 					ExtraContainerArgs: []string{"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+				},
+			},
+		},
+		{
+			name: "adds tls-min-version TLS 1.3 and the right ecdh curves only to TLSDefaults",
+			tlsConfig: &config.TLSConfig{
+				CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+				MinVersion:   tls.VersionTLS13,
+				OpenShift: &config.OpenShiftTLS{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Groups: []configv1.TLSGroup{
+							configv1.TLSGroupX25519MLKEM768,
+							configv1.TLSGroupX25519,
+							configv1.TLSGroupSecP256r1,
+							configv1.TLSGroupSecP384r1,
+						},
+					},
+				},
+			},
+			istioVersion: "1.30.0",
+			inputValues:  &v1.Values{},
+			wantValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					MeshMTLS: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+						EcdhCurves:         nil,
+					},
+					TlsDefaults: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+						EcdhCurves:         []string{"X25519MLKEM768", "X25519", "P-256", "P-384"},
+					},
+				},
+				Pilot: &v1.PilotConfig{
+					ExtraContainerArgs: []string{
+						"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						"--tls-min-version=1.3",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?
- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

When fetching TLS configuration from Openshift API, we are transpiling the cipher suite list to meshConfig.

The issue is that Envoy rejects listeners that have min tlsVersion of 1.3 AND establishes a ciphersuite, causing the proxy to never be ready.

This change enforces that when tlsVersion is 1.3, the cipher suite is removed from Envoy/MeshConfig.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:

Some executed tests:
* Setting TLSProfile as modern, check that just TLS 1.3 is used and that Gateway will provide as the first in the list `X25519MLKEM768` cipher
* Setting TLSProfile as intermediate, both TLS 1.2 and TLS 1.3 are available and the right ciphers are used
