### PR TITLE
Fix flaky e2e tests across test suites

### DIFF
--- a/.agents/knowledge/domain-knowledge-testing-framework.md
+++ b/.agents/knowledge/domain-knowledge-testing-framework.md
@@ -402,6 +402,74 @@ CONTAINER_CLI=podman TARGET_OS=linux TARGET_ARCH=arm64 make test.e2e.kind
 CONTAINER_CLI=podman DOCKER_GID=0 make test.integration
 ```
 
+### Flaky Test Detection
+
+The test runner passes `GINKGO_FLAGS` verbatim to the `ginkgo` invocation, so all standard Ginkgo stress-test and retry flags work without any additional setup. These are intended for **local use only** — do not add them to CI job definitions.
+
+#### Repeat a suite N times (CI-safe stress test)
+
+Run the full suite up to N additional times or until the first failure. `--repeat=N` runs the suite `1+N` times total.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--repeat=3"
+```
+
+Combine with `--randomize-all` to surface ordering-dependent flakiness:
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--repeat=5 --randomize-all"
+```
+
+#### Loop forever until a failure (local debugging)
+
+Runs indefinitely — useful for catching rare race conditions. Stop with `Ctrl+C` when a failure is detected.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--until-it-fails"
+```
+
+#### Retry flaky specs globally
+
+When a spec fails, Ginkgo retries it up to N times before marking the suite failed. Successful retries are reported but do not fail the run.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--flake-attempts=3"
+```
+
+#### Target a specific test to stress
+
+Combine with `--focus` to isolate a single spec:
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind \
+  GINKGO_FLAGS="--focus='should update istiod deployment' --repeat=10"
+```
+
+#### Per-spec decorators in test code
+
+For specs that are known to be sensitive, you can mark them in the source rather than relying on command-line flags:
+
+```go
+// Require strict N-in-a-row passes (no retries on failure — use for correctness checks)
+It("does not enter an infinite reconcile loop", MustPassRepeatedly(3), func() {
+    // ...
+})
+
+// Accept up to N retries (use sparingly — prefer fixing the root cause)
+It("syncs TLS settings", FlakeAttempts(3), func() {
+    // ...
+})
+```
+
+> **`FlakeAttempts` in `Ordered` containers**: if the failure occurs in a `BeforeAll`, Ginkgo runs `AfterAll` to clean up and then re-runs `BeforeAll`. If it occurs inside an `It`, only that `It` is retried — `BeforeAll` is not re-run. Keep this in mind when using `FlakeAttempts` on specs that depend on `BeforeAll` state.
+
+#### Recommended workflow for investigating a flaky CI result
+
+1. Identify the failing spec from CI output.
+2. Run it locally with `--focus` and `--repeat=10` to reproduce.
+3. If reproduced, add `MustPassRepeatedly` or fix the underlying race.
+4. If not reproduced, try `--until-it-fails` with `--randomize-all` to expose ordering dependencies.
+
 ### Continuous Integration
 Tests run automatically on:
 - **Pull requests** - Unit and integration tests

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -21,7 +21,8 @@ This end-to-end test suite utilizes Ginkgo, a testing framework known for its ex
     1. [Running the test locally](#running-the-test-locally)
     1. [Test Run scenarios while running on OCP](#test-run-scenarios-while-running-on-ocp)
     1. [Settings for end-to-end test execution](#settings-for-end-to-end-test-execution)
-    1. [Customizing the test run](#customizing-the-test-run)    
+    1. [Customizing the test run](#customizing-the-test-run)
+    1. [Detecting and investigating flaky tests](#detecting-and-investigating-flaky-tests)
     1. [Get test definitions for the end-to-end test](#get-test-definitions-for-the-end-to-end-test)
 1. [Contributing](#contributing)
 
@@ -539,6 +540,85 @@ FAIL! -- 81 Passed | 1 Failed | 0 Pending | 0 Skipped
 Ginkgo ran 1 suite in 3m46.401610849s
 Test Suite Failed
 ```
+
+### Detecting and investigating flaky tests
+
+The `GINKGO_FLAGS` variable is passed directly to the Ginkgo runner, so all Ginkgo stress-test and retry flags work without any additional setup. The workflows below are intended for local use when investigating a test that fails intermittently.
+
+#### Repeat a suite N times
+
+Run the full suite (or a focused subset) up to N additional times, stopping at the first failure. Total runs = `1 + N`.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--repeat=3"
+```
+
+Combine with `--randomize-all` to expose ordering-dependent failures:
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--repeat=5 --randomize-all"
+```
+
+#### Loop until a failure occurs
+
+Runs the suite indefinitely until a failure is detected. Stop with `Ctrl+C`. Useful for catching rare race conditions.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--until-it-fails"
+```
+
+#### Retry flaky specs automatically
+
+When a spec fails, Ginkgo retries it up to N times before marking the suite as failed. Retried-but-passing specs are reported but do not fail the run.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--flake-attempts=3"
+```
+
+#### Targeting a specific test
+
+Combine any of the flags above with `--focus` to isolate a single spec:
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind \
+  GINKGO_FLAGS="--focus='should update istiod deployment' --repeat=10"
+```
+
+Or use a label filter to stress a specific feature area:
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind \
+  GINKGO_FLAGS="--label-filter=library --repeat=5"
+```
+
+#### Per-spec decorators in test code
+
+For specs that are known to be sensitive, you can mark them in the source instead of relying on command-line flags.
+
+`MustPassRepeatedly(N)` requires the spec to pass N times in a row with no retries on failure — use this to verify correctness:
+
+```go
+It("does not enter an infinite reconcile loop", MustPassRepeatedly(3), func() {
+    // ...
+})
+```
+
+`FlakeAttempts(N)` retries the spec up to N times on failure — use sparingly and prefer fixing the root cause:
+
+```go
+It("syncs TLS settings", FlakeAttempts(3), func() {
+    // ...
+})
+```
+
+> **Note on `FlakeAttempts` in `Ordered` containers**: if the failure occurs inside an `It`, only that `It` is retried — `BeforeAll` is not re-run. If the failure is in a `BeforeAll`, Ginkgo runs `AfterAll` to clean up and then re-runs `BeforeAll`.
+
+#### Recommended workflow for a flaky CI result
+
+1. Identify the failing spec from the CI output.
+2. Run it locally with `--focus` and `--repeat=10` to reproduce.
+3. If it reproduces, add `MustPassRepeatedly` or fix the underlying race condition.
+4. If it does not reproduce, try `--until-it-fails --randomize-all` to expose ordering dependencies.
 
 ### Get test definitions for the end-to-end test
 

--- a/tests/e2e/ambient/ambient_dependency_test.go
+++ b/tests/e2e/ambient/ambient_dependency_test.go
@@ -327,8 +327,8 @@ spec:
 				When("dependencies are restored", func() {
 					It("should make IstioRevision healthy again", func(ctx SpecContext) {
 						// Wait for all dependencies to become Ready
-						common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key("default"), &v1.IstioCNI{}, k, cl, 60*time.Second)
-						common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl, 60*time.Second)
+						common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key("default"), &v1.IstioCNI{}, k, cl, 2*time.Minute)
+						common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl, 2*time.Minute)
 
 						// Get the active revision name
 						istio := &v1.Istio{}

--- a/tests/e2e/ambient/ambient_update_test.go
+++ b/tests/e2e/ambient/ambient_update_test.go
@@ -167,12 +167,13 @@ spec:
 
 			When("IstioCNI version is updated", func() {
 				BeforeAll(func(ctx SpecContext) {
-					cni := &v1.IstioCNI{}
-					Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
-
 					Log(fmt.Sprintf("Updating IstioCNI from %s to %s", baseVersion.Name, newVersion.Name))
-					cni.Spec.Version = newVersion.Name
-					Expect(cl.Update(ctx, cni)).To(Succeed())
+					Eventually(func(g Gomega) {
+						cni := &v1.IstioCNI{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
+						cni.Spec.Version = newVersion.Name
+						g.Expect(cl.Update(ctx, cni)).To(Succeed())
+					}).Should(Succeed())
 					Success("IstioCNI version updated")
 				})
 
@@ -208,12 +209,13 @@ spec:
 
 			When("ZTunnel version is updated", func() {
 				BeforeAll(func(ctx SpecContext) {
-					ztunnel := &v1.ZTunnel{}
-					Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
-
 					Log(fmt.Sprintf("Updating ZTunnel from %s to %s", baseVersion.Name, newVersion.Name))
-					ztunnel.Spec.Version = newVersion.Name
-					Expect(cl.Update(ctx, ztunnel)).To(Succeed())
+					Eventually(func(g Gomega) {
+						ztunnel := &v1.ZTunnel{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+						ztunnel.Spec.Version = newVersion.Name
+						g.Expect(cl.Update(ctx, ztunnel)).To(Succeed())
+					}).Should(Succeed())
 					Success("ZTunnel version updated")
 				})
 
@@ -253,13 +255,13 @@ spec:
 
 			When("Istio version is updated", func() {
 				BeforeAll(func(ctx SpecContext) {
-					// Update the Istio CR to new version
-					istio := &v1.Istio{}
-					Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
-
 					Log(fmt.Sprintf("Updating Istio from %s to %s", baseVersion.Name, newVersion.Name))
-					istio.Spec.Version = newVersion.Name
-					Expect(cl.Update(ctx, istio)).To(Succeed())
+					Eventually(func(g Gomega) {
+						istio := &v1.Istio{}
+						g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						istio.Spec.Version = newVersion.Name
+						g.Expect(cl.Update(ctx, istio)).To(Succeed())
+					}).Should(Succeed())
 					Success("Istio version updated")
 				})
 

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -221,7 +221,7 @@ spec:
 					Expect(samplePods.Items).ToNot(BeEmpty(), "No pods found in sample namespace")
 
 					for _, pod := range samplePods.Items {
-						cl.Delete(ctx, &pod)
+						Expect(cl.Delete(ctx, &pod)).To(Succeed())
 					}
 
 					Eventually(common.CheckSamplePodsReady).WithArguments(ctx, cl).Should(Succeed(), "Error checking status of sample pods")
@@ -378,7 +378,7 @@ updateStrategy:
 						revisions := &v1.IstioRevisionList{}
 						g.Expect(cl.List(ctx, revisions)).To(Succeed())
 						g.Expect(revisions.Items).To(HaveLen(1), "Should have exactly one IstioRevision")
-					}).WithTimeout(30 * time.Second).Should(Succeed())
+					}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 					Success("Single IstioRevision maintained")
 				})
 
@@ -499,24 +499,26 @@ updateStrategy:
 
 			When("spec.values is updated on Istio CR", func() {
 				It("should update istiod deployment when values change", func(ctx SpecContext) {
-					// Get current Istio CR
-					istio := &v1.Istio{}
-					Expect(cl.Get(ctx, kube.Key("default"), istio)).To(Succeed())
-
-					// Modify spec.values to add a custom env var
-					if istio.Spec.Values == nil {
-						istio.Spec.Values = &v1.Values{}
-					}
-					if istio.Spec.Values.Pilot == nil {
-						istio.Spec.Values.Pilot = &v1.PilotConfig{}
-					}
-					if istio.Spec.Values.Pilot.Env == nil {
-						istio.Spec.Values.Pilot.Env = make(map[string]string)
-					}
-					istio.Spec.Values.Pilot.Env["TEST_VAR"] = "test-value"
-
 					Log("Updating Istio spec.values")
-					Expect(cl.Update(ctx, istio)).To(Succeed())
+					Eventually(func(g Gomega) {
+						// Get current Istio CR fresh on each attempt to avoid 409 Conflict
+						istio := &v1.Istio{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), istio)).To(Succeed())
+
+						// Modify spec.values to add a custom env var
+						if istio.Spec.Values == nil {
+							istio.Spec.Values = &v1.Values{}
+						}
+						if istio.Spec.Values.Pilot == nil {
+							istio.Spec.Values.Pilot = &v1.PilotConfig{}
+						}
+						if istio.Spec.Values.Pilot.Env == nil {
+							istio.Spec.Values.Pilot.Env = make(map[string]string)
+						}
+						istio.Spec.Values.Pilot.Env["TEST_VAR"] = "test-value"
+
+						g.Expect(cl.Update(ctx, istio)).To(Succeed())
+					}).Should(Succeed())
 
 					// Verify the istiod Deployment is updated with the new env var
 					Eventually(func(g Gomega) {

--- a/tests/e2e/library/library_reconcile_test.go
+++ b/tests/e2e/library/library_reconcile_test.go
@@ -18,6 +18,7 @@ package library
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
+	"helm.sh/helm/v4/pkg/storage/driver"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -83,7 +85,14 @@ var _ = Describe("Library Reconciliation", Label("library", "reconciliation"), O
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				Expect(lib.Uninstall(ctx, namespace, revision)).To(Succeed())
+				// lib.Uninstall may race with Helm's internal purge step: after finding
+				// the release, the secret can be deleted concurrently before Helm purges
+				// it, producing a spurious ErrReleaseNotFound. EnsureNamespaceWithCleanup
+				// deletes the namespace afterward regardless, so no state is left behind.
+				// Any other error is unexpected and must be reported.
+				if err := lib.Uninstall(ctx, namespace, revision); err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
+					Expect(err).NotTo(HaveOccurred(), "unexpected error uninstalling Helm chart")
+				}
 				lib.Stop()
 				Success("Cleaned up TLS test")
 			})
@@ -188,7 +197,14 @@ var _ = Describe("Library Reconciliation", Label("library", "reconciliation"), O
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				Expect(lib.Uninstall(ctx, namespace, revision)).To(Succeed())
+				// lib.Uninstall may race with Helm's internal purge step: after finding
+				// the release, the secret can be deleted concurrently before Helm purges
+				// it, producing a spurious ErrReleaseNotFound. EnsureNamespaceWithCleanup
+				// deletes the namespace afterward regardless, so no state is left behind.
+				// Any other error is unexpected and must be reported.
+				if err := lib.Uninstall(ctx, namespace, revision); err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
+					Expect(err).NotTo(HaveOccurred(), "unexpected error uninstalling Helm chart")
+				}
 				lib.Stop()
 				Success("Cleaned up reconcile loop test")
 			})

--- a/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
+++ b/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
@@ -175,7 +175,8 @@ kind: ServiceAccount
 metadata:
   name: istiod-service-account
 `
-						k1.WithNamespace(externalControlPlaneNamespace).CreateFromString(externalSVCAccountYAML)
+						Expect(k1.WithNamespace(externalControlPlaneNamespace).CreateFromString(externalSVCAccountYAML)).To(
+							Succeed(), "Failed to create istiod service account on Cluster #1")
 
 						apiURLCluster2, err := k2.GetClusterAPIURL()
 						Expect(apiURLCluster2).NotTo(BeEmpty(), "API URL is empty for the Cluster #2")

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -167,13 +167,15 @@ values:
 						Expect(RemoteClusterAPIURL).NotTo(BeEmpty(), "API URL is empty for Remote Cluster")
 						Expect(err).NotTo(HaveOccurred())
 
-						// Wait for the remote Istio CR to be created, this can be moved to a condition verification, but the resource it not will be Ready at this point
-						time.Sleep(5 * time.Second)
-
 						// Install a remote secret in Primary cluster that provides access to the Remote cluster API server.
+						// Wrap in Eventually: CreateRemoteSecret may fail until the remote Istio service account is provisioned.
 						By("Creating Remote Secret on Primary Cluster")
-						secret, err := istioctl.CreateRemoteSecret(kubeconfig2, controlPlaneNamespace, "remote", RemoteClusterAPIURL)
-						Expect(err).NotTo(HaveOccurred())
+						var secret string
+						Eventually(func() error {
+							var err error
+							secret, err = istioctl.CreateRemoteSecret(kubeconfig2, controlPlaneNamespace, "remote", RemoteClusterAPIURL)
+							return err
+						}).ShouldNot(HaveOccurred(), "Remote secret generation failed")
 						Expect(k1.WithNamespace(controlPlaneNamespace).ApplyString(secret)).To(Succeed(), "Remote secret creation failed on Primary Cluster")
 					})
 

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -429,7 +429,8 @@ spec:
 				g.Expect(rev.Spec.Values.Pilot.ExtraContainerArgs).To(
 					ContainElement(ContainSubstring("--tls-cipher-suites=")),
 					"IstioRevision should have --tls-cipher-suites in pilot.extraContainerArgs")
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed(), "IstioRevision is not syncing TLS settings but should be")
+			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed(),
+				"IstioRevision is not syncing TLS settings but should be")
 
 			Step("Verifying metrics endpoint accepts the custom cipher")
 			Eventually(func() bool {

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -429,7 +429,7 @@ spec:
 				g.Expect(rev.Spec.Values.Pilot.ExtraContainerArgs).To(
 					ContainElement(ContainSubstring("--tls-cipher-suites=")),
 					"IstioRevision should have --tls-cipher-suites in pilot.extraContainerArgs")
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed(),
+			}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
 				"IstioRevision is not syncing TLS settings but should be")
 
 			Step("Verifying metrics endpoint accepts the custom cipher")

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -328,17 +328,17 @@ spec:
 
 			DeferCleanup(func(ctx SpecContext) {
 				Step("Restoring the original APIServer TLS settings")
-				apiServer := &configv1.APIServer{}
-				err := cl.Get(ctx, apiServerKey, apiServer)
-				Expect(err).NotTo(HaveOccurred(), "Failed to get APIServer")
-				apiServer.Spec.TLSSecurityProfile = originalTLSProfile
-				// TLSAdherence cannot be set back to NoOpinion once set,
-				// so only restore it if the original was a non-empty value.
-				if originalTLSAdherence != configv1.TLSAdherencePolicyNoOpinion {
-					apiServer.Spec.TLSAdherence = originalTLSAdherence
-				}
-				err = cl.Update(ctx, apiServer)
-				Expect(err).NotTo(HaveOccurred(), "Failed to update APIServer TLS settings")
+				Eventually(func(g Gomega) {
+					apiServer := &configv1.APIServer{}
+					g.Expect(cl.Get(ctx, apiServerKey, apiServer)).To(Succeed(), "Failed to get APIServer")
+					apiServer.Spec.TLSSecurityProfile = originalTLSProfile
+					// TLSAdherence cannot be set back to NoOpinion once set,
+					// so only restore it if the original was a non-empty value.
+					if originalTLSAdherence != configv1.TLSAdherencePolicyNoOpinion {
+						apiServer.Spec.TLSAdherence = originalTLSAdherence
+					}
+					g.Expect(cl.Update(ctx, apiServer)).To(Succeed(), "Failed to update APIServer TLS settings")
+				}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 			})
 
 			Step("Creating Istio")
@@ -429,7 +429,7 @@ spec:
 				g.Expect(rev.Spec.Values.Pilot.ExtraContainerArgs).To(
 					ContainElement(ContainSubstring("--tls-cipher-suites=")),
 					"IstioRevision should have --tls-cipher-suites in pilot.extraContainerArgs")
-			}).Should(Succeed(), "IstioRevision is not syncing TLS settings but should be")
+			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed(), "IstioRevision is not syncing TLS settings but should be")
 
 			Step("Verifying metrics endpoint accepts the custom cipher")
 			Eventually(func() bool {

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -185,6 +185,17 @@ func (k Kubectl) Delete(kind, name string) error {
 	return nil
 }
 
+// DeleteIgnoreNotFound deletes a resource and succeeds if the resource does not exist.
+// Use this in teardown blocks where the resource may not have been created due to an earlier failure.
+func (k Kubectl) DeleteIgnoreNotFound(kind, name string) error {
+	cmd := k.build(" delete " + kind + " " + name + " --ignore-not-found=true")
+	_, err := k.executeCommand(cmd)
+	if err != nil {
+		return fmt.Errorf("error deleting resource: %w", err)
+	}
+	return nil
+}
+
 // Patch patches a resource
 func (k Kubectl) Patch(kind, name, patchType, patch string) error {
 	cmd := k.build(fmt.Sprintf(" patch %s %s --type=%s -p=%q", kind, name, patchType, patch))


### PR DESCRIPTION
Fix a set of flaky e2e test failures identified across multiple test suites.

- **library**: `DeferCleanup` called `Expect(lib.Uninstall(...)).To(Succeed())` unconditionally; Helm can race between finding and purging the release secret, producing a spurious `ErrReleaseNotFound`. Only that specific error is now ignored — any other uninstall error is still reported.
- **operator**: APIServer restore in `DeferCleanup` used bare `Get`+`Update` with no retry, failing on HTTP 409 when the apiserver is rolling out. Wrapped in `Eventually`. Also extended the TLS cipher sync timeout from 3 to 5 minutes for slow OCP 4.22+ rollouts.
- **ambient**: Three `BeforeAll` blocks updating IstioCNI, ZTunnel and Istio version used bare `Get`+`Update` with no conflict retry. Wrapped each in `Eventually`. Also increased a post-DaemonSet-restore `AwaitCondition` timeout from 60s to 2 minutes.
- **controlplane**: Same bare `Get`+`Update` pattern in an `It` block, a silently discarded `cl.Delete` return value in a pod restart loop, and a `Consistently` window too narrow (30s → 60s with 5s polling) after a version patch.
- **multicluster**: Replaced `time.Sleep(5s)` before `CreateRemoteSecret` with an `Eventually` wrapper, and added a missing `Expect` on a `CreateFromString` call whose error was silently dropped.
- **util/kubectl**: Added `DeleteIgnoreNotFound` method for teardown blocks where a resource may not exist due to an earlier failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)