### PR TITLE
[release-1.30] test(e2e): truncate debug output in JUnit XML to prevent excessive fi…

### DIFF
--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -56,6 +56,10 @@ const (
 const (
 	SleepNamespace   = "sleep"
 	HttpbinNamespace = "httpbin"
+
+	// maxJUnitErrorMessageSize is the maximum size (in bytes) for error messages
+	// written to junit XML files. Messages exceeding this size will be truncated.
+	maxJUnitErrorMessageSize = 10 * 1024 // 10KB
 )
 
 var (
@@ -364,6 +368,22 @@ func logFailedPodsDetails(k kubectl.Kubectl, namespace string, buf *strings.Buil
 	logDebugElement("=====Pod descriptions in "+namespace+"=====", describe, err, buf, printDebug)
 }
 
+// truncateForJUnit truncates strings that exceed maxJUnitErrorMessageSize
+// to prevent junit XML files from becoming excessively large.
+func truncateForJUnit(s string) string {
+	if len(s) <= maxJUnitErrorMessageSize {
+		return s
+	}
+
+	const truncationMsg = "\n\n... [truncated due to size limit] ..."
+	truncateAt := maxJUnitErrorMessageSize - len(truncationMsg)
+	if truncateAt < 0 {
+		truncateAt = 0
+	}
+
+	return s[:truncateAt] + truncationMsg
+}
+
 func logDebugElement(caption string, info string, err error, buf *strings.Builder, printDebug bool) {
 	buf.WriteString("\n" + caption + ":\n")
 	if err != nil {
@@ -375,9 +395,9 @@ func logDebugElement(caption string, info string, err error, buf *strings.Builde
 	if printDebug {
 		GinkgoWriter.Println("\n" + caption + ":")
 		if err != nil {
-			GinkgoWriter.Println(Indent(err.Error()))
+			GinkgoWriter.Println(Indent(truncateForJUnit(err.Error())))
 		} else {
-			GinkgoWriter.Println(Indent(strings.TrimSpace(info)))
+			GinkgoWriter.Println(Indent(truncateForJUnit(strings.TrimSpace(info))))
 		}
 	}
 }


### PR DESCRIPTION
…le sizes (#2054)

Add truncateForJUnit() function to cap debug messages at 10KB when written to JUnit XML via GinkgoWriter. Artifact files still receive full untruncated content.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #2067 

Related Issue/PR #

#### Additional information:
