### PR TITLE
Capture logs immideately at test failure

### DIFF
--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -41,8 +41,6 @@ var _ = Describe("Ambient configuration ", Label("ambient", "slow"), Ordered, fu
 	SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
-	debugInfoLogged := false
-
 	Describe("for supported versions", func() {
 		for _, version := range istioversion.GetLatestPatchVersions() {
 			// The minimum supported version is 1.24 (and above)
@@ -116,6 +114,13 @@ profile: ambient`
 					common.CreateIstio(k, version.Name, istioYAML)
 
 					Success("All ambient components created in reverse order to test order independence")
+				})
+
+				// Capture debug info immediately on test failure
+				JustAfterEach(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.Ambient, k)
+					}
 				})
 
 				When("the ambient components are deployed", func() {
@@ -323,12 +328,7 @@ profile: ambient`
 				})
 
 				AfterAll(func(ctx SpecContext) {
-					// Log debug info before Cleanup: Cleaner removes CRs created after Record()
-					// (e.g. Istio), and parent AfterAll hooks run after this AfterAll.
-					if CurrentSpecReport().Failed() {
-						common.LogDebugInfo(common.Ambient, k)
-						debugInfoLogged = true
-					}
+					// Skip cleanup if test failed and keepOnFailure is set
 					if CurrentSpecReport().Failed() && keepOnFailure {
 						return
 					}
@@ -336,20 +336,6 @@ profile: ambient`
 					clr.Cleanup(ctx)
 				})
 			})
-		}
-
-		AfterAll(func(ctx SpecContext) {
-			if CurrentSpecReport().Failed() && !debugInfoLogged {
-				common.LogDebugInfo(common.Ambient, k)
-				debugInfoLogged = true
-			}
-		})
-	})
-
-	AfterAll(func(ctx SpecContext) {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.Ambient, k)
-			debugInfoLogged = true
 		}
 	})
 })

--- a/tests/e2e/ambient/ambient_update_test.go
+++ b/tests/e2e/ambient/ambient_update_test.go
@@ -37,7 +37,6 @@ import (
 var _ = Describe("Ambient Update & Lifecycle", Label("ambient", "update", "slow"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
-	debugInfoLogged := false
 
 	// Get two consecutive minor versions for update testing
 	baseVersion, newVersion, err := update.GetTwoConsecutiveAmbientVersions(fipsCluster)
@@ -56,6 +55,13 @@ var _ = Describe("Ambient Update & Lifecycle", Label("ambient", "update", "slow"
 				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
 				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
 				Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+			})
+
+			// Capture debug info immediately on test failure
+			JustAfterEach(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.Ambient, k)
+				}
 			})
 
 			When("all components are created with base version", func() {
@@ -279,12 +285,9 @@ spec:
 			})
 
 			AfterAll(func(ctx SpecContext) {
-				if CurrentSpecReport().Failed() {
-					common.LogDebugInfo(common.Ambient, k)
-					debugInfoLogged = true
-					if keepOnFailure {
-						return
-					}
+				// Skip cleanup if test failed and keepOnFailure is set
+				if CurrentSpecReport().Failed() && keepOnFailure {
+					return
 				}
 				clr.Cleanup(ctx)
 			})
@@ -340,6 +343,12 @@ spec:
 				// the first IstioRevision is created.
 
 				Success("Shared dependencies created at base version")
+			})
+			// Capture debug info immediately on test failure
+			JustAfterEach(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.Ambient, k)
+				}
 			})
 
 			When("Istio CR is created with base version (default revision)", func() {
@@ -585,12 +594,9 @@ spec:
 			})
 
 			AfterAll(func(ctx SpecContext) {
-				if CurrentSpecReport().Failed() {
-					common.LogDebugInfo(common.Ambient, k)
-					debugInfoLogged = true
-					if keepOnFailure {
-						return
-					}
+				// Skip cleanup if test failed and keepOnFailure is set
+				if CurrentSpecReport().Failed() && keepOnFailure {
+					return
 				}
 				clr.Cleanup(ctx)
 			})
@@ -642,6 +648,12 @@ spec:
 				common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl, 240*time.Second)
 
 				Success("Control plane and IstioCNI created for lifecycle tests")
+			})
+			// Capture debug info immediately on test failure
+			JustAfterEach(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.Ambient, k)
+				}
 			})
 
 			When("spec.values is updated on ZTunnel", func() {
@@ -743,28 +755,12 @@ spec:
 			})
 
 			AfterAll(func(ctx SpecContext) {
-				if CurrentSpecReport().Failed() {
-					common.LogDebugInfo(common.Ambient, k)
-					debugInfoLogged = true
-					if keepOnFailure {
-						return
-					}
+				// Skip cleanup if test failed and keepOnFailure is set
+				if CurrentSpecReport().Failed() && keepOnFailure {
+					return
 				}
 				clr.Cleanup(ctx)
 			})
 		})
-	})
-
-	AfterAll(func() {
-		if CurrentSpecReport().Failed() {
-			if !debugInfoLogged {
-				common.LogDebugInfo(common.Ambient, k)
-				debugInfoLogged = true
-
-				if keepOnFailure {
-					return
-				}
-			}
-		}
 	})
 })

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -38,7 +38,6 @@ import (
 var _ = Describe("Control Plane Installation", Label("control-plane", "slow", "sidecar"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
-	debugInfoLogged := false
 
 	Describe("defaulting", func() {
 		DescribeTable("IstioCNI",
@@ -99,6 +98,13 @@ metadata:
 					clr.Record(ctx)
 					Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
 					Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
+				})
+
+				// Capture debug info immediately on test failure
+				JustAfterEach(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.ControlPlane, k)
+					}
 				})
 
 				When("the IstioCNI CR is created", func() {
@@ -224,11 +230,7 @@ metadata:
 				})
 
 				AfterAll(func(ctx SpecContext) {
-					if CurrentSpecReport().Failed() {
-						common.LogDebugInfo(common.ControlPlane, k)
-						debugInfoLogged = true
-					}
-
+					// Skip cleanup if test failed and keepOnFailure is set
 					if CurrentSpecReport().Failed() && keepOnFailure {
 						return
 					}
@@ -236,12 +238,6 @@ metadata:
 					clr.Cleanup(ctx)
 				})
 			})
-		}
-	})
-
-	AfterAll(func() {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.ControlPlane, k)
 		}
 	})
 })

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -41,7 +41,6 @@ import (
 var _ = Describe("Control Plane updates", Label("control-plane", "update", "slow", "sidecar"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
-	debugInfoLogged := false
 
 	Describe("using IstioRevisionTag", func() {
 		var baseVersion, newVersion istioversion.VersionInfo
@@ -64,6 +63,13 @@ var _ = Describe("Control Plane updates", Label("control-plane", "update", "slow
 
 				common.CreateIstioCNI(k, baseVersion.Name)
 				common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
+			})
+
+			// Capture debug info immediately on test failure
+			JustAfterEach(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.ControlPlane, k)
+				}
 			})
 
 			When(fmt.Sprintf("the Istio CR is created with RevisionBased updateStrategy for base version %s", baseVersion.Name), func() {
@@ -266,29 +272,13 @@ spec:
 			})
 
 			AfterAll(func(ctx SpecContext) {
-				if CurrentSpecReport().Failed() {
-					common.LogDebugInfo(common.ControlPlane, k)
-					debugInfoLogged = true
-					if keepOnFailure {
-						return
-					}
+				// Skip cleanup if test failed and keepOnFailure is set
+				if CurrentSpecReport().Failed() && keepOnFailure {
+					return
 				}
 
 				clr.Cleanup(ctx)
 			})
-		})
-
-		AfterAll(func() {
-			if CurrentSpecReport().Failed() {
-				if !debugInfoLogged {
-					common.LogDebugInfo(common.ControlPlane, k)
-					debugInfoLogged = true
-
-					if keepOnFailure {
-						return
-					}
-				}
-			}
 		})
 	})
 
@@ -314,6 +304,13 @@ spec:
 
 				common.CreateIstioCNI(k, baseVersion.Name)
 				common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
+			})
+
+			// Capture debug info immediately on test failure
+			JustAfterEach(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.ControlPlane, k)
+				}
 			})
 
 			When(fmt.Sprintf("Istio CR is created with InPlace updateStrategy for version %s", baseVersion.Name), func() {
@@ -451,11 +448,9 @@ updateStrategy:
 			})
 
 			AfterAll(func(ctx SpecContext) {
-				if CurrentSpecReport().Failed() {
-					common.LogDebugInfo(common.ControlPlane, k)
-					if keepOnFailure {
-						return
-					}
+				// Skip cleanup if test failed and keepOnFailure is set
+				if CurrentSpecReport().Failed() && keepOnFailure {
+					return
 				}
 				clr.Cleanup(ctx)
 			})
@@ -493,6 +488,13 @@ updateStrategy:
 				// Wait for it to be ready
 				common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key("default"), &v1.Istio{}, k, cl)
 				Success("Istio CR created and ready for lifecycle tests")
+			})
+
+			// Capture debug info immediately on test failure
+			JustAfterEach(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.ControlPlane, k)
+				}
 			})
 
 			When("spec.values is updated on Istio CR", func() {
@@ -581,11 +583,9 @@ updateStrategy:
 			})
 
 			AfterAll(func(ctx SpecContext) {
-				if CurrentSpecReport().Failed() {
-					common.LogDebugInfo(common.ControlPlane, k)
-					if keepOnFailure {
-						return
-					}
+				// Skip cleanup if test failed and keepOnFailure is set
+				if CurrentSpecReport().Failed() && keepOnFailure {
+					return
 				}
 				clr.Cleanup(ctx)
 			})

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -47,8 +47,6 @@ var _ = Describe("DualStack configuration ", Label("dualstack", "slow", "sidecar
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
-	debugInfoLogged := false
-
 	Describe("for supported versions", func() {
 		for _, version := range istioversion.GetLatestPatchVersions() {
 			// The minimum supported version is 1.23 (and above)
@@ -62,6 +60,13 @@ var _ = Describe("DualStack configuration ", Label("dualstack", "slow", "sidecar
 					clr.Record(ctx)
 					Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
 					Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
+				})
+
+				// Capture debug info immediately on test failure
+				JustAfterEach(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.ControlPlane, k)
+					}
 				})
 
 				When("the IstioCNI CR is created", func() {
@@ -222,11 +227,7 @@ values:
 				})
 
 				AfterAll(func(ctx SpecContext) {
-					if CurrentSpecReport().Failed() {
-						common.LogDebugInfo(common.DualStack, k)
-						debugInfoLogged = true
-					}
-
+					// Skip cleanup if test failed and keepOnFailure is set
 					if CurrentSpecReport().Failed() && keepOnFailure {
 						return
 					}
@@ -234,12 +235,6 @@ values:
 					clr.Cleanup(ctx)
 				})
 			})
-		}
-	})
-
-	AfterAll(func(ctx SpecContext) {
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.DualStack, k)
 		}
 	})
 })

--- a/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
+++ b/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
@@ -64,6 +64,14 @@ var _ = Describe("Multicluster deployment models", Label("multicluster", "multic
 					clr2.Record(ctx)
 				})
 
+				// Capture debug info immediately on test failure (before any cleanup or next BeforeEach runs)
+				// Use JustAfterEach instead of DeferCleanup to run immediately after test failure
+				JustAfterEach(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.MultiCluster, k1, k2)
+					}
+				})
+
 				When("default Istio is created in Cluster #1 to handle ingress to External Control Plane", func() {
 					BeforeAll(func(ctx SpecContext) {
 						createIstioNamespaces(k1, "network1", "default")
@@ -394,12 +402,9 @@ spec:
 				})
 
 				AfterAll(func(ctx SpecContext) {
-					if CurrentSpecReport().Failed() {
-						common.LogDebugInfo(common.MultiCluster, k1, k2)
-						debugInfoLogged = true
-						if keepOnFailure {
-							return
-						}
+					// Skip cleanup if test failed and keepOnFailure is set
+					if CurrentSpecReport().Failed() && keepOnFailure {
+						return
 					}
 
 					c1Deleted := clr1.CleanupNoWait(ctx)

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -66,6 +66,14 @@ func generateMultiPrimaryTestCases(profile string) {
 					clr2.Record(ctx)
 				})
 
+				// Capture debug info immediately on test failure (before any cleanup or next BeforeEach runs)
+				// Use JustAfterEach instead of DeferCleanup to run immediately after test failure
+				JustAfterEach(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.MultiCluster, k1, k2)
+					}
+				})
+
 				When("Istio and IstioCNI resources are created in both clusters", func() {
 					BeforeAll(func(ctx SpecContext) {
 						createIstioNamespaces(k1, "network1", profile)
@@ -231,12 +239,9 @@ func generateMultiPrimaryTestCases(profile string) {
 				})
 
 				AfterAll(func(ctx SpecContext) {
-					if CurrentSpecReport().Failed() {
-						common.LogDebugInfo(common.MultiCluster, k1, k2)
-						debugInfoLogged = true
-						if keepOnFailure {
-							return
-						}
+					// Skip cleanup if test failed and keepOnFailure is set
+					if CurrentSpecReport().Failed() && keepOnFailure {
+						return
 					}
 
 					c1Deleted := clr1.CleanupNoWait(ctx)

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -64,6 +64,14 @@ var _ = Describe("Multicluster deployment models", Label("multicluster", "multic
 					clr2.Record(ctx)
 				})
 
+				// Capture debug info immediately on test failure (before any cleanup or next BeforeEach runs)
+				// Use JustAfterEach instead of DeferCleanup to run immediately after test failure
+				JustAfterEach(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.MultiCluster, k1, k2)
+					}
+				})
+
 				When("Istio and IstioCNI resources are created in both clusters", func() {
 					BeforeAll(func(ctx SpecContext) {
 						createIstioNamespaces(k1, "network1", profile)
@@ -357,12 +365,9 @@ values:
 				})
 
 				AfterAll(func(ctx SpecContext) {
-					if CurrentSpecReport().Failed() {
-						common.LogDebugInfo(common.MultiCluster, k1, k2)
-						debugInfoLogged = true
-						if keepOnFailure {
-							return
-						}
+					// Skip cleanup if test failed and keepOnFailure is set
+					if CurrentSpecReport().Failed() && keepOnFailure {
+						return
 					}
 
 					c1Deleted := clr1.CleanupNoWait(ctx)

--- a/tests/e2e/multicluster/multicluster_suite_test.go
+++ b/tests/e2e/multicluster/multicluster_suite_test.go
@@ -36,7 +36,6 @@ var (
 	clPrimary                     client.Client
 	clRemote                      client.Client
 	err                           error
-	debugInfoLogged               bool
 	externalControlPlaneNamespace = env.Get("EXTERNAL_CONTROL_PLANE_NS", "external-istiod")
 	istioName                     = env.Get("ISTIO_NAME", "default")
 	istioCniNamespace             = common.IstioCniNamespace
@@ -103,9 +102,3 @@ func setup(t *testing.T) {
 	k1 = kubectl.New().WithKubeconfig(kubeconfig).WithClusterName("primary")
 	k2 = kubectl.New().WithKubeconfig(kubeconfig2).WithClusterName("remote")
 }
-
-var _ = ReportAfterSuite("Conditional cleanup", func(ctx SpecContext, r Report) {
-	if !r.SuiteSucceeded && !debugInfoLogged {
-		common.LogDebugInfo(common.MultiCluster, k1, k2)
-	}
-})

--- a/tests/e2e/multicontrolplane/multi_control_plane_test.go
+++ b/tests/e2e/multicontrolplane/multi_control_plane_test.go
@@ -35,7 +35,6 @@ import (
 var _ = Describe("Multi control plane deployment model", Label("multi-control-plane", "slow", "sidecar"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
-	debugInfoLogged := false
 	latestVersion := istioversion.GetLatestPatchVersions()[0]
 
 	Describe("for supported versions", func() {
@@ -45,6 +44,13 @@ var _ = Describe("Multi control plane deployment model", Label("multi-control-pl
 
 				BeforeAll(func(ctx SpecContext) {
 					clr.Record(ctx)
+				})
+
+				// Capture debug info immediately on test failure
+				JustAfterEach(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.ControlPlane, k)
+					}
 				})
 
 				Describe("Installation", func() {
@@ -149,22 +155,9 @@ spec:
 				})
 
 				AfterAll(func(ctx SpecContext) {
-					if CurrentSpecReport().Failed() {
-						common.LogDebugInfo(common.ControlPlane, k)
-						debugInfoLogged = true
-					}
 					clr.Cleanup(ctx)
 				})
 			})
 		}
-
-		AfterAll(func(ctx SpecContext) {
-			if CurrentSpecReport().Failed() {
-				if !debugInfoLogged {
-					common.LogDebugInfo(common.MultiControlPlane, k)
-					debugInfoLogged = true
-				}
-			}
-		})
 	})
 })

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -90,18 +90,24 @@ var (
 var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
-	debugInfoLogged := false
 	clr := cleaner.New(cl)
+
 	BeforeAll(func(ctx SpecContext) {
 		clr.Record(ctx)
 		DeferCleanup(func(ctx SpecContext) {
 			if CurrentSpecReport().Failed() {
 				common.LogDebugInfo(common.Operator, k)
-				debugInfoLogged = true
 			}
 
 			clr.Cleanup(ctx)
 		})
+	})
+
+	// Capture debug info immediately on test failure
+	JustAfterEach(func(ctx SpecContext) {
+		if CurrentSpecReport().Failed() {
+			common.LogDebugInfo(common.Operator, k)
+		}
 	})
 
 	Describe("installation", func() {
@@ -457,10 +463,6 @@ spec:
 	AfterAll(func(ctx SpecContext) {
 		if CurrentSpecReport().Failed() && keepOnFailure {
 			return
-		}
-
-		if CurrentSpecReport().Failed() && !debugInfoLogged {
-			common.LogDebugInfo(common.Operator, k)
 		}
 	})
 })


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Currently, during e2e test failure, logs gathering happens in "AfterAll" section.
But since within the tests, many nested "When" blocks have "BeforeEach" section, when the test fails, ginkgo goes to the next "When" section and executes the "BeforeEach" section there, which leas to a cleanup of different resource, depends on the cleanup steps within specifc section.

That leads to a state, when many gathered logs are empty, since the requested resource already deleted.
That state, makes debugging harded.

Move the logs gathering step to the "JustAfterEach" section. It will capture debug info immediately on test failure (before any cleanup or next BeforeEach runs).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
