### PR TITLE
[release-1.29] Pin helm to 3.21.0

### DIFF
--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -139,9 +139,10 @@ OPERATOR_SDK_LATEST_VERSION=$(getVersionForUpdate operator-framework/operator-sd
 "$SED_CMD" -i "s|OPERATOR_SDK_VERSION ?= .*|OPERATOR_SDK_VERSION ?= ${OPERATOR_SDK_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 find "${ROOTDIR}/chart/templates/olm/scorecard.yaml" -type f -exec "$SED_CMD" -i "s|quay.io/operator-framework/scorecard-test:.*|quay.io/operator-framework/scorecard-test:${OPERATOR_SDK_LATEST_VERSION}|" {} +
 
-# Update helm (FIXME: pinned to v3 as we don't support helm4 yet, see https://github.com/istio-ecosystem/sail-operator/issues/1371)
-HELM_LATEST_VERSION=$(getLatestVersionByPrefix helm/helm v3)
-"$SED_CMD" -i "s|HELM_VERSION ?= .*|HELM_VERSION ?= ${HELM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
+# Update helm
+# Pinned to 3.21.0 to avoid required golang update, see https://github.com/istio-ecosystem/sail-operator/pull/2051
+# HELM_LATEST_VERSION=$(getLatestVersionByPrefix helm/helm v3)
+# "$SED_CMD" -i "s|HELM_VERSION ?= .*|HELM_VERSION ?= ${HELM_LATEST_VERSION}|" "${ROOTDIR}/Makefile.core.mk"
 
 # Update controller-tools
 CONTROLLER_TOOLS_LATEST_VERSION=$(getVersionForUpdate kubernetes-sigs/controller-tools "${CONTROLLER_TOOLS_VERSION}")


### PR DESCRIPTION
This avoids pulling in a new golang version that's required for the new helm version.

Unblocks https://github.com/istio-ecosystem/sail-operator/pull/2051