### PR TITLE
Fix update-deps failure caused by new upstream LabelSelector field

### DIFF
--- a/hack/api_transformer/transform.yaml
+++ b/hack/api_transformer/transform.yaml
@@ -179,6 +179,7 @@ inputFiles:
       MeshConfig_OutboundTrafficPolicy.Tls: "*ClientTLSSettings"
       MeshConfig_ServiceScopeConfigs.NamespaceSelector: "*metav1.LabelSelector"
       MeshConfig_ServiceScopeConfigs.ServicesSelector: "*metav1.LabelSelector"
+      ServiceEntryVisibility_MatchRule_NamespaceSelector.NamespaceSelector: "*metav1.LabelSelector"
     removeTypes:
     - LabelSelector
     - LabelSelectorRequirement


### PR DESCRIPTION
A recent change in istio.io/api added the `ServiceEntryVisibility` feature to config.pb.go, introducing a new NamespaceSelector field of type *LabelSelector.

Our transformer removes the generated `LabelSelector` type and rewrites known references to use `metav1.LabelSelector` instead. Since this new field wasn't included in the replaceFieldTypes, it remained as `*LabelSelector`, causing controller-gen to fail with an "unknown type LabelSelector" error during CRD generation.
