### PR TITLE
Do not use hardcoded curl image as shortname

### DIFF
--- a/tests/e2e/gatewaycontroller/gateway_controller_test.go
+++ b/tests/e2e/gatewaycontroller/gateway_controller_test.go
@@ -193,7 +193,7 @@ spec:
     %s
   containers:
   - name: curl
-    image: curlimages/curl
+    image: quay.io/curl/curl:8.16.0
     command: ["sleep", "3600"]
     securityContext:
       allowPrivilegeEscalation: false


### PR DESCRIPTION
Do not use shortname images since it causes an issue on IBM clusters in mirroring (related to cri-o update to enforce shorname images)