### PR TITLE
fix(e2e): add multicluster skip to gateway controller tests

### DIFF
--- a/tests/e2e/gatewaycontroller/gateway_controller_suite_test.go
+++ b/tests/e2e/gatewaycontroller/gateway_controller_suite_test.go
@@ -43,6 +43,7 @@ var (
 	istioCniNamespace     = common.IstioCniNamespace
 	keepOnFailure         = env.GetBool("KEEP_ON_FAILURE", false)
 	artifactsDir          = env.Get("ARTIFACTS", "/tmp/artifacts")
+	multicluster          = env.GetBool("MULTICLUSTER", false)
 
 	k kubectl.Kubectl
 )
@@ -57,6 +58,10 @@ const (
 )
 
 func TestGatewayController(t *testing.T) {
+	if multicluster {
+		t.Skip("Skipping Gateway Controller tests")
+	}
+
 	RegisterFailHandler(Fail)
 	setup()
 	RunSpecs(t, "Gateway Controller Test Suite")


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

Gateway controller tests are single-cluster only and should skip when MULTICLUSTER=true, consistent with all other single-cluster test suites (library, cert-manager, ztwim, ambient, etc.).

The tests deploy and test gateway controller functionality using the install library on a single cluster with multiple namespaces, and do not require or use multicluster features

#### Need cherry-pick to:

**- release-1.30**