### PR TITLE
test(e2e): truncate debug output in JUnit XML to prevent excessive fi…

### DIFF
--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -59,6 +59,10 @@ const (
 	HttpbinNamespace     = "httpbin"
 	SleepContainerName   = "sleep"
 	HttpbinContainerName = "httpbin"
+
+	// maxJUnitErrorMessageSize is the maximum size (in bytes) for error messages
+	// written to junit XML files. Messages exceeding this size will be truncated.
+	maxJUnitErrorMessageSize = 10 * 1024 // 10KB
 )
 
 var (
@@ -404,6 +408,22 @@ func logFailedPodsDetails(k kubectl.Kubectl, namespace string, buf *strings.Buil
 	logDebugElement("=====Pod descriptions in "+namespace+"=====", describe, err, buf, printDebug)
 }
 
+// truncateForJUnit truncates strings that exceed maxJUnitErrorMessageSize
+// to prevent junit XML files from becoming excessively large.
+func truncateForJUnit(s string) string {
+	if len(s) <= maxJUnitErrorMessageSize {
+		return s
+	}
+
+	const truncationMsg = "\n\n... [truncated due to size limit] ..."
+	truncateAt := maxJUnitErrorMessageSize - len(truncationMsg)
+	if truncateAt < 0 {
+		truncateAt = 0
+	}
+
+	return s[:truncateAt] + truncationMsg
+}
+
 func logDebugElement(caption string, info string, err error, buf *strings.Builder, printDebug bool) {
 	buf.WriteString("\n" + caption + ":\n")
 	if err != nil {
@@ -415,9 +435,9 @@ func logDebugElement(caption string, info string, err error, buf *strings.Builde
 	if printDebug {
 		GinkgoWriter.Println("\n" + caption + ":")
 		if err != nil {
-			GinkgoWriter.Println(Indent(err.Error()))
+			GinkgoWriter.Println(Indent(truncateForJUnit(err.Error())))
 		} else {
-			GinkgoWriter.Println(Indent(strings.TrimSpace(info)))
+			GinkgoWriter.Println(Indent(truncateForJUnit(strings.TrimSpace(info))))
 		}
 	}
 }


### PR DESCRIPTION
…le sizes

Add truncateForJUnit() function to cap debug messages at 10KB when written to JUnit XML via GinkgoWriter. Artifact files still receive full untruncated content.

