### PR TITLE
[release-1.30] test: organization of labels used on e2e test

### DIFF
--- a/.agents/knowledge/domain-knowledge-testing-framework.md
+++ b/.agents/knowledge/domain-knowledge-testing-framework.md
@@ -402,6 +402,74 @@ CONTAINER_CLI=podman TARGET_OS=linux TARGET_ARCH=arm64 make test.e2e.kind
 CONTAINER_CLI=podman DOCKER_GID=0 make test.integration
 ```
 
+### Flaky Test Detection
+
+The test runner passes `GINKGO_FLAGS` verbatim to the `ginkgo` invocation, so all standard Ginkgo stress-test and retry flags work without any additional setup. These are intended for **local use only** — do not add them to CI job definitions.
+
+#### Repeat a suite N times (CI-safe stress test)
+
+Run the full suite up to N additional times or until the first failure. `--repeat=N` runs the suite `1+N` times total.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--repeat=3"
+```
+
+Combine with `--randomize-all` to surface ordering-dependent flakiness:
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--repeat=5 --randomize-all"
+```
+
+#### Loop forever until a failure (local debugging)
+
+Runs indefinitely — useful for catching rare race conditions. Stop with `Ctrl+C` when a failure is detected.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--until-it-fails"
+```
+
+#### Retry flaky specs globally
+
+When a spec fails, Ginkgo retries it up to N times before marking the suite failed. Successful retries are reported but do not fail the run.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--flake-attempts=3"
+```
+
+#### Target a specific test to stress
+
+Combine with `--focus` to isolate a single spec:
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind \
+  GINKGO_FLAGS="--focus='should update istiod deployment' --repeat=10"
+```
+
+#### Per-spec decorators in test code
+
+For specs that are known to be sensitive, you can mark them in the source rather than relying on command-line flags:
+
+```go
+// Require strict N-in-a-row passes (no retries on failure — use for correctness checks)
+It("does not enter an infinite reconcile loop", MustPassRepeatedly(3), func() {
+    // ...
+})
+
+// Accept up to N retries (use sparingly — prefer fixing the root cause)
+It("syncs TLS settings", FlakeAttempts(3), func() {
+    // ...
+})
+```
+
+> **`FlakeAttempts` in `Ordered` containers**: if the failure occurs in a `BeforeAll`, Ginkgo runs `AfterAll` to clean up and then re-runs `BeforeAll`. If it occurs inside an `It`, only that `It` is retried — `BeforeAll` is not re-run. Keep this in mind when using `FlakeAttempts` on specs that depend on `BeforeAll` state.
+
+#### Recommended workflow for investigating a flaky CI result
+
+1. Identify the failing spec from CI output.
+2. Run it locally with `--focus` and `--repeat=10` to reproduce.
+3. If reproduced, add `MustPassRepeatedly` or fix the underlying race.
+4. If not reproduced, try `--until-it-fails` with `--randomize-all` to expose ordering dependencies.
+
 ### Continuous Integration
 Tests run automatically on:
 - **Pull requests** - Unit and integration tests

--- a/pkg/istioversion/version.go
+++ b/pkg/istioversion/version.go
@@ -227,3 +227,24 @@ func GetTwoConsecutiveMinorVersions(minVersion *semver.Version) (baseVer, newVer
 	// filtered[1] = second newest (previous minor)
 	return filtered[1], filtered[0], nil
 }
+
+// GetLatestAmbientVersion returns the latest supported version for ambient mode
+// Ambient mode requires Istio 1.24+, and FIPS clusters require 1.28+
+func GetLatestAmbientVersion() VersionInfo {
+	versions := GetLatestPatchVersions()
+	fipsCluster := env.GetBool("FIPS_CLUSTER", false)
+
+	for _, version := range versions {
+		// Minimum supported version is 1.24
+		if version.Version.LessThan(semver.MustParse("1.24.0")) {
+			continue
+		}
+		// FIPS clusters require v1.28+
+		if fipsCluster && version.Version.LessThan(semver.MustParse("1.28.0")) {
+			continue
+		}
+		return version
+	}
+	// Fallback to the last version if no suitable version found
+	return versions[len(versions)-1]
+}

--- a/pkg/istioversion/version.go
+++ b/pkg/istioversion/version.go
@@ -203,3 +203,27 @@ func GetLatestPatchVersions() []VersionInfo {
 
 	return latestSlice
 }
+
+// GetTwoConsecutiveMinorVersions returns two consecutive minor versions (with their latest patches)
+// that are greater than or equal to the specified minimum version.
+// Returns the base (older) and new (newer) versions suitable for upgrade testing.
+func GetTwoConsecutiveMinorVersions(minVersion *semver.Version) (baseVer, newVer VersionInfo, err error) {
+	allLatestPatches := GetLatestPatchVersions()
+
+	// Filter: only keep versions >= minVersion
+	var filtered []VersionInfo
+	for _, v := range allLatestPatches {
+		if !v.Version.LessThan(minVersion) {
+			filtered = append(filtered, v)
+		}
+	}
+
+	if len(filtered) < 2 {
+		return baseVer, newVer, fmt.Errorf("insufficient versions available (need 2, found %d)", len(filtered))
+	}
+
+	// GetLatestPatchVersions() returns versions sorted descending, so:
+	// filtered[0] = newest version
+	// filtered[1] = second newest (previous minor)
+	return filtered[1], filtered[0], nil
+}

--- a/pkg/istioversion/version_test.go
+++ b/pkg/istioversion/version_test.go
@@ -216,3 +216,166 @@ func TestGetLatestPatchVersions_Valid(t *testing.T) {
 		assert.Len(t, versions, 0)
 	})
 }
+
+func TestGetTwoConsecutiveMinorVersions(t *testing.T) {
+	t.Run("valid consecutive versions", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.24.2", Version: semver.MustParse("1.24.2")},
+			{Name: "v1.24.1", Version: semver.MustParse("1.24.1")},
+			{Name: "v1.23.5", Version: semver.MustParse("1.23.5")},
+			{Name: "v1.23.4", Version: semver.MustParse("1.23.4")},
+		}
+
+		baseVer, newVer, err := GetTwoConsecutiveMinorVersions(semver.MustParse("1.23.0"))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "v1.24.2", baseVer.Name)
+		assert.Equal(t, "v1.25.0", newVer.Name)
+	})
+
+	t.Run("min version filters out older versions", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.24.2", Version: semver.MustParse("1.24.2")},
+			{Name: "v1.23.5", Version: semver.MustParse("1.23.5")},
+			{Name: "v1.22.0", Version: semver.MustParse("1.22.0")},
+		}
+
+		baseVer, newVer, err := GetTwoConsecutiveMinorVersions(semver.MustParse("1.24.0"))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "v1.24.2", baseVer.Name)
+		assert.Equal(t, "v1.25.0", newVer.Name)
+	})
+
+	t.Run("insufficient versions returns error", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.24.2", Version: semver.MustParse("1.24.2")},
+		}
+
+		_, _, err := GetTwoConsecutiveMinorVersions(semver.MustParse("1.25.0"))
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "insufficient versions available")
+	})
+
+	t.Run("empty list returns error", func(t *testing.T) {
+		List = []VersionInfo{}
+
+		_, _, err := GetTwoConsecutiveMinorVersions(semver.MustParse("1.23.0"))
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "insufficient versions available")
+	})
+
+	t.Run("only one version returns error", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.25.1", Version: semver.MustParse("1.25.1")},
+		}
+
+		_, _, err := GetTwoConsecutiveMinorVersions(semver.MustParse("1.24.0"))
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "insufficient versions available")
+	})
+}
+
+func TestGetLatestAmbientVersion(t *testing.T) {
+	t.Run("returns latest version >= 1.24", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.26.0", Version: semver.MustParse("1.26.0")},
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.24.2", Version: semver.MustParse("1.24.2")},
+			{Name: "v1.23.5", Version: semver.MustParse("1.23.5")},
+		}
+		t.Setenv("FIPS_CLUSTER", "false")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.26.0", version.Name)
+	})
+
+	t.Run("skips versions < 1.24", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+			{Name: "v1.23.5", Version: semver.MustParse("1.23.5")},
+			{Name: "v1.22.0", Version: semver.MustParse("1.22.0")},
+		}
+		t.Setenv("FIPS_CLUSTER", "false")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.25.0", version.Name)
+	})
+
+	t.Run("FIPS cluster requires >= 1.28", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.29.0", Version: semver.MustParse("1.29.0")},
+			{Name: "v1.28.2", Version: semver.MustParse("1.28.2")},
+			{Name: "v1.27.5", Version: semver.MustParse("1.27.5")},
+			{Name: "v1.26.0", Version: semver.MustParse("1.26.0")},
+		}
+		t.Setenv("FIPS_CLUSTER", "true")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.29.0", version.Name)
+	})
+
+	t.Run("FIPS cluster skips versions < 1.28", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.28.0", Version: semver.MustParse("1.28.0")},
+			{Name: "v1.27.5", Version: semver.MustParse("1.27.5")},
+			{Name: "v1.26.0", Version: semver.MustParse("1.26.0")},
+		}
+		t.Setenv("FIPS_CLUSTER", "true")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.28.0", version.Name)
+	})
+
+	t.Run("returns last version when all < 1.24", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.23.5", Version: semver.MustParse("1.23.5")},
+			{Name: "v1.22.0", Version: semver.MustParse("1.22.0")},
+			{Name: "v1.21.0", Version: semver.MustParse("1.21.0")},
+		}
+		t.Setenv("FIPS_CLUSTER", "false")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.21.0", version.Name)
+	})
+
+	t.Run("FIPS returns last version when all < 1.28", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.27.5", Version: semver.MustParse("1.27.5")},
+			{Name: "v1.26.0", Version: semver.MustParse("1.26.0")},
+			{Name: "v1.25.0", Version: semver.MustParse("1.25.0")},
+		}
+		t.Setenv("FIPS_CLUSTER", "true")
+
+		version := GetLatestAmbientVersion()
+
+		assert.Equal(t, "v1.25.0", version.Name)
+	})
+
+	t.Run("handles multiple patch versions", func(t *testing.T) {
+		List = []VersionInfo{
+			{Name: "v1.25.3", Version: semver.MustParse("1.25.3")},
+			{Name: "v1.25.2", Version: semver.MustParse("1.25.2")},
+			{Name: "v1.24.5", Version: semver.MustParse("1.24.5")},
+			{Name: "v1.24.4", Version: semver.MustParse("1.24.4")},
+		}
+		t.Setenv("FIPS_CLUSTER", "false")
+
+		version := GetLatestAmbientVersion()
+
+		// Should return latest patch of latest minor version
+		assert.Equal(t, "v1.25.3", version.Name)
+	})
+}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,6 +11,10 @@ This end-to-end test suite utilizes Ginkgo, a testing framework known for its ex
     1. [Adding a Test Suite](#adding-a-test-suite)
     1. [Sub-Tests](#sub-tests)
     1. [Best practices](#best-practices)
+1. [Test Labels](#test-labels)
+    1. [Label Structure](#label-structure)
+    1. [Label Reference](#label-reference)
+    1. [Common Filter Examples](#common-filter-examples)
 1. [Running Tests](#running-the-tests)
     1. [Pre-requisites](#pre-requisites)
     1. [How to Run the test](#how-to-run-the-test)
@@ -193,6 +197,115 @@ var _ = Describe("Testing with cleanup", Ordered, func() {
 ```
     * You can use multiple cleaners, each with its own state. This is useful if the test does some global set up, e.g. sets up the operator, and then specific tests create further resources which you want cleaned.
     * To clean resources without waiting, and waiting for them later, use `CleanupNoWait` followed by `WaitForDeletion`. This is particularly useful when working with more than one cluster.
+
+## Test Labels
+
+Tests are labeled using Ginkgo's `Label()` function so that CI pipelines and developers can filter exactly the tests they want to run. Labels are passed via the `--label-filter` flag in `GINKGO_FLAGS`.
+
+### Label Structure
+
+Labels follow a multi-dimensional structure. Each test file carries one label from each applicable dimension.
+
+**Scope / Duration** — `smoke` or `slow` (never both; absence means normal duration)
+
+| Label | Meaning |
+|-------|---------|
+| `smoke` | Fast, critical-path tests for basic operator functionality. Only `operator` tests currently. |
+| `slow` | Tests that deploy full control planes, run traffic, or perform upgrade procedures. Expect longer execution times. |
+
+**Feature Area** — primary label, one per file
+
+| Label | Tests |
+|-------|-------|
+| `operator` | Operator deployment, CRDs, metrics endpoint |
+| `control-plane` | Istio/IstioRevision/IstioCNI lifecycle, defaulting, status |
+| `ambient` | Ambient mode (IstioCNI + ZTunnel + Istio ambient profile) |
+| `library` | Sail install library (reconciliation, CRD ownership) |
+| `dualstack` | Dual-stack networking |
+| `gateway-controller` | Gateway API controller via install library |
+| `multicluster` | Multi-cluster deployments |
+| `multi-control-plane` | Multiple Istio CRs in a single cluster |
+| `migration` | Sidecar-to-ambient migration procedures |
+
+**Sub-feature** — optional, for finer filtering within a feature area
+
+| Label | Tests |
+|-------|-------|
+| `ambient-dependency` | Dependency detection and health propagation |
+| `ambient-targetref` | ZTunnel value propagation via targetRef |
+| `ambient-validation` | API validation (CR naming enforcement) |
+| `reconciliation` | Library reconciliation loop behavior |
+| `crd-ownership` | CRD ownership and OLM coexistence |
+| `multicluster-multiprimary` | Multi-primary multi-network topology |
+| `multicluster-primaryremote` | Primary-remote multi-network topology |
+| `multicluster-external` | External control plane topology |
+| `migration-procedure` | Full sidecar-to-ambient migration procedure |
+| `migration-coexistence` | Sidecar/ambient coexistence during migration |
+| `update` | Version upgrade and in-place update tests |
+| `tls-profile` | OpenShift TLS profile syncing (operator metrics + IstioRevision) |
+
+**Dataplane Mode** — additive, marks tests that exercise a specific dataplane
+
+| Label | Tests |
+|-------|-------|
+| `sidecar` | Tests that validate sidecar injection mode |
+
+### Label Reference
+
+Complete label set per test file:
+
+| File | Labels |
+|------|--------|
+| `operator/operator_install_test.go` | `smoke`, `operator` |
+| `operator/operator_install_test.go` (TLS sub-describe) | `smoke`, `operator`, `tls-profile` |
+| `controlplane/control_plane_test.go` | `control-plane`, `slow`, `sidecar` |
+| `controlplane/control_plane_update_test.go` | `control-plane`, `update`, `slow`, `sidecar` |
+| `ambient/ambient_test.go` | `ambient`, `slow` |
+| `ambient/ambient_dependency_test.go` | `ambient`, `ambient-dependency` |
+| `ambient/ambient_targetref_test.go` | `ambient`, `ambient-targetref` |
+| `ambient/ambient_update_test.go` | `ambient`, `update`, `slow` |
+| `ambient/ambient_validation_test.go` | `ambient`, `ambient-validation` |
+| `library/library_reconcile_test.go` | `library`, `reconciliation` |
+| `library/library_crd_ownership_test.go` | `library`, `crd-ownership` |
+| `dualstack/dualstack_test.go` | `dualstack`, `slow`, `sidecar` |
+| `gatewaycontroller/gateway_controller_test.go` | `gateway-controller`, `slow` |
+| `multicluster/multicluster_multiprimary_test.go` | `multicluster`, `multicluster-multiprimary`, `slow` |
+| `multicluster/multicluster_primaryremote_test.go` | `multicluster`, `multicluster-primaryremote`, `slow`, `sidecar` |
+| `multicluster/multicluster_externalcontrolplane_test.go` | `multicluster`, `multicluster-external`, `slow`, `sidecar` |
+| `multicontrolplane/multi_control_plane_test.go` | `multi-control-plane`, `slow`, `sidecar` |
+| `migration/migration_procedure_test.go` | `migration`, `migration-procedure`, `slow` |
+| `migration/migration_coexistence_test.go` | `migration`, `migration-coexistence`, `slow` |
+
+### Common Filter Examples
+
+```bash
+# Only the smoke suite (operator install checks)
+GINKGO_FLAGS="--label-filter=smoke" make test.e2e.kind
+
+# All ambient tests
+GINKGO_FLAGS="--label-filter=ambient" make test.e2e.kind
+
+# All tests except slow ones (fast feedback loop)
+GINKGO_FLAGS="--label-filter=!slow" make test.e2e.kind
+
+# All sidecar-mode tests
+GINKGO_FLAGS="--label-filter=sidecar" make test.e2e.kind
+
+# All library tests (reconciliation + CRD ownership)
+GINKGO_FLAGS="--label-filter=library" make test.e2e.kind
+
+# All multicluster tests
+GINKGO_FLAGS="--label-filter=multicluster" make test.e2e.kind
+
+# Smoke suite without OpenShift-specific TLS tests
+GINKGO_FLAGS="--label-filter=smoke && !tls-profile" make test.e2e.kind
+
+# All control plane tests except version update tests
+GINKGO_FLAGS="--label-filter=control-plane && !update" make test.e2e.kind
+
+# Run a specific sub-feature
+GINKGO_FLAGS="--label-filter=ambient-targetref" make test.e2e.kind
+```
 
 ## Running the tests
 The end-to-end test can be run in two different environments: OCP (OpenShift Container Platform) and KinD (Kubernetes in Docker).

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -21,7 +21,8 @@ This end-to-end test suite utilizes Ginkgo, a testing framework known for its ex
     1. [Running the test locally](#running-the-test-locally)
     1. [Test Run scenarios while running on OCP](#test-run-scenarios-while-running-on-ocp)
     1. [Settings for end-to-end test execution](#settings-for-end-to-end-test-execution)
-    1. [Customizing the test run](#customizing-the-test-run)    
+    1. [Customizing the test run](#customizing-the-test-run)
+    1. [Detecting and investigating flaky tests](#detecting-and-investigating-flaky-tests)
     1. [Get test definitions for the end-to-end test](#get-test-definitions-for-the-end-to-end-test)
 1. [Contributing](#contributing)
 
@@ -539,6 +540,85 @@ FAIL! -- 81 Passed | 1 Failed | 0 Pending | 0 Skipped
 Ginkgo ran 1 suite in 3m46.401610849s
 Test Suite Failed
 ```
+
+### Detecting and investigating flaky tests
+
+The `GINKGO_FLAGS` variable is passed directly to the Ginkgo runner, so all Ginkgo stress-test and retry flags work without any additional setup. The workflows below are intended for local use when investigating a test that fails intermittently.
+
+#### Repeat a suite N times
+
+Run the full suite (or a focused subset) up to N additional times, stopping at the first failure. Total runs = `1 + N`.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--repeat=3"
+```
+
+Combine with `--randomize-all` to expose ordering-dependent failures:
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--repeat=5 --randomize-all"
+```
+
+#### Loop until a failure occurs
+
+Runs the suite indefinitely until a failure is detected. Stop with `Ctrl+C`. Useful for catching rare race conditions.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--until-it-fails"
+```
+
+#### Retry flaky specs automatically
+
+When a spec fails, Ginkgo retries it up to N times before marking the suite as failed. Retried-but-passing specs are reported but do not fail the run.
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind GINKGO_FLAGS="--flake-attempts=3"
+```
+
+#### Targeting a specific test
+
+Combine any of the flags above with `--focus` to isolate a single spec:
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind \
+  GINKGO_FLAGS="--focus='should update istiod deployment' --repeat=10"
+```
+
+Or use a label filter to stress a specific feature area:
+
+```bash
+SKIP_BUILD=true SKIP_DEPLOY=true make test.e2e.kind \
+  GINKGO_FLAGS="--label-filter=library --repeat=5"
+```
+
+#### Per-spec decorators in test code
+
+For specs that are known to be sensitive, you can mark them in the source instead of relying on command-line flags.
+
+`MustPassRepeatedly(N)` requires the spec to pass N times in a row with no retries on failure — use this to verify correctness:
+
+```go
+It("does not enter an infinite reconcile loop", MustPassRepeatedly(3), func() {
+    // ...
+})
+```
+
+`FlakeAttempts(N)` retries the spec up to N times on failure — use sparingly and prefer fixing the root cause:
+
+```go
+It("syncs TLS settings", FlakeAttempts(3), func() {
+    // ...
+})
+```
+
+> **Note on `FlakeAttempts` in `Ordered` containers**: if the failure occurs inside an `It`, only that `It` is retried — `BeforeAll` is not re-run. If the failure is in a `BeforeAll`, Ginkgo runs `AfterAll` to clean up and then re-runs `BeforeAll`.
+
+#### Recommended workflow for a flaky CI result
+
+1. Identify the failing spec from the CI output.
+2. Run it locally with `--focus` and `--repeat=10` to reproduce.
+3. If it reproduces, add `MustPassRepeatedly` or fix the underlying race condition.
+4. If it does not reproduce, try `--until-it-fails --randomize-all` to expose ordering dependencies.
 
 ### Get test definitions for the end-to-end test
 

--- a/tests/e2e/ambient/ambient_dependency_test.go
+++ b/tests/e2e/ambient/ambient_dependency_test.go
@@ -1,0 +1,357 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
+	"github.com/istio-ecosystem/sail-operator/pkg/kube"
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Ambient Dependency Management", Label("ambient", "ambient-dependency", "smoke"), Ordered, func() {
+	SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	Describe("Dependency Detection and Health Propagation", func() {
+		for _, version := range istioversion.GetLatestPatchVersions() {
+			// The minimum supported version for ambient is 1.24 (and above)
+			if version.Version.LessThan(semver.MustParse("1.24.0")) {
+				continue
+			}
+
+			// FIPS clusters do not support ambient mode for versions below 1.28
+			if fipsCluster && version.Version.LessThan(semver.MustParse("1.28.0")) {
+				continue
+			}
+
+			Context(fmt.Sprintf("Istio version %s", version.Version), func() {
+				clr := cleaner.New(cl)
+
+				BeforeAll(func(ctx SpecContext) {
+					clr.Record(ctx)
+					Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
+					Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
+					Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+				})
+
+				When("IstioRevision with ambient profile is created before IstioCNI exists", func() {
+					BeforeAll(func() {
+						// Create IstioRevision with ambient profile (depends on IstioCNI)
+						istioYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: %s
+spec:
+  version: %s
+  namespace: %s
+  values:
+    profile: ambient
+    pilot:
+      cni:
+        enabled: true
+      trustedZtunnelNamespace: ztunnel`, istioName, version.Name, controlPlaneNamespace)
+						Log("Creating Istio CR with ambient profile before IstioCNI exists:", istioYAML)
+						Expect(k.CreateFromString(istioYAML)).To(Succeed())
+						Success("Istio CR created")
+					})
+
+					It("should show IstioCNINotFound reason in DependenciesHealthy condition", func(ctx SpecContext) {
+						// Wait for the IstioRevision to be created (Istio creates a revision)
+						Eventually(func(g Gomega) {
+							istio := &v1.Istio{}
+							g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+							g.Expect(istio.Status.ActiveRevisionName).NotTo(BeEmpty(), "Active revision not set yet")
+						}).Should(Succeed(), "Waiting for Istio to create active revision")
+
+						// Get the active revision name
+						istio := &v1.Istio{}
+						Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						revisionName := istio.Status.ActiveRevisionName
+
+						// Check that DependenciesHealthy condition shows IstioCNINotFound
+						Eventually(func(g Gomega) {
+							revision := &v1.IstioRevision{}
+							g.Expect(cl.Get(ctx, kube.Key(revisionName, controlPlaneNamespace), revision)).To(Succeed())
+							g.Expect(revision).To(HaveConditionStatus(v1.IstioRevisionConditionDependenciesHealthy, metav1.ConditionFalse))
+
+							// Check the reason is IstioCNINotFound
+							for _, cond := range revision.Status.Conditions {
+								if cond.Type == v1.IstioRevisionConditionDependenciesHealthy {
+									g.Expect(cond.Reason).To(Equal(v1.IstioRevisionReasonIstioCNINotFound),
+										fmt.Sprintf("Expected reason IstioCNINotFound, got: %s", cond.Reason))
+									break
+								}
+							}
+						}).Should(Succeed(), "IstioRevision should show IstioCNINotFound")
+						Success("IstioRevision correctly shows IstioCNINotFound")
+					})
+				})
+
+				When("IstioCNI is created", func() {
+					BeforeAll(func() {
+						cniYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s
+  profile: ambient`, version.Name, istioCniNamespace)
+						Log("Creating IstioCNI CR:", cniYAML)
+						Expect(k.CreateFromString(cniYAML)).To(Succeed())
+						Success("IstioCNI created")
+					})
+
+					It("should transition from IstioCNINotFound to ZTunnelNotFound", func(ctx SpecContext) {
+						// Wait for IstioCNI to be Ready
+						common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key("default"), &v1.IstioCNI{}, k, cl)
+
+						// Get the active revision name
+						istio := &v1.Istio{}
+						Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						revisionName := istio.Status.ActiveRevisionName
+
+						// Now check that IstioRevision shows ZTunnelNotFound (next missing dependency)
+						Eventually(func(g Gomega) {
+							revision := &v1.IstioRevision{}
+							g.Expect(cl.Get(ctx, kube.Key(revisionName, controlPlaneNamespace), revision)).To(Succeed())
+							g.Expect(revision).To(HaveConditionStatus(v1.IstioRevisionConditionDependenciesHealthy, metav1.ConditionFalse))
+
+							// Check the reason is ZTunnelNotFound
+							for _, cond := range revision.Status.Conditions {
+								if cond.Type == v1.IstioRevisionConditionDependenciesHealthy {
+									g.Expect(cond.Reason).To(Equal(v1.IstioRevisionReasonZTunnelNotFound),
+										fmt.Sprintf("Expected reason ZTunnelNotFound, got: %s", cond.Reason))
+									break
+								}
+							}
+						}).Should(Succeed(), "IstioRevision should show ZTunnelNotFound")
+						Success("IstioRevision correctly transitioned to ZTunnelNotFound")
+					})
+				})
+
+				When("ZTunnel is created", func() {
+					BeforeAll(func() {
+						ztunnelYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s`, version.Name, ztunnelNamespace)
+						Log("Creating ZTunnel CR:", ztunnelYAML)
+						Expect(k.CreateFromString(ztunnelYAML)).To(Succeed())
+						Success("ZTunnel created")
+					})
+
+					It("should make DependenciesHealthy condition True", func(ctx SpecContext) {
+						// Wait for ZTunnel to be Ready
+						common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl)
+
+						// Get the active revision name
+						istio := &v1.Istio{}
+						Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						revisionName := istio.Status.ActiveRevisionName
+
+						// Now check that IstioRevision shows DependenciesHealthy = True
+						Eventually(func(g Gomega) {
+							revision := &v1.IstioRevision{}
+							g.Expect(cl.Get(ctx, kube.Key(revisionName, controlPlaneNamespace), revision)).To(Succeed())
+							g.Expect(revision).To(HaveConditionStatus(v1.IstioRevisionConditionDependenciesHealthy, metav1.ConditionTrue))
+						}).Should(Succeed(), "IstioRevision should have DependenciesHealthy=True")
+						Success("All dependencies are healthy")
+					})
+
+					It("should make IstioRevision Ready", func(ctx SpecContext) {
+						istio := &v1.Istio{}
+						Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						revisionName := istio.Status.ActiveRevisionName
+
+						// Check that IstioRevision becomes Ready
+						common.AwaitCondition(ctx, v1.IstioRevisionConditionReady, kube.Key(revisionName, controlPlaneNamespace), &v1.IstioRevision{}, k, cl)
+						Success("IstioRevision is Ready")
+					})
+				})
+
+				When("IstioCNI becomes unhealthy", func() {
+					It("should make IstioRevision show IstioCNINotHealthy", func(ctx SpecContext) {
+						// Scale the IstioCNI DaemonSet to 0 to make it unhealthy
+						daemonset := &appsv1.DaemonSet{}
+						Expect(cl.Get(ctx, kube.Key("istio-cni-node", istioCniNamespace), daemonset)).To(Succeed())
+
+						originalReplicas := daemonset.Status.DesiredNumberScheduled
+						Log("Scaling IstioCNI DaemonSet to 0 replicas")
+
+						// Update the DaemonSet to have 0 desired replicas by setting nodeSelector that matches no nodes
+						daemonset.Spec.Template.Spec.NodeSelector = map[string]string{
+							"non-existent-label": "true",
+						}
+						Expect(cl.Update(ctx, daemonset)).To(Succeed())
+
+						// Wait for IstioCNI to become not Ready
+						Eventually(func(g Gomega) {
+							cni := &v1.IstioCNI{}
+							g.Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
+							// IstioCNI should show as not Ready when DaemonSet has no pods
+							g.Expect(cni).To(HaveConditionStatus(v1.IstioCNIConditionReady, metav1.ConditionFalse))
+						}).WithTimeout(60*time.Second).Should(Succeed(), "IstioCNI should become not Ready")
+
+						// Get the active revision name
+						istio := &v1.Istio{}
+						Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						revisionName := istio.Status.ActiveRevisionName
+
+						// Check that IstioRevision shows IstioCNINotHealthy
+						Eventually(func(g Gomega) {
+							revision := &v1.IstioRevision{}
+							g.Expect(cl.Get(ctx, kube.Key(revisionName, controlPlaneNamespace), revision)).To(Succeed())
+							g.Expect(revision).To(HaveConditionStatus(v1.IstioRevisionConditionDependenciesHealthy, metav1.ConditionFalse))
+
+							// Check the reason
+							for _, cond := range revision.Status.Conditions {
+								if cond.Type == v1.IstioRevisionConditionDependenciesHealthy {
+									g.Expect(cond.Reason).To(Equal(v1.IstioRevisionReasonIstioCNINotHealthy),
+										fmt.Sprintf("Expected reason IstioCNINotHealthy, got: %s", cond.Reason))
+									break
+								}
+							}
+						}).WithTimeout(60*time.Second).Should(Succeed(), "IstioRevision should show IstioCNINotHealthy")
+						Success("IstioRevision correctly detected unhealthy IstioCNI")
+
+						// Restore the DaemonSet
+						Log("Restoring IstioCNI DaemonSet")
+						Expect(cl.Get(ctx, kube.Key("istio-cni-node", istioCniNamespace), daemonset)).To(Succeed())
+						daemonset.Spec.Template.Spec.NodeSelector = nil
+						Expect(cl.Update(ctx, daemonset)).To(Succeed())
+
+						// Wait for recovery
+						Eventually(func(g Gomega) {
+							ds := &appsv1.DaemonSet{}
+							g.Expect(cl.Get(ctx, kube.Key("istio-cni-node", istioCniNamespace), ds)).To(Succeed())
+							g.Expect(ds.Status.NumberAvailable).To(Equal(originalReplicas))
+						}).WithTimeout(60*time.Second).Should(Succeed(), "DaemonSet should recover")
+						Success("IstioCNI DaemonSet restored")
+					})
+				})
+
+				When("ZTunnel becomes unhealthy", func() {
+					It("should make IstioRevision show ZTunnelNotHealthy", func(ctx SpecContext) {
+						// Scale the ZTunnel DaemonSet to 0 to make it unhealthy
+						daemonset := &appsv1.DaemonSet{}
+						Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+
+						originalReplicas := daemonset.Status.DesiredNumberScheduled
+						Log("Scaling ZTunnel DaemonSet to 0 replicas")
+
+						// Update the DaemonSet to have 0 desired replicas by setting nodeSelector that matches no nodes
+						daemonset.Spec.Template.Spec.NodeSelector = map[string]string{
+							"non-existent-label": "true",
+						}
+						Expect(cl.Update(ctx, daemonset)).To(Succeed())
+
+						// Wait for ZTunnel to become not Ready
+						Eventually(func(g Gomega) {
+							ztunnel := &v1.ZTunnel{}
+							g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+							// ZTunnel should show as not Ready when DaemonSet has no pods
+							g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionFalse))
+						}).WithTimeout(60*time.Second).Should(Succeed(), "ZTunnel should become not Ready")
+
+						// Get the active revision name
+						istio := &v1.Istio{}
+						Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						revisionName := istio.Status.ActiveRevisionName
+
+						// Check that IstioRevision shows ZTunnelNotHealthy
+						Eventually(func(g Gomega) {
+							revision := &v1.IstioRevision{}
+							g.Expect(cl.Get(ctx, kube.Key(revisionName, controlPlaneNamespace), revision)).To(Succeed())
+							g.Expect(revision).To(HaveConditionStatus(v1.IstioRevisionConditionDependenciesHealthy, metav1.ConditionFalse))
+
+							// Check the reason
+							for _, cond := range revision.Status.Conditions {
+								if cond.Type == v1.IstioRevisionConditionDependenciesHealthy {
+									g.Expect(cond.Reason).To(Equal(v1.IstioRevisionReasonZTunnelNotHealthy),
+										fmt.Sprintf("Expected reason ZTunnelNotHealthy, got: %s", cond.Reason))
+									break
+								}
+							}
+						}).WithTimeout(60*time.Second).Should(Succeed(), "IstioRevision should show ZTunnelNotHealthy")
+						Success("IstioRevision correctly detected unhealthy ZTunnel")
+
+						// Restore the DaemonSet
+						Log("Restoring ZTunnel DaemonSet")
+						Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+						daemonset.Spec.Template.Spec.NodeSelector = nil
+						Expect(cl.Update(ctx, daemonset)).To(Succeed())
+
+						// Wait for recovery
+						Eventually(func(g Gomega) {
+							ds := &appsv1.DaemonSet{}
+							g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), ds)).To(Succeed())
+							g.Expect(ds.Status.NumberAvailable).To(Equal(originalReplicas))
+						}).WithTimeout(60*time.Second).Should(Succeed(), "DaemonSet should recover")
+						Success("ZTunnel DaemonSet restored")
+					})
+				})
+
+				When("dependencies are restored", func() {
+					It("should make IstioRevision healthy again", func(ctx SpecContext) {
+						// Wait for all dependencies to become Ready
+						common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key("default"), &v1.IstioCNI{}, k, cl, 60*time.Second)
+						common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl, 60*time.Second)
+
+						// Get the active revision name
+						istio := &v1.Istio{}
+						Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						revisionName := istio.Status.ActiveRevisionName
+
+						// Check that IstioRevision shows DependenciesHealthy = True again
+						Eventually(func(g Gomega) {
+							revision := &v1.IstioRevision{}
+							g.Expect(cl.Get(ctx, kube.Key(revisionName, controlPlaneNamespace), revision)).To(Succeed())
+							g.Expect(revision).To(HaveConditionStatus(v1.IstioRevisionConditionDependenciesHealthy, metav1.ConditionTrue))
+						}).WithTimeout(60*time.Second).Should(Succeed(), "IstioRevision should have DependenciesHealthy=True")
+						Success("IstioRevision recovered after dependencies became healthy")
+					})
+				})
+
+				AfterAll(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() && keepOnFailure {
+						return
+					}
+					clr.Cleanup(ctx)
+				})
+			})
+		}
+	})
+})

--- a/tests/e2e/ambient/ambient_dependency_test.go
+++ b/tests/e2e/ambient/ambient_dependency_test.go
@@ -327,8 +327,8 @@ spec:
 				When("dependencies are restored", func() {
 					It("should make IstioRevision healthy again", func(ctx SpecContext) {
 						// Wait for all dependencies to become Ready
-						common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key("default"), &v1.IstioCNI{}, k, cl, 60*time.Second)
-						common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl, 60*time.Second)
+						common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key("default"), &v1.IstioCNI{}, k, cl, 2*time.Minute)
+						common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl, 2*time.Minute)
 
 						// Get the active revision name
 						istio := &v1.Istio{}

--- a/tests/e2e/ambient/ambient_dependency_test.go
+++ b/tests/e2e/ambient/ambient_dependency_test.go
@@ -346,9 +346,14 @@ spec:
 				})
 
 				AfterAll(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.Ambient, k)
+					}
+
 					if CurrentSpecReport().Failed() && keepOnFailure {
 						return
 					}
+
 					clr.Cleanup(ctx)
 				})
 			})

--- a/tests/e2e/ambient/ambient_dependency_test.go
+++ b/tests/e2e/ambient/ambient_dependency_test.go
@@ -34,7 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("Ambient Dependency Management", Label("ambient", "ambient-dependency", "smoke"), Ordered, func() {
+var _ = Describe("Ambient Dependency Management", Label("ambient", "ambient-dependency"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 

--- a/tests/e2e/ambient/ambient_targetref_test.go
+++ b/tests/e2e/ambient/ambient_targetref_test.go
@@ -1,0 +1,618 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
+	"github.com/istio-ecosystem/sail-operator/pkg/kube"
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Ambient TargetRef Behavior", Label("ambient", "ambient-targetref"), Ordered, func() {
+	SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	// Use the latest supported ambient version for these tests
+	version := getLatestAmbientVersion()
+
+	var clr cleaner.Cleaner
+
+	BeforeAll(func(ctx SpecContext) {
+		clr = cleaner.New(cl)
+		clr.Record(ctx)
+
+		Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
+		Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
+		Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+
+		// Create IstioCNI CR for shared use across scenarios
+		common.CreateIstioCNI(k, version.Name, `
+profile: ambient`)
+		Success("IstioCNI created")
+	})
+
+	AfterAll(func(ctx SpecContext) {
+		if CurrentSpecReport().Failed() {
+			common.LogDebugInfo(common.Ambient, k)
+			if keepOnFailure {
+				return
+			}
+		}
+		clr.Cleanup(ctx)
+	})
+
+	Context("Value Propagation from TargetRef", Ordered, func() {
+		networkValue := "test-network"
+
+		When("Istio CR is created with custom global.network value", func() {
+			It("creates Istio with custom network configuration", func(ctx SpecContext) {
+				common.CreateIstio(k, version.Name, `
+profile: ambient
+values:
+  global:
+    network: `+networkValue)
+				Success("Istio CR created with custom network value")
+			})
+
+			It("waits for Istio to be Ready", func(ctx SpecContext) {
+				istio := &v1.Istio{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+					g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReconciled, metav1.ConditionTrue))
+					g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+					g.Expect(istio.Status.ActiveRevisionName).NotTo(BeEmpty())
+				}).Should(Succeed(), "Istio should be Ready")
+				Success("Istio is Ready with active revision")
+			})
+		})
+
+		When("ZTunnel is created with targetRef pointing to Istio", func() {
+			It("creates ZTunnel with targetRef (no custom values)", func(ctx SpecContext) {
+				ztunnelYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s
+  targetRef:
+    kind: Istio
+    name: %s`, version.Name, ztunnelNamespace, istioName)
+
+				Expect(k.CreateFromString(ztunnelYAML)).To(Succeed())
+				Success("ZTunnel CR created with targetRef to Istio")
+			})
+
+			It("waits for ZTunnel to be Ready", func(ctx SpecContext) {
+				ztunnel := &v1.ZTunnel{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReconciled, metav1.ConditionTrue))
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+				}).Should(Succeed(), "ZTunnel should be Ready")
+				Success("ZTunnel is Ready")
+			})
+
+			It("verifies ZTunnel Status.IstioRevision matches Istio active revision", func(ctx SpecContext) {
+				istio := &v1.Istio{}
+				Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+
+				ztunnel := &v1.ZTunnel{}
+				Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+
+				Expect(ztunnel.Status.IstioRevision).To(Equal(istio.Status.ActiveRevisionName),
+					"ZTunnel.Status.IstioRevision should match Istio.Status.ActiveRevisionName")
+				Success(fmt.Sprintf("ZTunnel Status.IstioRevision correctly set to: %s", ztunnel.Status.IstioRevision))
+			})
+
+			It("verifies ZTunnel DaemonSet inherits NETWORK environment variable", func(ctx SpecContext) {
+				// NETWORK env var is only available in v1.27+
+				if version.Version.LessThan(semver.MustParse("1.27.0")) {
+					Skip("NETWORK environment variable not available in versions < 1.27")
+				}
+
+				daemonset := &appsv1.DaemonSet{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+					g.Expect(daemonSetHasEnvVar(daemonset, "NETWORK", networkValue)).To(BeTrue(),
+						"NETWORK env var should be set to %s", networkValue)
+				}).Should(Succeed())
+				Success(fmt.Sprintf("ZTunnel DaemonSet inherited NETWORK=%s from Istio", networkValue))
+			})
+		})
+
+		When("Istio values are updated", func() {
+			newNetworkValue := "updated-network"
+
+			It("updates Istio with new network value", func(ctx SpecContext) {
+				patch := fmt.Sprintf(`{"spec":{"values":{"global":{"network":"%s"}}}}`, newNetworkValue)
+				Expect(k.Patch("istio", istioName, "merge", patch)).To(Succeed())
+				Success("Istio patched with new network value")
+			})
+
+			It("waits for Istio to reconcile", func(ctx SpecContext) {
+				istio := &v1.Istio{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+					g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReconciled, metav1.ConditionTrue))
+					g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+				}).Should(Succeed())
+				Success("Istio reconciled after update")
+			})
+
+			It("verifies ZTunnel picks up new inherited value", func(ctx SpecContext) {
+				// NETWORK env var is only available in v1.27+
+				if version.Version.LessThan(semver.MustParse("1.27.0")) {
+					Skip("NETWORK environment variable not available in versions < 1.27")
+				}
+
+				daemonset := &appsv1.DaemonSet{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+					g.Expect(daemonSetHasEnvVar(daemonset, "NETWORK", newNetworkValue)).To(BeTrue(),
+						"NETWORK env var should be updated to %s", newNetworkValue)
+				}).Should(Succeed())
+				Success(fmt.Sprintf("ZTunnel DaemonSet inherited updated NETWORK=%s", newNetworkValue))
+			})
+		})
+	})
+
+	Context("MeshConfig Propagation from TargetRef", Ordered, func() {
+		customTrustDomain := "custom-trust.local"
+
+		BeforeAll(func(ctx SpecContext) {
+			// Delete the ZTunnel from the previous context
+			_ = k.Delete("ztunnel", "default")
+			Eventually(func(g Gomega) {
+				ztunnel := &v1.ZTunnel{}
+				err := cl.Get(ctx, kube.Key("default"), ztunnel)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("not found"))
+			}).Should(Succeed())
+			Success("Previous ZTunnel deleted and verified gone")
+		})
+
+		When("Istio CR is created with custom meshConfig", func() {
+			It("creates Istio with custom trustDomain in meshConfig", func(ctx SpecContext) {
+				istioYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: meshconfig-test
+spec:
+  version: %s
+  namespace: %s
+  profile: ambient
+  values:
+    meshConfig:
+      trustDomain: %s`, version.Name, controlPlaneNamespace, customTrustDomain)
+
+				Expect(k.CreateFromString(istioYAML)).To(Succeed())
+				Success("Istio CR created with custom meshConfig")
+			})
+
+			It("waits for Istio to be Ready", func(ctx SpecContext) {
+				istio := &v1.Istio{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("meshconfig-test"), istio)).To(Succeed())
+					g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReconciled, metav1.ConditionTrue))
+					g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+					g.Expect(istio.Status.ActiveRevisionName).NotTo(BeEmpty())
+				}).Should(Succeed())
+				Success("Istio with meshConfig is Ready")
+			})
+		})
+
+		When("ZTunnel is created with targetRef to Istio with meshConfig", func() {
+			It("creates ZTunnel with targetRef (no custom meshConfig)", func(ctx SpecContext) {
+				ztunnelYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s
+  targetRef:
+    kind: Istio
+    name: meshconfig-test`, version.Name, ztunnelNamespace)
+
+				Expect(k.CreateFromString(ztunnelYAML)).To(Succeed())
+				Success("ZTunnel created with targetRef to Istio with meshConfig")
+			})
+
+			It("waits for ZTunnel to be Ready", func(ctx SpecContext) {
+				ztunnel := &v1.ZTunnel{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReconciled, metav1.ConditionTrue))
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+				}).Should(Succeed())
+				Success("ZTunnel is Ready with inherited meshConfig")
+			})
+
+			It("verifies ZTunnel Status.IstioRevision is set", func(ctx SpecContext) {
+				ztunnel := &v1.ZTunnel{}
+				Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+
+				istio := &v1.Istio{}
+				Expect(cl.Get(ctx, kube.Key("meshconfig-test"), istio)).To(Succeed())
+
+				Expect(ztunnel.Status.IstioRevision).To(Equal(istio.Status.ActiveRevisionName))
+				Success(fmt.Sprintf("ZTunnel references correct IstioRevision: %s", ztunnel.Status.IstioRevision))
+			})
+
+			It("verifies ZTunnel DaemonSet is deployed successfully", func(ctx SpecContext) {
+				daemonset := &appsv1.DaemonSet{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+					g.Expect(daemonset.Status.NumberAvailable).To(BeNumerically(">", 0))
+				}).Should(Succeed())
+				Success("ZTunnel DaemonSet deployed with inherited meshConfig")
+			})
+		})
+
+		When("Istio meshConfig is updated", func() {
+			updatedTrustDomain := "updated-trust.local"
+
+			It("updates Istio meshConfig trustDomain", func(ctx SpecContext) {
+				patch := fmt.Sprintf(`{"spec":{"values":{"meshConfig":{"trustDomain":"%s"}}}}`, updatedTrustDomain)
+				Expect(k.Patch("istio", "meshconfig-test", "merge", patch)).To(Succeed())
+				Success("Istio meshConfig patched with new trustDomain")
+			})
+
+			It("waits for Istio to reconcile", func(ctx SpecContext) {
+				istio := &v1.Istio{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("meshconfig-test"), istio)).To(Succeed())
+					g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReconciled, metav1.ConditionTrue))
+					g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+				}).Should(Succeed())
+				Success("Istio reconciled after meshConfig update")
+			})
+
+			It("verifies ZTunnel picks up updated meshConfig", func(ctx SpecContext) {
+				ztunnel := &v1.ZTunnel{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReconciled, metav1.ConditionTrue))
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+				}).Should(Succeed())
+				Success("ZTunnel reconciled with updated meshConfig")
+			})
+
+			It("verifies ZTunnel DaemonSet remains healthy", func(ctx SpecContext) {
+				daemonset := &appsv1.DaemonSet{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+					g.Expect(daemonset.Status.NumberAvailable).To(BeNumerically(">", 0))
+				}).Should(Succeed())
+				Success("ZTunnel DaemonSet healthy after meshConfig update")
+			})
+		})
+	})
+
+	Context("User Value Override Precedence", Ordered, func() {
+		inheritedNetwork := "inherited-net"
+		overrideNetwork := "override-net"
+		customEnvVar := "CUSTOM_TEST_VAR"
+		customEnvValue := "custom-value"
+
+		BeforeAll(func(ctx SpecContext) {
+			// Delete the ZTunnel from the previous context since only one ZTunnel named 'default' can exist
+			// Wait for deletion to complete to avoid conflicts
+			_ = k.Delete("ztunnel", "default")
+			Eventually(func(g Gomega) {
+				ztunnel := &v1.ZTunnel{}
+				err := cl.Get(ctx, kube.Key("default"), ztunnel)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("not found"))
+			}).Should(Succeed())
+			Success("Previous ZTunnel deleted and verified gone")
+		})
+
+		When("Istio is created with a network value", func() {
+			It("creates second Istio CR for override testing", func(ctx SpecContext) {
+				istioName2 := "override-test"
+				istioYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: %s
+spec:
+  version: %s
+  namespace: %s
+  profile: ambient
+  values:
+    global:
+      network: %s`, istioName2, version.Name, controlPlaneNamespace, inheritedNetwork)
+
+				Expect(k.CreateFromString(istioYAML)).To(Succeed())
+				Success("Second Istio CR created")
+			})
+
+			It("waits for second Istio to be Ready", func(ctx SpecContext) {
+				istio := &v1.Istio{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("override-test"), istio)).To(Succeed())
+					g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+				}).Should(Succeed())
+				Success("Second Istio is Ready")
+			})
+		})
+
+		When("ZTunnel is created with targetRef AND custom values", func() {
+			It("creates ZTunnel with both targetRef and value overrides", func(ctx SpecContext) {
+				ztunnelYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s
+  targetRef:
+    kind: Istio
+    name: override-test
+  values:
+    ztunnel:
+      network: %s
+      env:
+        %s: "%s"`, version.Name, ztunnelNamespace, overrideNetwork, customEnvVar, customEnvValue)
+
+				Expect(k.CreateFromString(ztunnelYAML)).To(Succeed())
+				Success("ZTunnel created with targetRef and custom values")
+			})
+
+			It("waits for ZTunnel to be Ready", func(ctx SpecContext) {
+				ztunnel := &v1.ZTunnel{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+				}).Should(Succeed())
+				Success("Override ZTunnel is Ready")
+			})
+
+			It("verifies DaemonSet uses override network value (not inherited)", func(ctx SpecContext) {
+				// NETWORK env var is only available in v1.27+
+				if version.Version.LessThan(semver.MustParse("1.27.0")) {
+					Skip("NETWORK environment variable not available in versions < 1.27")
+				}
+
+				daemonset := &appsv1.DaemonSet{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+					g.Expect(daemonSetHasEnvVar(daemonset, "NETWORK", overrideNetwork)).To(BeTrue(),
+						"NETWORK should use override value %s, not inherited value %s", overrideNetwork, inheritedNetwork)
+				}).Should(Succeed())
+				Success(fmt.Sprintf("DaemonSet uses override NETWORK=%s (not inherited %s)", overrideNetwork, inheritedNetwork))
+			})
+
+			It("verifies custom environment variables are present", func(ctx SpecContext) {
+				daemonset := &appsv1.DaemonSet{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+					g.Expect(daemonSetHasEnvVar(daemonset, customEnvVar, customEnvValue)).To(BeTrue(),
+						"Custom env var %s should be set to %s", customEnvVar, customEnvValue)
+				}).Should(Succeed())
+				Success(fmt.Sprintf("Custom environment variable %s=%s is present", customEnvVar, customEnvValue))
+			})
+		})
+
+		When("override value is removed from ZTunnel spec", func() {
+			It("patches ZTunnel to remove network override (keep custom env)", func(ctx SpecContext) {
+				// Remove the ztunnel.network override, keep custom env var
+				patch := fmt.Sprintf(`{"spec":{"values":{"ztunnel":{"network":null,"env":{"%s":"%s"}}}}}`,
+					customEnvVar, customEnvValue)
+				Expect(k.Patch("ztunnel", "default", "merge", patch)).To(Succeed())
+				Success("ZTunnel patched to remove network override")
+			})
+
+			It("waits for ZTunnel to reconcile", func(ctx SpecContext) {
+				ztunnel := &v1.ZTunnel{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+				}).Should(Succeed())
+				Success("ZTunnel reconciled after patch")
+			})
+
+			It("verifies ZTunnel now uses inherited network value", func(ctx SpecContext) {
+				// NETWORK env var is only available in v1.27+
+				if version.Version.LessThan(semver.MustParse("1.27.0")) {
+					Skip("NETWORK environment variable not available in versions < 1.27")
+				}
+
+				daemonset := &appsv1.DaemonSet{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+					g.Expect(daemonSetHasEnvVar(daemonset, "NETWORK", inheritedNetwork)).To(BeTrue(),
+						"NETWORK should fallback to inherited value %s", inheritedNetwork)
+				}).Should(Succeed())
+				Success(fmt.Sprintf("ZTunnel now uses inherited NETWORK=%s", inheritedNetwork))
+			})
+		})
+	})
+
+	Context("Invalid TargetRef Handling", Ordered, func() {
+		BeforeAll(func(ctx SpecContext) {
+			// Delete the ZTunnel from the previous context since only one ZTunnel named 'default' can exist
+			// Wait for deletion to complete to avoid conflicts
+			_ = k.Delete("ztunnel", "default")
+			Eventually(func(g Gomega) {
+				ztunnel := &v1.ZTunnel{}
+				err := cl.Get(ctx, kube.Key("default"), ztunnel)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("not found"))
+			}).Should(Succeed())
+			Success("Previous ZTunnel deleted and verified gone")
+		})
+
+		When("ZTunnel targetRef points to non-existent Istio resource", func() {
+			missingIstioName := "missing-istio"
+
+			BeforeAll(func(ctx SpecContext) {
+				// Delete the ZTunnel from the previous When block
+				// Wait for deletion to complete to avoid conflicts
+				_ = k.Delete("ztunnel", "default")
+				Eventually(func(g Gomega) {
+					ztunnel := &v1.ZTunnel{}
+					err := cl.Get(ctx, kube.Key("default"), ztunnel)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err.Error()).To(ContainSubstring("not found"))
+				}).Should(Succeed())
+				Success("Previous ZTunnel deleted and verified gone")
+			})
+
+			It("creates ZTunnel with targetRef to non-existent Istio", func(ctx SpecContext) {
+				ztunnelYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s
+  targetRef:
+    kind: Istio
+    name: %s`, version.Name, ztunnelNamespace, missingIstioName)
+
+				Expect(k.CreateFromString(ztunnelYAML)).To(Succeed())
+				Success("ZTunnel created with targetRef to non-existent Istio")
+			})
+
+			It("verifies ZTunnel Reconciled condition is False", func(ctx SpecContext) {
+				ztunnel := &v1.ZTunnel{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReconciled, metav1.ConditionFalse))
+				}).Should(Succeed())
+				Success("ZTunnel Reconciled=False due to missing targetRef")
+			})
+
+			It("verifies error message indicates resource not found", func(ctx SpecContext) {
+				ztunnel := &v1.ZTunnel{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					// Error message should contain "not found" or similar
+					g.Expect(ztunnel).To(HaveConditionMessage(v1.ZTunnelConditionReconciled, "not found"))
+				}).Should(Succeed())
+				Success("Error message indicates resource not found")
+			})
+
+			It("creates the missing Istio resource", func(ctx SpecContext) {
+				istioYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: %s
+spec:
+  version: %s
+  namespace: %s
+  profile: ambient`, missingIstioName, version.Name, controlPlaneNamespace)
+
+				Expect(k.CreateFromString(istioYAML)).To(Succeed())
+				Success("Missing Istio CR created")
+			})
+
+			It("waits for Istio to be Ready", func(ctx SpecContext) {
+				istio := &v1.Istio{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key(missingIstioName), istio)).To(Succeed())
+					g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+					g.Expect(istio.Status.ActiveRevisionName).NotTo(BeEmpty())
+				}).Should(Succeed())
+				Success("Missing Istio is now Ready")
+			})
+
+			It("verifies ZTunnel auto-recovers and becomes Ready", func(ctx SpecContext) {
+				ztunnel := &v1.ZTunnel{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReconciled, metav1.ConditionTrue))
+					g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+				}).Should(Succeed())
+				Success("ZTunnel auto-recovered after Istio was created")
+			})
+
+			It("verifies Status.IstioRevision is populated", func(ctx SpecContext) {
+				ztunnel := &v1.ZTunnel{}
+				Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+				Expect(ztunnel.Status.IstioRevision).NotTo(BeEmpty(), "Status.IstioRevision should be populated")
+
+				istio := &v1.Istio{}
+				Expect(cl.Get(ctx, kube.Key(missingIstioName), istio)).To(Succeed())
+				Expect(ztunnel.Status.IstioRevision).To(Equal(istio.Status.ActiveRevisionName))
+				Success(fmt.Sprintf("Status.IstioRevision correctly set to: %s", ztunnel.Status.IstioRevision))
+			})
+
+			It("verifies value propagation works after recovery", func(ctx SpecContext) {
+				// Verify that the DaemonSet was created successfully
+				daemonset := &appsv1.DaemonSet{}
+				Eventually(func(g Gomega) {
+					g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+					g.Expect(daemonset.Status.NumberAvailable).To(BeNumerically(">", 0))
+				}).Should(Succeed())
+				Success("Value propagation working - ZTunnel DaemonSet is deployed")
+			})
+		})
+	})
+})
+
+// getLatestAmbientVersion returns the latest supported version for ambient mode
+func getLatestAmbientVersion() istioversion.VersionInfo {
+	versions := istioversion.GetLatestPatchVersions()
+
+	for _, version := range versions {
+		// Minimum supported version is 1.24
+		if version.Version.LessThan(semver.MustParse("1.24.0")) {
+			continue
+		}
+		// FIPS clusters require v1.28+
+		if fipsCluster && version.Version.LessThan(semver.MustParse("1.28.0")) {
+			continue
+		}
+		return version
+	}
+	// Fallback to the last version if no suitable version found
+	return versions[len(versions)-1]
+}
+
+// daemonSetHasEnvVar checks if a DaemonSet's containers have an environment variable with the expected value
+func daemonSetHasEnvVar(daemonset *appsv1.DaemonSet, envName, expectedValue string) bool {
+	for _, container := range daemonset.Spec.Template.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name == envName && env.Value == expectedValue {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -62,11 +62,32 @@ var _ = Describe("Ambient configuration ", Label("smoke", "ambient"), Ordered, f
 					Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
 					Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
 					Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed(), "ZTunnel namespace failed to be created")
-				})
 
-				When("the IstioCNI CR is created with ambient profile", func() {
-					BeforeAll(func() {
-						cniYAML := `
+					// Create all ambient components in reverse order to test order independence
+					// This validates that the operator correctly handles dependencies regardless of creation order
+
+					// Create ZTunnel first (won't be fully ready until Istio/istiod exists for XDS)
+					ztunnelYaml := `
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s
+  targetRef:
+    kind: Istio
+    name: %s
+  values:
+    ztunnel:
+      env:
+        CUSTOM_ENV_VAR: "true"`
+					ztunnelYaml = fmt.Sprintf(ztunnelYaml, version.Name, ztunnelNamespace, istioName)
+					Log("Creating ZTunnel first (reverse order):", ztunnelYaml)
+					Expect(k.CreateFromString(ztunnelYaml)).To(Succeed(), "ZTunnel creation failed")
+
+					// Create IstioCNI second
+					cniYAML := `
 apiVersion: sailoperator.io/v1
 kind: IstioCNI
 metadata:
@@ -79,12 +100,26 @@ spec:
   profile: ambient
   version: %s
   namespace: %s`
-						cniYAML = fmt.Sprintf(cniYAML, version.Name, istioCniNamespace)
-						Log("IstioCNI YAML:", cniYAML)
-						Expect(k.CreateFromString(cniYAML)).To(Succeed(), "IstioCNI creation failed")
-						Success("IstioCNI created")
-					})
+					cniYAML = fmt.Sprintf(cniYAML, version.Name, istioCniNamespace)
+					Log("Creating IstioCNI second:", cniYAML)
+					Expect(k.CreateFromString(cniYAML)).To(Succeed(), "IstioCNI creation failed")
 
+					// Create Istio last (this will trigger ZTunnel to become ready)
+					istioYAML := `
+values:
+  global:
+    network: custom-network
+  pilot:
+    trustedZtunnelNamespace: ztunnel
+profile: ambient`
+					Log("Creating Istio last (enables ZTunnel to become ready)")
+					common.CreateIstio(k, version.Name, istioYAML)
+
+					Success("All ambient components created in reverse order to test order independence")
+				})
+
+				When("the ambient components are deployed", func() {
+					// IstioCNI tests
 					It("deploys the CNI DaemonSet", func(ctx SpecContext) {
 						Eventually(func(g Gomega) {
 							daemonset := &appsv1.DaemonSet{}
@@ -93,6 +128,10 @@ spec:
 								To(Equal(daemonset.Status.CurrentNumberScheduled), "CNI DaemonSet Pods not Available; expected numberAvailable to be equal to currentNumberScheduled")
 						}).Should(Succeed(), "CNI DaemonSet Pods are not Available")
 						Success("CNI DaemonSet is deployed in the namespace and Running")
+					})
+
+					It("updates the IstioCNI CR status to Ready", func(ctx SpecContext) {
+						common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key("default"), &v1.IstioCNI{}, k, cl)
 					})
 
 					It("uses the configured values in the istio-cni-config config map", func(ctx SpecContext) {
@@ -109,25 +148,26 @@ spec:
 							return nil
 						}).Should(Succeed(), "Expected 'AMBIENT_DNS_CAPTURE' to be set to 'true'")
 					})
-				})
 
-				When("the Istio CR is created with ambient profile", func() {
-					BeforeAll(func() {
-						common.CreateIstio(k, version.Name, `
-values:
-  global:
-    network: custom-network
-  pilot:
-    trustedZtunnelNamespace: ztunnel
-profile: ambient`)
-					})
-
+					// Istio tests
 					It("updates the Istio CR status to Reconciled", func(ctx SpecContext) {
 						common.AwaitCondition(ctx, v1.IstioConditionReconciled, kube.Key(istioName), &v1.Istio{}, k, cl)
 					})
 
 					It("updates the Istio CR status to Ready", func(ctx SpecContext) {
 						common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl)
+					})
+
+					It("updates the IstioRevision status to Ready", func(ctx SpecContext) {
+						// Get the active revision name from Istio CR
+						istio := &v1.Istio{}
+						Eventually(func(g Gomega) {
+							g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+							g.Expect(istio.Status.ActiveRevisionName).NotTo(BeEmpty(), "Active revision not set")
+						}).Should(Succeed(), "Istio should have an active revision")
+
+						revisionName := istio.Status.ActiveRevisionName
+						common.AwaitCondition(ctx, v1.IstioRevisionConditionReady, kube.Key(revisionName, controlPlaneNamespace), &v1.IstioRevision{}, k, cl)
 					})
 
 					It("deploys istiod", func(ctx SpecContext) {
@@ -156,31 +196,8 @@ profile: ambient`)
 							ContainElement(corev1.EnvVar{Name: "CA_TRUSTED_NODE_ACCOUNTS", Value: "ztunnel/ztunnel"})))),
 							"Expected CA_TRUSTED_NODE_ACCOUNTS to be set to ztunnel/ztunnel, but not found")
 					})
-				})
 
-				When("the ZTunnel CR is created", func() {
-					BeforeAll(func() {
-						ztunnelYaml := `
-apiVersion: sailoperator.io/v1
-kind: ZTunnel
-metadata:
-  name: default
-spec:
-  version: %s
-  namespace: %s
-  targetRef:
-    kind: Istio
-    name: %s
-  values:
-    ztunnel:
-      env:
-        CUSTOM_ENV_VAR: "true"`
-						ztunnelYaml = fmt.Sprintf(ztunnelYaml, version.Name, ztunnelNamespace, istioName)
-						Log("ZTunnel YAML:", ztunnelYaml)
-						Expect(k.CreateFromString(ztunnelYaml)).To(Succeed(), "ZTunnel creation failed")
-						Success("ZTunnel created")
-					})
-
+					// ZTunnel tests
 					It("deploys the ZTunnel DaemonSet", func(ctx SpecContext) {
 						Eventually(func(g Gomega) {
 							daemonset := &appsv1.DaemonSet{}
@@ -190,6 +207,10 @@ spec:
 									"ZTunnel DaemonSet Pods not Available; expected numberAvailable to be equal to currentNumberScheduled")
 						}).Should(Succeed(), "ZTunnel DaemonSet Pods are not Available")
 						Success("ZTunnel DaemonSet is deployed and Running")
+					})
+
+					It("updates the ZTunnel CR status to Ready", func(ctx SpecContext) {
+						common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl)
 					})
 
 					It("has ztunnel running with appropriate env variables set", func(ctx SpecContext) {

--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -37,7 +37,7 @@ import (
 
 var defaultTimeout = env.GetInt("DEFAULT_TEST_TIMEOUT", 180)
 
-var _ = Describe("Ambient configuration ", Label("smoke", "ambient"), Ordered, func() {
+var _ = Describe("Ambient configuration ", Label("ambient", "slow"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 

--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -254,8 +254,8 @@ profile: ambient`
 						Expect(k.Label("namespace", common.HttpbinNamespace, "istio.io/dataplane-mode", "ambient")).To(Succeed(), "Error labeling httpbin namespace")
 
 						// Deploy the test pods.
-						Expect(k.WithNamespace(common.SleepNamespace).ApplyKustomize("sleep")).To(Succeed(), "Error deploying sleep pod")
-						Expect(k.WithNamespace(common.HttpbinNamespace).ApplyKustomize("httpbin")).To(Succeed(), "Error deploying httpbin pod")
+						Expect(k.WithNamespace(common.SleepNamespace).ApplyKustomize(common.SleepContainerName)).To(Succeed(), "Error deploying sleep pod")
+						Expect(k.WithNamespace(common.HttpbinNamespace).ApplyKustomize(common.HttpbinContainerName)).To(Succeed(), "Error deploying httpbin pod")
 
 						Success("Ambient validation pods deployed")
 					})
@@ -274,7 +274,7 @@ profile: ambient`
 					})
 
 					It("can access the httpbin service from the sleep pod", func(ctx SpecContext) {
-						common.CheckPodConnectivity(sleepPod.Items[0].Name, common.SleepNamespace, common.HttpbinNamespace, k)
+						common.CheckPodConnectivity(sleepPod.Items[0].Name, common.SleepContainerName, common.SleepNamespace, common.HttpbinNamespace, k)
 					})
 				})
 
@@ -359,7 +359,7 @@ func getEnvVars(container corev1.Container) []corev1.EnvVar {
 }
 
 func checkZtunnelPort(podName, srcNamespace string) {
-	response, err := k.WithNamespace(srcNamespace).Exec(podName, srcNamespace, "netstat -tlpn")
+	response, err := k.WithNamespace(srcNamespace).Exec(podName, common.SleepContainerName, "netstat -tlpn")
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error validating the proxy sockets in the %q pod", podName))
 	// Verify that the HBONE mTLS tunnel port (15008) is listed in the output.
 	Expect(response).To(ContainSubstring("15008"), fmt.Sprintf("Unexpected response from %s pod", podName))

--- a/tests/e2e/ambient/ambient_update_test.go
+++ b/tests/e2e/ambient/ambient_update_test.go
@@ -1,0 +1,770 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"fmt"
+	"time"
+
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/kube"
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/update"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Ambient Update & Lifecycle", Label("ambient", "update", "slow"), Ordered, func() {
+	SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
+	SetDefaultEventuallyPollingInterval(time.Second)
+	debugInfoLogged := false
+
+	// Get two consecutive minor versions for update testing
+	baseVersion, newVersion, err := update.GetTwoConsecutiveAmbientVersions(fipsCluster)
+	if err != nil {
+		Skip(fmt.Sprintf("Skipping ambient update tests: %v", err))
+		return
+	}
+
+	Describe("In-Place Updates", func() {
+		Context(fmt.Sprintf("Updating from %s to %s", baseVersion.Version, newVersion.Version), func() {
+			clr := cleaner.New(cl)
+			var validator *common.WorkloadValidator
+
+			BeforeAll(func(ctx SpecContext) {
+				clr.Record(ctx)
+				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+			})
+
+			When("all components are created with base version", func() {
+				BeforeAll(func(ctx SpecContext) {
+					// Create IstioCNI
+					cniYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s
+  profile: ambient`, baseVersion.Name, istioCniNamespace)
+					Log("Creating IstioCNI with version:", baseVersion.Name)
+					Expect(k.CreateFromString(cniYAML)).To(Succeed())
+
+					// Create ZTunnel
+					ztunnelYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s`, baseVersion.Name, ztunnelNamespace)
+					Log("Creating ZTunnel with version:", baseVersion.Name)
+					Expect(k.CreateFromString(ztunnelYAML)).To(Succeed())
+
+					// Create Istio
+					istioYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: %s
+spec:
+  version: %s
+  namespace: %s
+  values:
+    profile: ambient
+    pilot:
+      cni:
+        enabled: true
+      trustedZtunnelNamespace: ztunnel`, istioName, baseVersion.Name, controlPlaneNamespace)
+					Log("Creating Istio with version:", baseVersion.Name)
+					Expect(k.CreateFromString(istioYAML)).To(Succeed())
+					Success("All components created with base version")
+				})
+
+				It("should have IstioCNI Ready", func(ctx SpecContext) {
+					common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key("default"), &v1.IstioCNI{}, k, cl, 180*time.Second)
+					Success("IstioCNI is Ready with base version")
+				})
+
+				It("should have ZTunnel Ready", func(ctx SpecContext) {
+					common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl, 180*time.Second)
+					Success("ZTunnel is Ready with base version")
+				})
+
+				It("should have Istio Ready", func(ctx SpecContext) {
+					common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl, 240*time.Second)
+					Success("Istio is Ready with base version")
+				})
+
+				It("should have istiod deployment running", func(ctx SpecContext) {
+					common.AwaitDeployment(ctx, "istiod", k, cl)
+					Success("istiod deployment is running")
+				})
+			})
+
+			When("workloads are deployed in ambient mode", func() {
+				BeforeAll(func(ctx SpecContext) {
+					// Step 1: Initialize WorkloadValidator for ambient mode testing
+					// This sets up the validator to deploy and validate workloads in ambient dataplane mode
+					validator = &common.WorkloadValidator{
+						K:             k,
+						Cl:            cl,
+						Namespace:     "workload-update-test",
+						DataplaneMode: common.DataplaneModeAmbient,
+					}
+					// Step 2: Deploy test workloads (sleep + httpbin)
+					// - Creates workload-update-test and httpbin namespaces
+					// - Labels both namespaces with istio.io/dataplane-mode=ambient
+					// - Deploys sleep pod in workload-update-test namespace
+					// - Deploys httpbin service in httpbin namespace
+					Expect(validator.DeployWorkload(ctx)).To(Succeed(), "Failed to deploy ambient workloads")
+					Success("Workloads deployed in ambient mode")
+				})
+
+				It("should have connectivity with base version components", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						// Step 3: Validate connectivity between workloads
+						// Tests that sleep pod in workload-update-test can reach httpbin service in httpbin namespace
+						// This verifies the ambient mesh is routing traffic correctly through ZTunnel proxies
+						g.Expect(validator.ValidateConnectivity(ctx)).To(Succeed())
+						// Step 4: Verify ZTunnel version matches base version
+						// Checks the ZTunnel DaemonSet image tag to confirm it's running the expected base version
+						g.Expect(validator.ValidateProxyVersion(ctx, baseVersion.Version)).To(Succeed())
+					}).WithTimeout(120*time.Second).Should(Succeed(), "Workloads should have connectivity with old ZTunnel version")
+					Success("Workloads have connectivity with old version")
+				})
+			})
+
+			When("IstioCNI version is updated", func() {
+				BeforeAll(func(ctx SpecContext) {
+					cni := &v1.IstioCNI{}
+					Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
+
+					Log(fmt.Sprintf("Updating IstioCNI from %s to %s", baseVersion.Name, newVersion.Name))
+					cni.Spec.Version = newVersion.Name
+					Expect(cl.Update(ctx, cni)).To(Succeed())
+					Success("IstioCNI version updated")
+				})
+
+				It("should reconcile and remain Ready", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						cni := &v1.IstioCNI{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
+						g.Expect(cni.Spec.Version).To(Equal(newVersion.Name))
+						g.Expect(cni).To(HaveConditionStatus(v1.IstioCNIConditionReady, metav1.ConditionTrue))
+					}).WithTimeout(180*time.Second).Should(Succeed(), "IstioCNI should be Ready with new version")
+					Success("IstioCNI successfully updated")
+				})
+
+				It("should update the DaemonSet", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						ds := &appsv1.DaemonSet{}
+						g.Expect(cl.Get(ctx, kube.Key("istio-cni-node", istioCniNamespace), ds)).To(Succeed())
+						g.Expect(ds.Status.NumberAvailable).To(BeNumerically(">", 0))
+						g.Expect(ds.Status.UpdatedNumberScheduled).To(Equal(ds.Status.DesiredNumberScheduled))
+					}).WithTimeout(180*time.Second).Should(Succeed(), "DaemonSet should be fully updated")
+					Success("IstioCNI DaemonSet updated successfully")
+				})
+
+				It("workloads maintain connectivity after IstioCNI update", func(ctx SpecContext) {
+					// Validate connectivity is still working after IstioCNI update
+					// Tests that sleep pod can still reach httpbin service through the mesh
+					// This confirms that updating the CNI component doesn't break existing connections
+					Expect(validator.ValidateConnectivity(ctx)).To(Succeed(),
+						"Workloads should maintain connectivity after IstioCNI update")
+					Success("Workloads maintain connectivity")
+				})
+			})
+
+			When("ZTunnel version is updated", func() {
+				BeforeAll(func(ctx SpecContext) {
+					ztunnel := &v1.ZTunnel{}
+					Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+
+					Log(fmt.Sprintf("Updating ZTunnel from %s to %s", baseVersion.Name, newVersion.Name))
+					ztunnel.Spec.Version = newVersion.Name
+					Expect(cl.Update(ctx, ztunnel)).To(Succeed())
+					Success("ZTunnel version updated")
+				})
+
+				It("should reconcile and remain Ready", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						ztunnel := &v1.ZTunnel{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+						g.Expect(ztunnel.Spec.Version).To(Equal(newVersion.Name))
+						g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+					}).WithTimeout(180*time.Second).Should(Succeed(), "ZTunnel should be Ready with new version")
+					Success("ZTunnel successfully updated")
+				})
+
+				It("should update the DaemonSet", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						ds := &appsv1.DaemonSet{}
+						g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), ds)).To(Succeed())
+						g.Expect(ds.Status.NumberAvailable).To(BeNumerically(">", 0))
+						g.Expect(ds.Status.UpdatedNumberScheduled).To(Equal(ds.Status.DesiredNumberScheduled))
+					}).WithTimeout(180*time.Second).Should(Succeed(), "ZTunnel DaemonSet should be fully updated")
+					Success("ZTunnel DaemonSet updated successfully")
+				})
+
+				It("workloads have connectivity and use new ZTunnel version", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						// Validate connectivity after ZTunnel update
+						// Tests that sleep pod can reach httpbin service through the updated ZTunnel proxies
+						// This confirms the ZTunnel rolling update completed successfully without breaking traffic
+						g.Expect(validator.ValidateConnectivity(ctx)).To(Succeed())
+						// Verify ZTunnel version has been upgraded
+						// ZTunnel DaemonSet should now have new version
+						g.Expect(validator.ValidateProxyVersion(ctx, newVersion.Version)).To(Succeed())
+					}).WithTimeout(120*time.Second).Should(Succeed(), "Workloads should have connectivity with new ZTunnel version")
+					Success("Workloads have connectivity with new ZTunnel version")
+				})
+			})
+
+			When("Istio version is updated", func() {
+				BeforeAll(func(ctx SpecContext) {
+					// Update the Istio CR to new version
+					istio := &v1.Istio{}
+					Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+
+					Log(fmt.Sprintf("Updating Istio from %s to %s", baseVersion.Name, newVersion.Name))
+					istio.Spec.Version = newVersion.Name
+					Expect(cl.Update(ctx, istio)).To(Succeed())
+					Success("Istio version updated")
+				})
+
+				It("should reconcile and remain Ready", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						istio := &v1.Istio{}
+						g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						g.Expect(istio.Spec.Version).To(Equal(newVersion.Name))
+						g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+					}).WithTimeout(240*time.Second).Should(Succeed(), "Istio should be Ready with new version")
+					Success("Istio successfully updated")
+				})
+
+				It("should update the istiod deployment", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						deployment := &appsv1.Deployment{}
+						g.Expect(cl.Get(ctx, kube.Key("istiod", controlPlaneNamespace), deployment)).To(Succeed())
+						g.Expect(deployment.Status.AvailableReplicas).To(BeNumerically(">", 0))
+						g.Expect(deployment.Status.UpdatedReplicas).To(Equal(deployment.Status.Replicas))
+					}).WithTimeout(180*time.Second).Should(Succeed(), "istiod deployment should be fully updated")
+					Success("istiod deployment updated successfully")
+				})
+			})
+
+			AfterAll(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.Ambient, k)
+					debugInfoLogged = true
+					if keepOnFailure {
+						return
+					}
+				}
+				clr.Cleanup(ctx)
+			})
+		})
+	})
+
+	Describe("Revision-Based Updates", func() {
+		Context(fmt.Sprintf("Canary update from %s to %s", baseVersion.Version, newVersion.Version), func() {
+			clr := cleaner.New(cl)
+			var validator *common.WorkloadValidator
+
+			BeforeAll(func(ctx SpecContext) {
+				clr.Record(ctx)
+				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+
+				// Create shared dependencies (IstioCNI and ZTunnel) with OLD version
+				// In a real canary update, you start with all components at the old version,
+				// then add a new revision at the new version
+				cniYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s
+  profile: ambient`, baseVersion.Name, istioCniNamespace)
+				Log("Creating IstioCNI with base version:", baseVersion.Name)
+				Expect(k.CreateFromString(cniYAML)).To(Succeed())
+
+				ztunnelYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s`, baseVersion.Name, ztunnelNamespace)
+				Log("Creating ZTunnel with base version:", baseVersion.Name)
+				Expect(k.CreateFromString(ztunnelYAML)).To(Succeed())
+
+				// Wait for IstioCNI to be ready
+				Eventually(func(g Gomega) {
+					cni := &v1.IstioCNI{}
+					g.Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
+					g.Expect(cni).To(HaveConditionStatus(v1.IstioCNIConditionReady, metav1.ConditionTrue))
+				}).Should(Succeed(), "IstioCNI should be Ready")
+
+				// Note: We don't wait for ZTunnel to be fully Ready here because it needs
+				// istiod to be running to get XDS configuration. It will become Ready once
+				// the first IstioRevision is created.
+
+				Success("Shared dependencies created at base version")
+			})
+
+			When("Istio CR is created with base version (default revision)", func() {
+				BeforeAll(func() {
+					// Use Istio CR for the default/first revision
+					// This creates an istiod service without revision suffix that ZTunnel can connect to
+					istioYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: %s
+spec:
+  version: %s
+  namespace: %s
+  values:
+    profile: ambient
+    pilot:
+      cni:
+        enabled: true
+      trustedZtunnelNamespace: ztunnel`, istioName, baseVersion.Name, controlPlaneNamespace)
+					Log("Creating Istio CR with base version:", baseVersion.Name)
+					Expect(k.CreateFromString(istioYAML)).To(Succeed())
+					Success("Istio CR created (default revision)")
+				})
+
+				It("should become Ready", func(ctx SpecContext) {
+					common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl, 240*time.Second)
+					Success("Istio is Ready with base version")
+				})
+
+				It("should make ZTunnel Ready now that istiod is running", func(ctx SpecContext) {
+					// ZTunnel should now become Ready since istiod is available
+					Eventually(func(g Gomega) {
+						ztunnel := &v1.ZTunnel{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+						g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+					}).WithTimeout(180*time.Second).Should(Succeed(), "ZTunnel should become Ready")
+					Success("ZTunnel is now Ready with base version")
+				})
+			})
+
+			When("workloads are deployed in ambient mode", func() {
+				BeforeAll(func(ctx SpecContext) {
+					// Step 1: Initialize WorkloadValidator for canary testing in ambient mode
+					validator = &common.WorkloadValidator{
+						K:             k,
+						Cl:            cl,
+						Namespace:     "workload-canary-test",
+						DataplaneMode: common.DataplaneModeAmbient,
+					}
+					// Step 2: Deploy test workloads for canary scenario
+					// - Creates workload-canary-test and httpbin namespaces
+					// - Labels both namespaces with istio.io/dataplane-mode=ambient
+					// - Deploys sleep pod and httpbin service
+					Expect(validator.DeployWorkload(ctx)).To(Succeed(), "Failed to deploy ambient workloads")
+					Success("Workloads deployed in ambient mode")
+				})
+
+				It("should have connectivity", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						// Validate initial connectivity with base version
+						// Tests that sleep pod in workload-canary-test can reach httpbin service
+						// This establishes the baseline before introducing the canary revision
+						g.Expect(validator.ValidateConnectivity(ctx)).To(Succeed())
+						// Verify initial ZTunnel version
+						g.Expect(validator.ValidateProxyVersion(ctx, baseVersion.Version)).To(Succeed())
+					}).WithTimeout(120*time.Second).Should(Succeed(), "Workloads should have connectivity with base version")
+					Success("Workloads have connectivity with base version")
+				})
+			})
+
+			When("shared dependencies are updated to latest version", func() {
+				BeforeAll(func(ctx SpecContext) {
+					// Upgrade IstioCNI
+					cni := &v1.IstioCNI{}
+					Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
+					Log(fmt.Sprintf("Updating IstioCNI from %s to %s", baseVersion.Name, newVersion.Name))
+					cni.Spec.Version = newVersion.Name
+					Expect(cl.Update(ctx, cni)).To(Succeed())
+
+					// Upgrade ZTunnel
+					ztunnel := &v1.ZTunnel{}
+					Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					Log(fmt.Sprintf("Updating ZTunnel from %s to %s", baseVersion.Name, newVersion.Name))
+					ztunnel.Spec.Version = newVersion.Name
+					Expect(cl.Update(ctx, ztunnel)).To(Succeed())
+
+					Success("Shared dependencies updated to latest version")
+				})
+
+				It("should have IstioCNI Ready with latest version", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						cni := &v1.IstioCNI{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
+						g.Expect(cni.Spec.Version).To(Equal(newVersion.Name))
+						g.Expect(cni).To(HaveConditionStatus(v1.IstioCNIConditionReady, metav1.ConditionTrue))
+					}).WithTimeout(180*time.Second).Should(Succeed(), "IstioCNI should be Ready with new version")
+					Success("IstioCNI updated successfully")
+				})
+
+				It("should have ZTunnel Ready with latest version", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						ztunnel := &v1.ZTunnel{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+						g.Expect(ztunnel.Spec.Version).To(Equal(newVersion.Name))
+						g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+					}).WithTimeout(180*time.Second).Should(Succeed(), "ZTunnel should be Ready with new version")
+					Success("ZTunnel updated successfully")
+				})
+
+				It("should keep default Istio revision healthy with updated dependencies", func(ctx SpecContext) {
+					// Default revision should remain healthy with new version of shared deps
+					Eventually(func(g Gomega) {
+						istio := &v1.Istio{}
+						g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+					}).WithTimeout(60*time.Second).Should(Succeed(), "Default Istio revision should remain Ready after dependency update")
+					Success("Default Istio revision remains healthy after dependency update")
+				})
+
+				It("should keep connectivity working after the update to latest version", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						// Validate connectivity after shared dependencies update
+						// Tests that sleep pod can reach httpbin service through the upgraded ZTunnel and CNI
+						// This confirms that updating shared components (IstioCNI + ZTunnel) doesn't affect
+						// workloads using the default (old) control plane revision
+						g.Expect(validator.ValidateConnectivity(ctx)).To(Succeed())
+						// Verify ZTunnel has been upgraded
+						// ZTunnel version should now be new version
+						g.Expect(validator.ValidateProxyVersion(ctx, newVersion.Version)).To(Succeed())
+					}).WithTimeout(120*time.Second).Should(Succeed(),
+						"Workloads should maintain connectivity with latest ZTunnel version")
+					Success("Workloads maintain connectivity with new shared dependencies")
+				})
+			})
+
+			When("canary IstioRevision is created with new version", func() {
+				BeforeAll(func() {
+					revisionYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: IstioRevision
+metadata:
+  name: canary
+spec:
+  version: %s
+  namespace: %s
+  values:
+    profile: ambient
+    revision: canary
+    global:
+      istioNamespace: %s
+    pilot:
+      cni:
+        enabled: true
+      trustedZtunnelNamespace: ztunnel`, newVersion.Name, controlPlaneNamespace, controlPlaneNamespace)
+					Log("Creating canary IstioRevision with new version:", newVersion.Name)
+					Expect(k.CreateFromString(revisionYAML)).To(Succeed())
+					Success("Canary IstioRevision created")
+				})
+
+				It("should become Ready", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						revision := &v1.IstioRevision{}
+						g.Expect(cl.Get(ctx, kube.Key("canary", controlPlaneNamespace), revision)).To(Succeed())
+						g.Expect(revision).To(HaveConditionStatus(v1.IstioRevisionConditionReady, metav1.ConditionTrue))
+					}).WithTimeout(240*time.Second).Should(Succeed(), "Canary revision should become Ready")
+					Success("Canary IstioRevision is Ready")
+				})
+
+				It("should coexist with default revision", func(ctx SpecContext) {
+					// Verify default revision (from Istio CR) is still Ready
+					istio := &v1.Istio{}
+					Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+					Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+
+					// Get the default revision name
+					defaultRevisionName := istio.Status.ActiveRevisionName
+					defaultRevision := &v1.IstioRevision{}
+					Expect(cl.Get(ctx, kube.Key(defaultRevisionName, controlPlaneNamespace), defaultRevision)).To(Succeed())
+					Expect(defaultRevision).To(HaveConditionStatus(v1.IstioRevisionConditionReady, metav1.ConditionTrue))
+
+					// Verify canary revision is Ready
+					canaryRevision := &v1.IstioRevision{}
+					Expect(cl.Get(ctx, kube.Key("canary", controlPlaneNamespace), canaryRevision)).To(Succeed())
+					Expect(canaryRevision).To(HaveConditionStatus(v1.IstioRevisionConditionReady, metav1.ConditionTrue))
+
+					// Verify both deployments exist
+					defaultDeployment := &appsv1.Deployment{}
+					Expect(cl.Get(ctx, kube.Key("istiod", controlPlaneNamespace), defaultDeployment)).To(Succeed())
+					Expect(defaultDeployment.Status.AvailableReplicas).To(BeNumerically(">", 0))
+
+					canaryDeployment := &appsv1.Deployment{}
+					Expect(cl.Get(ctx, kube.Key("istiod-canary", controlPlaneNamespace), canaryDeployment)).To(Succeed())
+					Expect(canaryDeployment.Status.AvailableReplicas).To(BeNumerically(">", 0))
+
+					Success("Default and canary revisions coexist successfully")
+				})
+
+				It("connectivity works with both revisions present", func(ctx SpecContext) {
+					// Validate connectivity with both control plane revisions active
+					// Tests that sleep pod can reach httpbin service while both default and canary
+					// istiod revisions are running side-by-side
+					// This confirms that introducing a canary revision doesn't disrupt existing traffic
+					Expect(validator.ValidateConnectivity(ctx)).To(Succeed(),
+						"Workloads should maintain connectivity with canary revision present")
+					Success("Workloads maintain connectivity with both revisions")
+				})
+			})
+
+			When("shared dependencies are verified", func() {
+				It("should have only one IstioCNI DaemonSet", func(ctx SpecContext) {
+					// List all DaemonSets in IstioCNI namespace
+					dsList := &appsv1.DaemonSetList{}
+					Expect(cl.List(ctx, dsList, client.InNamespace(istioCniNamespace))).To(Succeed())
+
+					// Should have exactly one CNI DaemonSet shared by both revisions
+					Expect(dsList.Items).To(HaveLen(1), "Should have exactly one IstioCNI DaemonSet")
+					Success("Single IstioCNI DaemonSet shared by both revisions")
+				})
+
+				It("should have only one ZTunnel DaemonSet", func(ctx SpecContext) {
+					// List all DaemonSets in ZTunnel namespace
+					dsList := &appsv1.DaemonSetList{}
+					Expect(cl.List(ctx, dsList, client.InNamespace(ztunnelNamespace))).To(Succeed())
+
+					// Should have exactly one ZTunnel DaemonSet shared by both revisions
+					Expect(dsList.Items).To(HaveLen(1), "Should have exactly one ZTunnel DaemonSet")
+					Success("Single ZTunnel DaemonSet shared by both revisions")
+				})
+
+				It("should have IstioCNI and ZTunnel at new version", func(ctx SpecContext) {
+					// Verify shared components were updated to new version
+					cni := &v1.IstioCNI{}
+					Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
+					Expect(cni.Spec.Version).To(Equal(newVersion.Name))
+
+					ztunnel := &v1.ZTunnel{}
+					Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					Expect(ztunnel.Spec.Version).To(Equal(newVersion.Name))
+
+					Success("Shared dependencies updated to new version")
+				})
+			})
+
+			AfterAll(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.Ambient, k)
+					debugInfoLogged = true
+					if keepOnFailure {
+						return
+					}
+				}
+				clr.Cleanup(ctx)
+			})
+		})
+	})
+
+	Describe("Lifecycle Transitions", func() {
+		Context("Spec changes and finalizers", func() {
+			clr := cleaner.New(cl)
+			// Use the newer version for lifecycle testing
+			testVersion := newVersion
+
+			BeforeAll(func(ctx SpecContext) {
+				clr.Record(ctx)
+				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+
+				// Create IstioCNI and Istio control plane so ZTunnel can become Ready
+				cniYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s
+  profile: ambient`, testVersion.Name, istioCniNamespace)
+				Expect(k.CreateFromString(cniYAML)).To(Succeed())
+
+				istioYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: %s
+spec:
+  version: %s
+  namespace: %s
+  values:
+    profile: ambient
+    pilot:
+      cni:
+        enabled: true
+      trustedZtunnelNamespace: ztunnel`, istioName, testVersion.Name, controlPlaneNamespace)
+				Expect(k.CreateFromString(istioYAML)).To(Succeed())
+
+				// Wait for IstioCNI and Istio to be ready
+				common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key("default"), &v1.IstioCNI{}, k, cl, 180*time.Second)
+				common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl, 240*time.Second)
+
+				Success("Control plane and IstioCNI created for lifecycle tests")
+			})
+
+			When("spec.values is updated on ZTunnel", func() {
+				BeforeAll(func(ctx SpecContext) {
+					ztunnelYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s`, testVersion.Name, ztunnelNamespace)
+					Expect(k.CreateFromString(ztunnelYAML)).To(Succeed())
+
+					// Wait for it to be ready
+					Eventually(func(g Gomega) {
+						ztunnel := &v1.ZTunnel{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+						g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+					}).Should(Succeed(), "ZTunnel should become Ready")
+					Success("ZTunnel created and ready")
+				})
+
+				It("should update DaemonSet when values change", func(ctx SpecContext) {
+					// Update the spec.values
+					ztunnel := &v1.ZTunnel{}
+					Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+
+					// Add a custom environment variable
+					if ztunnel.Spec.Values == nil {
+						ztunnel.Spec.Values = &v1.ZTunnelValues{}
+					}
+					if ztunnel.Spec.Values.ZTunnel == nil {
+						ztunnel.Spec.Values.ZTunnel = &v1.ZTunnelConfig{}
+					}
+					if ztunnel.Spec.Values.ZTunnel.Env == nil {
+						ztunnel.Spec.Values.ZTunnel.Env = make(map[string]string)
+					}
+					ztunnel.Spec.Values.ZTunnel.Env["TEST_VAR"] = "test-value"
+
+					Log("Updating ZTunnel spec.values")
+					Expect(cl.Update(ctx, ztunnel)).To(Succeed())
+
+					// Verify the DaemonSet is updated with the new env var
+					Eventually(func(g Gomega) {
+						ds := &appsv1.DaemonSet{}
+						g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), ds)).To(Succeed())
+
+						// Check if the env var exists in the DaemonSet
+						found := false
+						for _, container := range ds.Spec.Template.Spec.Containers {
+							for _, env := range container.Env {
+								if env.Name == "TEST_VAR" && env.Value == "test-value" {
+									found = true
+									break
+								}
+							}
+						}
+						g.Expect(found).To(BeTrue(), "TEST_VAR should be in DaemonSet")
+					}).WithTimeout(120*time.Second).Should(Succeed(), "DaemonSet should be updated with new values")
+					Success("ZTunnel DaemonSet updated after spec.values change")
+				})
+			})
+
+			When("CR is deleted", func() {
+				It("should have finalizer that prevents immediate deletion", func(ctx SpecContext) {
+					// Check that ZTunnel has finalizers
+					ztunnel := &v1.ZTunnel{}
+					Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+					Expect(ztunnel.Finalizers).NotTo(BeEmpty(), "ZTunnel should have finalizers")
+					Success("ZTunnel has finalizers")
+				})
+
+				It("should cleanup resources when deleted", func(ctx SpecContext) {
+					// Delete the ZTunnel CR
+					ztunnel := &v1.ZTunnel{}
+					Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+
+					Log("Deleting ZTunnel CR")
+					Expect(cl.Delete(ctx, ztunnel)).To(Succeed())
+
+					// Verify the DaemonSet is deleted
+					Eventually(func(g Gomega) {
+						ds := &appsv1.DaemonSet{}
+						err := cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), ds)
+						g.Expect(err).To(HaveOccurred())
+						g.Expect(err.Error()).To(ContainSubstring("not found"))
+					}).WithTimeout(120*time.Second).Should(Succeed(), "DaemonSet should be deleted")
+
+					// Verify the CR is fully deleted
+					Eventually(func(g Gomega) {
+						zt := &v1.ZTunnel{}
+						err := cl.Get(ctx, kube.Key("default"), zt)
+						g.Expect(err).To(HaveOccurred())
+						g.Expect(err.Error()).To(ContainSubstring("not found"))
+					}).WithTimeout(60*time.Second).Should(Succeed(), "ZTunnel CR should be fully deleted")
+					Success("ZTunnel CR and resources cleaned up successfully")
+				})
+			})
+
+			AfterAll(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.Ambient, k)
+					debugInfoLogged = true
+					if keepOnFailure {
+						return
+					}
+				}
+				clr.Cleanup(ctx)
+			})
+		})
+	})
+
+	AfterAll(func() {
+		if CurrentSpecReport().Failed() {
+			if !debugInfoLogged {
+				common.LogDebugInfo(common.Ambient, k)
+				debugInfoLogged = true
+
+				if keepOnFailure {
+					return
+				}
+			}
+		}
+	})
+})

--- a/tests/e2e/ambient/ambient_update_test.go
+++ b/tests/e2e/ambient/ambient_update_test.go
@@ -161,12 +161,13 @@ spec:
 
 			When("IstioCNI version is updated", func() {
 				BeforeAll(func(ctx SpecContext) {
-					cni := &v1.IstioCNI{}
-					Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
-
 					Log(fmt.Sprintf("Updating IstioCNI from %s to %s", baseVersion.Name, newVersion.Name))
-					cni.Spec.Version = newVersion.Name
-					Expect(cl.Update(ctx, cni)).To(Succeed())
+					Eventually(func(g Gomega) {
+						cni := &v1.IstioCNI{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), cni)).To(Succeed())
+						cni.Spec.Version = newVersion.Name
+						g.Expect(cl.Update(ctx, cni)).To(Succeed())
+					}).Should(Succeed())
 					Success("IstioCNI version updated")
 				})
 
@@ -202,12 +203,13 @@ spec:
 
 			When("ZTunnel version is updated", func() {
 				BeforeAll(func(ctx SpecContext) {
-					ztunnel := &v1.ZTunnel{}
-					Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
-
 					Log(fmt.Sprintf("Updating ZTunnel from %s to %s", baseVersion.Name, newVersion.Name))
-					ztunnel.Spec.Version = newVersion.Name
-					Expect(cl.Update(ctx, ztunnel)).To(Succeed())
+					Eventually(func(g Gomega) {
+						ztunnel := &v1.ZTunnel{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+						ztunnel.Spec.Version = newVersion.Name
+						g.Expect(cl.Update(ctx, ztunnel)).To(Succeed())
+					}).Should(Succeed())
 					Success("ZTunnel version updated")
 				})
 
@@ -247,13 +249,13 @@ spec:
 
 			When("Istio version is updated", func() {
 				BeforeAll(func(ctx SpecContext) {
-					// Update the Istio CR to new version
-					istio := &v1.Istio{}
-					Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
-
 					Log(fmt.Sprintf("Updating Istio from %s to %s", baseVersion.Name, newVersion.Name))
-					istio.Spec.Version = newVersion.Name
-					Expect(cl.Update(ctx, istio)).To(Succeed())
+					Eventually(func(g Gomega) {
+						istio := &v1.Istio{}
+						g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+						istio.Spec.Version = newVersion.Name
+						g.Expect(cl.Update(ctx, istio)).To(Succeed())
+					}).Should(Succeed())
 					Success("Istio version updated")
 				})
 

--- a/tests/e2e/ambient/ambient_validation_test.go
+++ b/tests/e2e/ambient/ambient_validation_test.go
@@ -1,0 +1,136 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Ambient API Validation", Label("ambient", "ambient-validation"), Ordered, func() {
+	SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	// Use the latest supported ambient version for these tests
+	version := getLatestAmbientVersion()
+
+	var clr cleaner.Cleaner
+
+	BeforeAll(func(ctx SpecContext) {
+		clr = cleaner.New(cl)
+		clr.Record(ctx)
+
+		Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
+		Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
+		Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+	})
+
+	AfterAll(func(ctx SpecContext) {
+		if CurrentSpecReport().Failed() {
+			common.LogDebugInfo(common.Ambient, k)
+			if keepOnFailure {
+				return
+			}
+		}
+		clr.Cleanup(ctx)
+	})
+
+	Context("Single Instance Name Enforcement", func() {
+		When("attempting to create IstioCNI with non-default name", func() {
+			It("rejects IstioCNI CR with name != 'default'", func(ctx SpecContext) {
+				cniYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: custom-cni
+spec:
+  version: %s
+  namespace: %s
+  profile: ambient`, version.Name, istioCniNamespace)
+
+				err := k.CreateFromString(cniYAML)
+				Expect(err).To(HaveOccurred(), "IstioCNI creation should fail with non-default name")
+
+				// Verify error message indicates validation failure
+				errorMsg := err.Error()
+				Expect(strings.Contains(errorMsg, "metadata.name") || strings.Contains(errorMsg, "default")).To(BeTrue(),
+					"Error message should mention metadata.name or 'default' requirement")
+				Success("IstioCNI with custom name correctly rejected")
+			})
+		})
+
+		When("attempting to create ZTunnel with non-default name", func() {
+			It("rejects ZTunnel CR with name != 'default'", func(ctx SpecContext) {
+				ztunnelYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: custom-ztunnel
+spec:
+  version: %s
+  namespace: %s`, version.Name, ztunnelNamespace)
+
+				err := k.CreateFromString(ztunnelYAML)
+				Expect(err).To(HaveOccurred(), "ZTunnel creation should fail with non-default name")
+
+				// Verify error message indicates validation failure
+				errorMsg := err.Error()
+				Expect(strings.Contains(errorMsg, "metadata.name") || strings.Contains(errorMsg, "default")).To(BeTrue(),
+					"Error message should mention metadata.name or 'default' requirement")
+				Success("ZTunnel with custom name correctly rejected")
+			})
+		})
+
+		When("creating IstioCNI and ZTunnel with metadata.name='default'", func() {
+			It("successfully creates IstioCNI with name 'default'", func(ctx SpecContext) {
+				cniYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s
+  profile: ambient`, version.Name, istioCniNamespace)
+
+				Expect(k.CreateFromString(cniYAML)).To(Succeed())
+				Success("IstioCNI with name='default' created successfully")
+			})
+
+			It("successfully creates ZTunnel with name 'default'", func(ctx SpecContext) {
+				ztunnelYAML := fmt.Sprintf(`
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: %s
+  namespace: %s`, version.Name, ztunnelNamespace)
+
+				Expect(k.CreateFromString(ztunnelYAML)).To(Succeed())
+				Success("ZTunnel with name='default' created successfully")
+			})
+		})
+	})
+})

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -17,12 +17,8 @@
 package controlplane
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
@@ -30,7 +26,6 @@ import (
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
-	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/istioctl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -191,7 +186,7 @@ metadata:
 
 					It("has sidecars with the correct istio version", func(ctx SpecContext) {
 						for _, pod := range samplePods.Items {
-							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
+							sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
 							Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
 							Expect(sidecarVersion).To(Equal(version.Version), "Sidecar Istio version does not match the expected version")
 						}
@@ -255,43 +250,3 @@ metadata:
 		}
 	})
 })
-
-func getProxyVersion(podName, namespace string) (*semver.Version, error) {
-	proxyStatus, err := istioctl.GetProxyStatus("--namespace " + namespace)
-	if err != nil {
-		return nil, fmt.Errorf("error getting sidecar version: %w", err)
-	}
-
-	lines := strings.Split(proxyStatus, "\n")
-	colSplit := regexp.MustCompile(`\s{2,}`)
-
-	versionIdx := -1
-	headers := colSplit.Split(strings.TrimSpace(lines[0]), -1)
-	for i, header := range headers {
-		if header == "VERSION" {
-			versionIdx = i
-			break
-		}
-	}
-	if versionIdx == -1 {
-		return nil, fmt.Errorf("VERSION header not found")
-	}
-
-	var versionStr string
-	for _, line := range lines[1:] {
-		if strings.Contains(line, podName+"."+namespace) {
-			values := colSplit.Split(strings.TrimSpace(line), -1)
-			versionStr = values[versionIdx]
-			break
-		}
-	}
-
-	if versionStr == "" {
-		return nil, fmt.Errorf("pod %s not found in proxy status output for namespace %s", podName, namespace)
-	}
-	version, err := semver.NewVersion(versionStr)
-	if err != nil {
-		return version, fmt.Errorf("error parsing sidecar version %q: %w", versionStr, err)
-	}
-	return version, err
-}

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -224,6 +224,11 @@ metadata:
 				})
 
 				AfterAll(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.ControlPlane, k)
+						debugInfoLogged = true
+					}
+
 					if CurrentSpecReport().Failed() && keepOnFailure {
 						return
 					}
@@ -232,21 +237,11 @@ metadata:
 				})
 			})
 		}
-
-		AfterAll(func(ctx SpecContext) {
-			if CurrentSpecReport().Failed() {
-				common.LogDebugInfo(common.ControlPlane, k)
-				debugInfoLogged = true
-			}
-		})
 	})
 
 	AfterAll(func() {
-		if CurrentSpecReport().Failed() {
-			if !debugInfoLogged {
-				common.LogDebugInfo(common.ControlPlane, k)
-				debugInfoLogged = true
-			}
+		if CurrentSpecReport().Failed() && !debugInfoLogged {
+			common.LogDebugInfo(common.ControlPlane, k)
 		}
 	})
 })

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -35,7 +35,7 @@ import (
 	"istio.io/istio/pkg/ptr"
 )
 
-var _ = Describe("Control Plane Installation", Label("smoke", "control-plane", "slow"), Ordered, func() {
+var _ = Describe("Control Plane Installation", Label("control-plane", "slow", "sidecar"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -29,44 +29,46 @@ import (
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/update"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Control Plane updates", Label("control-plane", "slow"), Ordered, func() {
+var _ = Describe("Control Plane updates", Label("control-plane", "update", "slow"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false
 
 	Describe("using IstioRevisionTag", func() {
+		var baseVersion, newVersion istioversion.VersionInfo
+
 		BeforeAll(func() {
-			if istioversion.Base == "" || istioversion.New == "" {
-				Skip("Skipping update tests because there are not enough versions in versions.yaml")
+			var err error
+			baseVersion, newVersion, err = update.GetTwoConsecutiveSidecarVersions()
+			if err != nil {
+				Skip(fmt.Sprintf("Skipping update tests: %v", err))
 			}
 		})
 
-		Context(istioversion.Base, func() {
+		Context(fmt.Sprintf("updating from %s to %s", baseVersion.Name, newVersion.Name), func() {
 			clr := cleaner.New(cl)
 
 			BeforeAll(func(ctx SpecContext) {
-				if len(istioversion.List) < 2 {
-					Skip("Skipping update tests because there are not enough versions in versions.yaml")
-				}
-
 				clr.Record(ctx)
 				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
 				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
 
-				common.CreateIstioCNI(k, istioversion.Base)
+				common.CreateIstioCNI(k, baseVersion.Name)
 				common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
 			})
 
-			When(fmt.Sprintf("the Istio CR is created with RevisionBased updateStrategy for base version %s", istioversion.Base), func() {
+			When(fmt.Sprintf("the Istio CR is created with RevisionBased updateStrategy for base version %s", baseVersion.Name), func() {
 				BeforeAll(func() {
-					common.CreateIstio(k, istioversion.Base, `
+					common.CreateIstio(k, baseVersion.Name, `
 updateStrategy:
   type: RevisionBased
   inactiveRevisionDeletionGracePeriodSeconds: 30`)
@@ -102,7 +104,7 @@ spec:
 				})
 
 				It("IstioRevisionTag revision name is equal to the IstioRevision base name", func(ctx SpecContext) {
-					revisionName := strings.Replace(istioversion.Base, ".", "-", -1)
+					revisionName := strings.Replace(baseVersion.Name, ".", "-", -1)
 					Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key("default"), &v1.IstioRevisionTag{}).
 						Should(HaveField("Status.IstioRevision", ContainSubstring(revisionName)),
 							"IstioRevisionTag version does not match the IstioRevision name of the base version")
@@ -126,9 +128,9 @@ spec:
 					Success("sample pods are ready")
 
 					for _, pod := range samplePods.Items {
-						sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
+						sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
 						Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
-						Expect(sidecarVersion).To(Equal(istioversion.Map[istioversion.Base].Version), "Sidecar Istio version does not match the expected version")
+						Expect(sidecarVersion).To(Equal(baseVersion.Version), "Sidecar Istio version does not match the expected version")
 					}
 					Success("Istio sidecar version matches the expected base Istio version")
 				})
@@ -140,7 +142,7 @@ spec:
 
 			When("the Istio CR is updated to the new Istio version", func() {
 				BeforeAll(func() {
-					Expect(k.Patch("istio", "default", "merge", `{"spec":{"version":"`+istioversion.New+`"}}`)).To(Succeed(), "Error updating Istio CR to new Istio version")
+					Expect(k.Patch("istio", "default", "merge", `{"spec":{"version":"`+newVersion.Name+`"}}`)).To(Succeed(), "Error updating Istio CR to new Istio version")
 					Success("Istio CR updated")
 				})
 
@@ -172,10 +174,10 @@ spec:
 					Expect(cl.List(ctx, istioRevisions)).To(Succeed())
 					Expect(istioRevisions.Items).To(HaveLen(2), "Unexpected number of IstioRevisionTags; expected 2")
 					Expect(istioRevisions.Items).To(ContainElement(
-						HaveField("Spec", HaveField("Version", ContainSubstring(istioversion.Base)))),
+						HaveField("Spec", HaveField("Version", ContainSubstring(baseVersion.Name)))),
 						"Expected a revision with the base version")
 					Expect(istioRevisions.Items).To(ContainElement(
-						HaveField("Spec", HaveField("Version", ContainSubstring(istioversion.New)))),
+						HaveField("Spec", HaveField("Version", ContainSubstring(newVersion.Name)))),
 						"Expected a revision with the new version")
 					Success("Two IstionRevision found")
 				})
@@ -197,9 +199,9 @@ spec:
 
 					for _, pod := range samplePods.Items {
 						Eventually(func(g Gomega) {
-							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
+							sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
 							g.Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
-							g.Expect(sidecarVersion).To(Equal(istioversion.Map[istioversion.Base].Version))
+							g.Expect(sidecarVersion).To(Equal(baseVersion.Version))
 						}).Should(Succeed(), "Sidecar Istio version does not match the expected version")
 					}
 					Success("Istio sidecar version matches the expected Istio version")
@@ -229,8 +231,8 @@ spec:
 						}
 
 						for _, pod := range samplePods.Items {
-							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
-							if err != nil || !sidecarVersion.Equal(istioversion.Map[istioversion.New].Version) {
+							sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
+							if err != nil || !sidecarVersion.Equal(newVersion.Version) {
 								return false
 							}
 						}
@@ -256,7 +258,7 @@ spec:
 				})
 
 				It("IstioRevisionTag revision name is equal to the IstionRevision name of the new Istio version", func(ctx SpecContext) {
-					revisionName := strings.Replace(istioversion.New, ".", "-", -1)
+					revisionName := strings.Replace(newVersion.Name, ".", "-", -1)
 					Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key("default"), &v1.IstioRevisionTag{}).
 						Should(HaveField("Status.IstioRevision", ContainSubstring(revisionName)), "IstioRevisionTag version does not match the new IstioRevision name")
 					Success("IstioRevisionTag points to the new IstioRevision")
@@ -287,6 +289,298 @@ spec:
 					}
 				}
 			}
+		})
+	})
+
+	Describe("In-Place Updates", func() {
+		var baseVersion, newVersion istioversion.VersionInfo
+
+		BeforeAll(func() {
+			var err error
+			baseVersion, newVersion, err = update.GetTwoConsecutiveSidecarVersions()
+			if err != nil {
+				Skip(fmt.Sprintf("Skipping update tests: %v", err))
+			}
+		})
+
+		Context(fmt.Sprintf("Updating from %s to %s", baseVersion.Name, newVersion.Name), func() {
+			clr := cleaner.New(cl)
+			var validator *common.WorkloadValidator
+
+			BeforeAll(func(ctx SpecContext) {
+				clr.Record(ctx)
+				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
+			})
+
+			When(fmt.Sprintf("Istio CR is created with InPlace updateStrategy for version %s", baseVersion.Name), func() {
+				BeforeAll(func() {
+					common.CreateIstio(k, baseVersion.Name, `
+updateStrategy:
+  type: InPlace`)
+				})
+
+				It("should deploy istiod and become Ready", func(ctx SpecContext) {
+					common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key("default"), &v1.Istio{}, k, cl)
+					common.AwaitDeployment(ctx, "istiod", k, cl)
+					Success("Istio CR is Ready and istiod deployment is available")
+				})
+			})
+
+			When("workloads are deployed in sidecar mode", func() {
+				BeforeAll(func(ctx SpecContext) {
+					// Step 1: Initialize WorkloadValidator for sidecar mode testing
+					// This sets up the validator to deploy and validate workloads with sidecar injection
+					validator = &common.WorkloadValidator{
+						K:             k,
+						Cl:            cl,
+						Namespace:     "workload-update-test",
+						DataplaneMode: common.DataplaneModeSidecar,
+					}
+					// Step 2: Deploy test workloads (sleep + httpbin) with sidecar injection
+					// - Creates workload-update-test and httpbin namespaces
+					// - Labels both namespaces with istio-injection=enabled for sidecar injection
+					// - Deploys sleep pod (with sidecar) in workload-update-test namespace
+					// - Deploys httpbin service (with sidecar) in httpbin namespace
+					Expect(validator.DeployWorkload(ctx)).To(Succeed(), "Failed to deploy workloads")
+					Success("Workloads deployed")
+				})
+
+				It("should have connectivity with old version", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						// Step 3: Validate connectivity between sidecar-injected workloads
+						// Tests that sleep pod can reach httpbin service through their sidecar proxies
+						// This verifies the mesh is routing traffic correctly with base version sidecars
+						g.Expect(validator.ValidateConnectivity(ctx)).To(Succeed())
+					}).WithTimeout(120*time.Second).Should(Succeed(), "Workload connectivity failed")
+					Success("Workloads have connectivity")
+				})
+
+				It("should have correct proxy version", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						// Step 4: Verify sidecar proxy version matches base version
+						// Checks the istio-proxy container version in workload pods
+						g.Expect(validator.ValidateProxyVersion(ctx, baseVersion.Version)).To(Succeed())
+					}).WithTimeout(60*time.Second).Should(Succeed(), "Proxy version validation failed")
+					Success("Proxy versions match old version")
+				})
+			})
+
+			When("Istio CR version is updated", func() {
+				BeforeAll(func() {
+					Expect(k.Patch("istio", "default", "merge", `{"spec":{"version":"`+newVersion.Name+`"}}`)).
+						To(Succeed(), "Error updating Istio CR version")
+					Success("Istio CR version updated to " + newVersion.Name)
+				})
+
+				It("should remain a single IstioRevision", func(ctx SpecContext) {
+					Consistently(func(g Gomega) {
+						revisions := &v1.IstioRevisionList{}
+						g.Expect(cl.List(ctx, revisions)).To(Succeed())
+						g.Expect(revisions.Items).To(HaveLen(1), "Should have exactly one IstioRevision")
+					}).WithTimeout(30 * time.Second).Should(Succeed())
+					Success("Single IstioRevision maintained")
+				})
+
+				It("should update the IstioRevision spec.version in-place", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						revision := &v1.IstioRevision{}
+						g.Expect(cl.Get(ctx, kube.Key("default", controlPlaneNamespace), revision)).To(Succeed())
+						g.Expect(revision.Spec.Version).To(Equal(newVersion.Name))
+					}).Should(Succeed(), "IstioRevision version should be updated in-place")
+					Success("IstioRevision updated in-place")
+				})
+
+				It("should reconcile and remain Ready", func(ctx SpecContext) {
+					common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key("default"), &v1.Istio{}, k, cl)
+					Success("Istio CR remains Ready after version update")
+				})
+
+				It("should update the istiod deployment", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						version, err := common.GetVersionFromIstiod()
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(version).To(Equal(newVersion.Version))
+					}).Should(Succeed(), "istiod deployment should be updated to new version")
+					Success("istiod deployment updated")
+				})
+			})
+
+			When("workloads are restarted", func() {
+				BeforeAll(func(ctx SpecContext) {
+					// Delete pods to trigger restart with new sidecar version
+					// This simulates pod restart which will pick up the updated injector webhook
+					// and inject sidecars with the new version
+					pods := &corev1.PodList{}
+					Expect(cl.List(ctx, pods, client.InNamespace("workload-update-test"))).To(Succeed())
+					for _, pod := range pods.Items {
+						Expect(cl.Delete(ctx, &pod)).To(Succeed())
+					}
+					Success("Workload pods deleted for restart")
+				})
+
+				It("should have connectivity with new version", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						// Validate connectivity after pod restart with new sidecars
+						// Tests that sleep pod (with new sidecar) can reach httpbin service (with new sidecar)
+						// This confirms the in-place update completed successfully and new sidecars are working
+						g.Expect(validator.ValidateConnectivity(ctx)).To(Succeed())
+					}).WithTimeout(120*time.Second).Should(Succeed(), "Workload connectivity failed after restart")
+					Success("Workloads have connectivity after restart")
+				})
+
+				It("should have updated proxy version", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						// Verify sidecar proxy version has been upgraded
+						// Checks that restarted pods now have sidecars with the new version
+						g.Expect(validator.ValidateProxyVersion(ctx, newVersion.Version)).To(Succeed())
+					}).WithTimeout(120*time.Second).Should(Succeed(), "Proxy version should match new version")
+					Success("Proxy versions updated to new version")
+				})
+
+				It("should still have only one IstioRevision", func(ctx SpecContext) {
+					revisions := &v1.IstioRevisionList{}
+					Expect(cl.List(ctx, revisions)).To(Succeed())
+					Expect(revisions.Items).To(HaveLen(1), "Should still have exactly one IstioRevision")
+					Expect(revisions.Items[0].Name).To(Equal("default"), "IstioRevision name should match Istio CR name")
+					Success("Single IstioRevision confirmed")
+				})
+			})
+
+			AfterAll(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.ControlPlane, k)
+					if keepOnFailure {
+						return
+					}
+				}
+				clr.Cleanup(ctx)
+			})
+		})
+	})
+
+	Describe("Lifecycle Transitions", func() {
+		var newVersion istioversion.VersionInfo
+
+		BeforeAll(func() {
+			var err error
+			_, newVersion, err = update.GetTwoConsecutiveSidecarVersions()
+			if err != nil {
+				Skip(fmt.Sprintf("Skipping update tests: %v", err))
+			}
+		})
+
+		Context("Spec changes and finalizers", func() {
+			clr := cleaner.New(cl)
+			testVersion := newVersion
+
+			BeforeAll(func(ctx SpecContext) {
+				clr.Record(ctx)
+				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
+
+				// Create Istio CR with test version
+				common.CreateIstio(k, testVersion.Name, `
+updateStrategy:
+  type: InPlace`)
+
+				// Wait for it to be ready
+				common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key("default"), &v1.Istio{}, k, cl)
+				Success("Istio CR created and ready for lifecycle tests")
+			})
+
+			When("spec.values is updated on Istio CR", func() {
+				It("should update istiod deployment when values change", func(ctx SpecContext) {
+					// Get current Istio CR
+					istio := &v1.Istio{}
+					Expect(cl.Get(ctx, kube.Key("default"), istio)).To(Succeed())
+
+					// Modify spec.values to add a custom env var
+					if istio.Spec.Values == nil {
+						istio.Spec.Values = &v1.Values{}
+					}
+					if istio.Spec.Values.Pilot == nil {
+						istio.Spec.Values.Pilot = &v1.PilotConfig{}
+					}
+					if istio.Spec.Values.Pilot.Env == nil {
+						istio.Spec.Values.Pilot.Env = make(map[string]string)
+					}
+					istio.Spec.Values.Pilot.Env["TEST_VAR"] = "test-value"
+
+					Log("Updating Istio spec.values")
+					Expect(cl.Update(ctx, istio)).To(Succeed())
+
+					// Verify the istiod Deployment is updated with the new env var
+					Eventually(func(g Gomega) {
+						deployment := &appsv1.Deployment{}
+						g.Expect(cl.Get(ctx, kube.Key("istiod", controlPlaneNamespace), deployment)).To(Succeed())
+
+						// Check if the env var exists in the deployment
+						found := false
+						for _, container := range deployment.Spec.Template.Spec.Containers {
+							for _, env := range container.Env {
+								if env.Name == "TEST_VAR" && env.Value == "test-value" {
+									found = true
+									break
+								}
+							}
+						}
+						g.Expect(found).To(BeTrue(), "TEST_VAR should be in istiod deployment")
+					}).WithTimeout(120*time.Second).Should(Succeed(), "istiod deployment should have new env var")
+					Success("istiod deployment updated after spec.values change")
+				})
+			})
+
+			When("CR is deleted", func() {
+				It("should have finalizer on IstioRevision that prevents immediate deletion", func(ctx SpecContext) {
+					// IstioRevision has finalizers (not Istio CR itself)
+					revision := &v1.IstioRevision{}
+					Expect(cl.Get(ctx, kube.Key("default", controlPlaneNamespace), revision)).To(Succeed())
+					Expect(revision.Finalizers).NotTo(BeEmpty(), "IstioRevision should have finalizers")
+					Success("IstioRevision has finalizers")
+				})
+
+				It("should cleanup resources when deleted", func(ctx SpecContext) {
+					istio := &v1.Istio{}
+					Expect(cl.Get(ctx, kube.Key("default"), istio)).To(Succeed())
+
+					Log("Deleting Istio CR")
+					Expect(cl.Delete(ctx, istio)).To(Succeed())
+
+					// Verify the istiod Deployment is deleted
+					Eventually(func(g Gomega) {
+						deployment := &appsv1.Deployment{}
+						err := cl.Get(ctx, kube.Key("istiod", controlPlaneNamespace), deployment)
+						g.Expect(err).To(HaveOccurred())
+						g.Expect(err.Error()).To(ContainSubstring("not found"))
+					}).WithTimeout(120*time.Second).Should(Succeed(), "istiod deployment should be deleted")
+
+					// Verify the IstioRevision is deleted
+					Eventually(func(g Gomega) {
+						revision := &v1.IstioRevision{}
+						err := cl.Get(ctx, kube.Key("default", controlPlaneNamespace), revision)
+						g.Expect(err).To(HaveOccurred())
+						g.Expect(err.Error()).To(ContainSubstring("not found"))
+					}).WithTimeout(60*time.Second).Should(Succeed(), "IstioRevision should be deleted")
+
+					// Verify the Istio CR is fully deleted
+					Eventually(func(g Gomega) {
+						ist := &v1.Istio{}
+						err := cl.Get(ctx, kube.Key("default"), ist)
+						g.Expect(err).To(HaveOccurred())
+						g.Expect(err.Error()).To(ContainSubstring("not found"))
+					}).WithTimeout(60*time.Second).Should(Succeed(), "Istio CR should be fully deleted")
+					Success("Istio CR and all resources cleaned up successfully")
+				})
+			})
+
+			AfterAll(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.ControlPlane, k)
+					if keepOnFailure {
+						return
+					}
+				}
+				clr.Cleanup(ctx)
+			})
 		})
 	})
 })

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Control Plane updates", Label("control-plane", "update", "slow"), Ordered, func() {
+var _ = Describe("Control Plane updates", Label("control-plane", "update", "slow", "sidecar"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -215,7 +215,7 @@ spec:
 					Expect(samplePods.Items).ToNot(BeEmpty(), "No pods found in sample namespace")
 
 					for _, pod := range samplePods.Items {
-						cl.Delete(ctx, &pod)
+						Expect(cl.Delete(ctx, &pod)).To(Succeed())
 					}
 
 					Eventually(common.CheckSamplePodsReady).WithArguments(ctx, cl).Should(Succeed(), "Error checking status of sample pods")
@@ -377,7 +377,7 @@ updateStrategy:
 						revisions := &v1.IstioRevisionList{}
 						g.Expect(cl.List(ctx, revisions)).To(Succeed())
 						g.Expect(revisions.Items).To(HaveLen(1), "Should have exactly one IstioRevision")
-					}).WithTimeout(30 * time.Second).Should(Succeed())
+					}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 					Success("Single IstioRevision maintained")
 				})
 
@@ -489,24 +489,26 @@ updateStrategy:
 
 			When("spec.values is updated on Istio CR", func() {
 				It("should update istiod deployment when values change", func(ctx SpecContext) {
-					// Get current Istio CR
-					istio := &v1.Istio{}
-					Expect(cl.Get(ctx, kube.Key("default"), istio)).To(Succeed())
-
-					// Modify spec.values to add a custom env var
-					if istio.Spec.Values == nil {
-						istio.Spec.Values = &v1.Values{}
-					}
-					if istio.Spec.Values.Pilot == nil {
-						istio.Spec.Values.Pilot = &v1.PilotConfig{}
-					}
-					if istio.Spec.Values.Pilot.Env == nil {
-						istio.Spec.Values.Pilot.Env = make(map[string]string)
-					}
-					istio.Spec.Values.Pilot.Env["TEST_VAR"] = "test-value"
-
 					Log("Updating Istio spec.values")
-					Expect(cl.Update(ctx, istio)).To(Succeed())
+					Eventually(func(g Gomega) {
+						// Get current Istio CR fresh on each attempt to avoid 409 Conflict
+						istio := &v1.Istio{}
+						g.Expect(cl.Get(ctx, kube.Key("default"), istio)).To(Succeed())
+
+						// Modify spec.values to add a custom env var
+						if istio.Spec.Values == nil {
+							istio.Spec.Values = &v1.Values{}
+						}
+						if istio.Spec.Values.Pilot == nil {
+							istio.Spec.Values.Pilot = &v1.PilotConfig{}
+						}
+						if istio.Spec.Values.Pilot.Env == nil {
+							istio.Spec.Values.Pilot.Env = make(map[string]string)
+						}
+						istio.Spec.Values.Pilot.Env["TEST_VAR"] = "test-value"
+
+						g.Expect(cl.Update(ctx, istio)).To(Succeed())
+					}).Should(Succeed())
 
 					// Verify the istiod Deployment is updated with the new env var
 					Eventually(func(g Gomega) {

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -222,6 +222,11 @@ values:
 				})
 
 				AfterAll(func(ctx SpecContext) {
+					if CurrentSpecReport().Failed() {
+						common.LogDebugInfo(common.DualStack, k)
+						debugInfoLogged = true
+					}
+
 					if CurrentSpecReport().Failed() && keepOnFailure {
 						return
 					}
@@ -230,19 +235,11 @@ values:
 				})
 			})
 		}
-
-		AfterAll(func(ctx SpecContext) {
-			if CurrentSpecReport().Failed() {
-				common.LogDebugInfo(common.DualStack, k)
-				debugInfoLogged = true
-			}
-		})
 	})
 
 	AfterAll(func(ctx SpecContext) {
 		if CurrentSpecReport().Failed() && !debugInfoLogged {
 			common.LogDebugInfo(common.DualStack, k)
-			debugInfoLogged = true
 		}
 	})
 })

--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -43,7 +43,7 @@ const (
 	SleepNamespace     = "sleep"
 )
 
-var _ = Describe("DualStack configuration ", Label("dualstack"), Ordered, func() {
+var _ = Describe("DualStack configuration ", Label("dualstack", "slow", "sidecar"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 

--- a/tests/e2e/gatewaycontroller/gateway_controller_test.go
+++ b/tests/e2e/gatewaycontroller/gateway_controller_test.go
@@ -40,7 +40,7 @@ import (
 	"istio.io/istio/pkg/ptr"
 )
 
-var _ = Describe("Gateway Controller with Install Library", Label("gateway-controller"), Ordered, func() {
+var _ = Describe("Gateway Controller with Install Library", Label("gateway-controller", "slow"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 

--- a/tests/e2e/library/library_crd_ownership_test.go
+++ b/tests/e2e/library/library_crd_ownership_test.go
@@ -120,7 +120,7 @@ func createAllIstioCRDs(ctx context.Context) {
 	})
 }
 
-var _ = Describe("CRD Ownership", Label("crd-ownership"), Ordered, func() {
+var _ = Describe("CRD Ownership", Label("library", "crd-ownership"), Ordered, func() {
 	SetDefaultEventuallyTimeout(3 * time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Second)
 

--- a/tests/e2e/library/library_reconcile_test.go
+++ b/tests/e2e/library/library_reconcile_test.go
@@ -18,6 +18,7 @@ package library
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
+	"helm.sh/helm/v4/pkg/storage/driver"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -83,7 +85,14 @@ var _ = Describe("Library Reconciliation", Label("library", "reconciliation"), O
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				Expect(lib.Uninstall(ctx, namespace, revision)).To(Succeed())
+				// lib.Uninstall may race with Helm's internal purge step: after finding
+				// the release, the secret can be deleted concurrently before Helm purges
+				// it, producing a spurious ErrReleaseNotFound. EnsureNamespaceWithCleanup
+				// deletes the namespace afterward regardless, so no state is left behind.
+				// Any other error is unexpected and must be reported.
+				if err := lib.Uninstall(ctx, namespace, revision); err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
+					Expect(err).NotTo(HaveOccurred(), "unexpected error uninstalling Helm chart")
+				}
 				lib.Stop()
 				Success("Cleaned up TLS test")
 			})
@@ -188,7 +197,14 @@ var _ = Describe("Library Reconciliation", Label("library", "reconciliation"), O
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				Expect(lib.Uninstall(ctx, namespace, revision)).To(Succeed())
+				// lib.Uninstall may race with Helm's internal purge step: after finding
+				// the release, the secret can be deleted concurrently before Helm purges
+				// it, producing a spurious ErrReleaseNotFound. EnsureNamespaceWithCleanup
+				// deletes the namespace afterward regardless, so no state is left behind.
+				// Any other error is unexpected and must be reported.
+				if err := lib.Uninstall(ctx, namespace, revision); err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
+					Expect(err).NotTo(HaveOccurred(), "unexpected error uninstalling Helm chart")
+				}
 				lib.Stop()
 				Success("Cleaned up reconcile loop test")
 			})

--- a/tests/e2e/library/library_reconcile_test.go
+++ b/tests/e2e/library/library_reconcile_test.go
@@ -47,7 +47,7 @@ const (
 	driftTestNamespace = "library-test-drift"
 )
 
-var _ = Describe("Library Reconciliation", Label("reconciliation"), Ordered, func() {
+var _ = Describe("Library Reconciliation", Label("library", "reconciliation"), Ordered, func() {
 	SetDefaultEventuallyTimeout(3 * time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Second)
 

--- a/tests/e2e/migration/migration_coexistence_test.go
+++ b/tests/e2e/migration/migration_coexistence_test.go
@@ -1,0 +1,420 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
+	"github.com/istio-ecosystem/sail-operator/pkg/kube"
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// expectedPodRestartError is the expected HTTP 503 error during pod restart in migration
+	expectedPodRestartError = "unexpected status code: 503"
+)
+
+var _ = Describe("Migration Sidecar-Ambient Coexistence Validation", Ordered,
+	Label("migration", "migration-coexistence", "slow"), func() {
+		// Tests sidecar-ambient coexistence during migration with continuous traffic.
+		// Uses a stable external client (sidecar mode, never migrates) to send traffic
+		// to a server that transitions from sidecar → HBONE → ambient while traffic flows.
+		// This validates cross-mode communication and verifies traffic resilience during migration.
+		// Validates:
+		//   1. Cross-mode communication works (sidecar client → ambient server)
+		//   2. Limited disruption during pod restart (≤10 503 errors - brief, acceptable)
+		//   3. Traffic RECOVERS after disruption (≥9/10 consecutive successes post-migration)
+		SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
+		SetDefaultEventuallyPollingInterval(time.Second)
+
+		version := istioversion.GetLatestAmbientVersion()
+
+		Context(fmt.Sprintf("Migration testing with Istio %s", version.Version), func() {
+			var clr cleaner.Cleaner
+			workloadNamespace := "workload-traffic"
+			stableClientNamespace := "stable-client"
+
+			BeforeAll(func(ctx SpecContext) {
+				clr = cleaner.New(cl)
+				clr.Record(ctx)
+
+				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+
+				common.CreateIstioCNI(k, version.Name)
+				common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
+				Success("IstioCNI created (no profile - sidecar mode)")
+
+				common.CreateIstio(k, version.Name)
+				common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl)
+				Success("Istio created (default profile - sidecar mode)")
+
+				// Wait for sidecar injector webhook to be ready
+				Eventually(func(g Gomega) {
+					webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
+					g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
+				}).Should(Succeed())
+				Success("Sidecar injector webhook is ready")
+			})
+
+			AfterAll(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.Ambient, k)
+					if keepOnFailure {
+						return
+					}
+				}
+				clr.Cleanup(ctx)
+			})
+
+			Context("Sidecar-Ambient Coexistence with Continuous Traffic", Ordered,
+				Label("migration-coexistence-traffic"), func() {
+					BeforeAll(func(ctx SpecContext) {
+						// Create and deploy stable client (never migrates, always stays in sidecar mode)
+						Expect(k.CreateNamespace(stableClientNamespace)).To(Succeed())
+						Expect(k.Label("namespace", stableClientNamespace, "istio-injection", "enabled")).To(Succeed())
+						Expect(k.WithNamespace(stableClientNamespace).ApplyKustomize("sleep")).To(Succeed())
+						Success("Stable sleep client deployed with sidecar injection")
+
+						Eventually(func(g Gomega) {
+							pods := &corev1.PodList{}
+							g.Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace))).To(Succeed())
+							g.Expect(pods.Items).To(HaveLen(1))
+
+							pod := pods.Items[0]
+							g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+
+							for _, containerStatus := range pod.Status.ContainerStatuses {
+								g.Expect(containerStatus.Ready).To(BeTrue(),
+									"Container %s should be ready", containerStatus.Name)
+							}
+
+							g.Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
+								"Stable client pod should have sidecar injected")
+						}).Should(Succeed())
+						Success("Stable client ready with sidecar")
+					})
+
+					When("server workloads are deployed in sidecar mode", func() {
+						It("creates and labels namespace for sidecar injection", func(ctx SpecContext) {
+							Expect(k.CreateNamespace(workloadNamespace)).To(Succeed())
+							Expect(k.Label("namespace", workloadNamespace, "istio-injection", "enabled")).To(Succeed())
+							Success(fmt.Sprintf("Namespace %s created and labeled for sidecar injection", workloadNamespace))
+						})
+
+						It("deploys httpbin server in sidecar mode", func(ctx SpecContext) {
+							// Only deploy httpbin - client is in stable-client namespace
+							Expect(k.WithNamespace(workloadNamespace).ApplyKustomize("httpbin")).To(Succeed())
+							Success("Httpbin server deployed in sidecar mode")
+						})
+
+						It("waits for httpbin pod to be ready with sidecar", func(ctx SpecContext) {
+							Eventually(func(g Gomega) {
+								pods := &corev1.PodList{}
+								g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+								g.Expect(pods.Items).To(HaveLen(1), "Expected 1 pod (httpbin)")
+
+								pod := pods.Items[0]
+								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+								g.Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
+									"Pod %s should have istio-proxy in either containers or init containers", pod.Name)
+							}).Should(Succeed())
+							Success("Httpbin running with sidecar")
+						})
+
+						It("verifies initial traffic works from stable client", func(ctx SpecContext) {
+							// Get stable client pod (never migrated)
+							pods := &corev1.PodList{}
+							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+							Expect(pods.Items).To(HaveLen(1))
+
+							clientPod := pods.Items[0].Name
+							GinkgoWriter.Printf("Using stable client: %s (in namespace %s)\n", clientPod, stableClientNamespace)
+
+							Eventually(func() error {
+								// Stable client (sidecar mode) → httpbin (sidecar mode)
+								targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+								return common.CheckHTTPConnectivity(k, stableClientNamespace, clientPod, "sleep", targetURL, 5, "200")
+							}).Should(Succeed())
+							Success("Traffic flows from stable client to httpbin (both sidecar mode)")
+						})
+					})
+
+					When("namespace is switched to ambient mode during traffic", func() {
+						var (
+							stats      *common.HTTPTrafficStats
+							cancelFunc context.CancelFunc
+						)
+
+						// Ensure continuous traffic is stopped when this When block completes
+						AfterAll(func() {
+							if cancelFunc != nil {
+								GinkgoWriter.Printf("Cleaning up: stopping any remaining continuous traffic...\n")
+								cancelFunc()
+								time.Sleep(500 * time.Millisecond)
+							}
+						})
+
+						It("starts continuous traffic from stable client", func(ctx SpecContext) {
+							pods := &corev1.PodList{}
+							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+							Expect(pods.Items).To(HaveLen(1))
+							clientPod := pods.Items[0].Name
+							GinkgoWriter.Printf("Using stable client pod: %s (in namespace %s)\n", clientPod, stableClientNamespace)
+
+							// Start continuous traffic from stable client → httpbin server
+							// Client stays in sidecar mode, server will migrate to ambient
+							// Background context is used so traffic continues
+							// across multiple It blocks until we explicitly stop it
+							targetService := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+							stats, cancelFunc = common.StartContinuousHTTPTraffic(
+								context.Background(), k, stableClientNamespace, clientPod, "sleep",
+								targetService, 100*time.Millisecond, nil)
+
+							// Wait for baseline traffic to establish (use Eventually to handle slower OCP clusters)
+							GinkgoWriter.Printf("Waiting for baseline traffic to establish (target: >=5 successful requests)...\n")
+							var total, success, failed int64
+							var errors []string
+
+							Eventually(func(g Gomega) {
+								total, success, failed, errors = stats.GetStats()
+								GinkgoWriter.Printf("[Baseline check] %d total, %d success, %d failed\n", total, success, failed)
+								g.Expect(success).To(BeNumerically(">=", 5), "Should have at least 5 successful requests for baseline")
+							}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+							total, success, failed, errors = stats.GetStats()
+							GinkgoWriter.Printf("Baseline traffic established: %d total, %d success, %d failed\n", total, success, failed)
+
+							if failed > 0 && len(errors) > 0 {
+								GinkgoWriter.Printf("Baseline errors (showing first 5):\n")
+								for i, errMsg := range errors {
+									if i >= 5 {
+										break
+									}
+									GinkgoWriter.Printf("  [%d] %s\n", i+1, errMsg)
+								}
+							}
+							Success("Continuous traffic started from stable client")
+						})
+
+						It("migrates Istio to ambient profile while traffic is running", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Updating Istio to ambient profile...\n")
+							patch := fmt.Sprintf(`{"spec":{"profile":"ambient","values":{"pilot":{"trustedZtunnelNamespace":"%s"}}}}`, ztunnelNamespace)
+							Expect(k.Patch("istio", istioName, "merge", patch)).To(Succeed())
+							common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl)
+							Success("Istio updated to ambient profile")
+						})
+
+						It("migrates IstioCNI to ambient profile while traffic is running", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Updating IstioCNI to ambient profile...\n")
+							Expect(k.Patch("istiocni", istioCniName, "merge", `{"spec":{"profile":"ambient"}}`)).To(Succeed())
+							common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
+							Success("IstioCNI updated to ambient profile")
+						})
+
+						It("deploys ZTunnel while traffic is running", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Deploying ZTunnel...\n")
+							common.CreateZTunnel(k, version.Name)
+							common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl)
+							Success("ZTunnel deployed and ready")
+						})
+
+						It("updates server namespace to revision-based injection for HBONE-aware sidecars", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Waiting for sidecar injector webhook to be recreated...\n")
+							Eventually(func(g Gomega) {
+								webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
+								g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
+							}).Should(Succeed())
+							Success("Sidecar injector webhook is ready")
+
+							// Update namespace to use revision-based injection (HBONE-aware sidecars)
+							ns := &corev1.Namespace{}
+							Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
+							delete(ns.Labels, "istio-injection")
+							ns.Labels["istio.io/rev"] = "default"
+							Expect(cl.Update(ctx, ns)).To(Succeed())
+							Success("Namespace updated to revision-based injection for HBONE-aware sidecars")
+						})
+
+						It("restarts httpbin to get HBONE-aware sidecars while traffic is running", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Restarting httpbin to get HBONE-aware sidecars...\n")
+							_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(func(g Gomega) {
+								_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
+								g.Expect(err).NotTo(HaveOccurred())
+							}).Should(Succeed())
+							Success("Httpbin restarted with HBONE-aware sidecars")
+						})
+
+						It("removes revision label and adds ambient label while traffic is running", func(ctx SpecContext) {
+							// Remove revision-based injection and add ambient label
+							// This is the final step to pure ambient mode
+							ns := &corev1.Namespace{}
+							Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
+							delete(ns.Labels, "istio.io/rev")
+							ns.Labels["istio.io/dataplane-mode"] = "ambient"
+							Expect(cl.Update(ctx, ns)).To(Succeed())
+							Success("Namespace switched to ambient mode (client stays in sidecar mode, traffic still running)")
+						})
+
+						It("restarts httpbin server to apply pure ambient mode while traffic is running", func(ctx SpecContext) {
+							GinkgoWriter.Printf("Restarting httpbin server (stable client stays running)...\n")
+
+							// Only restart httpbin server - stable client pod stays running in different namespace
+							_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
+							Expect(err).NotTo(HaveOccurred(), "Failed to restart httpbin")
+
+							Eventually(func(g Gomega) {
+								_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
+								g.Expect(err).NotTo(HaveOccurred())
+							}).Should(Succeed())
+
+							Success("Httpbin restarted in ambient mode (client never restarted, traffic continuous)")
+						})
+
+						It("waits for httpbin server to be ready in ambient mode", func(ctx SpecContext) {
+							Eventually(func(g Gomega) {
+								pods := &corev1.PodList{}
+								g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+								g.Expect(pods.Items).To(HaveLen(1), "Expected only httpbin pod in server namespace")
+
+								pod := pods.Items[0]
+								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+								g.Expect(pod.Spec.Containers).To(HaveLen(1), "Httpbin should not have sidecar in ambient mode")
+								g.Expect(pod.Annotations).To(HaveKey("ambient.istio.io/redirection"))
+							}).Should(Succeed())
+							Success("Httpbin server running in ambient mode without sidecar")
+
+							// Verify stable client still has sidecar (never migrated)
+							Eventually(func(g Gomega) {
+								pods := &corev1.PodList{}
+								g.Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace))).To(Succeed())
+								g.Expect(pods.Items).To(HaveLen(1))
+
+								clientPod := pods.Items[0]
+								g.Expect(clientPod.Status.Phase).To(Equal(corev1.PodRunning))
+								g.Expect(common.HasSidecarInjected(clientPod)).To(BeTrue(), "Stable client should still have sidecar")
+							}).Should(Succeed())
+							Success("Stable client still running in sidecar mode (never migrated)")
+						})
+
+						It("verifies traffic recovers after brief disruption during migration", func(ctx SpecContext) {
+							// Key insight: During pod restart, we expect:
+							// 1. Some 503 errors (pod terminating/starting) - ACCEPTABLE
+							// 2. Then traffic RESUMES successfully - CRITICAL
+							// 3. Sustained success after recovery - PROVES STABILITY
+
+							GinkgoWriter.Printf("Letting continuous traffic run for 5 more seconds during ambient mode...\n")
+							time.Sleep(5 * time.Second)
+
+							GinkgoWriter.Printf("Stopping continuous traffic and analyzing recovery pattern...\n")
+							if cancelFunc != nil {
+								cancelFunc()
+							}
+							time.Sleep(500 * time.Millisecond) // Allow final requests to complete
+
+							// Analyze the traffic pattern
+							total, success, failed, errors := stats.GetStats()
+							GinkgoWriter.Printf("Total traffic: %d requests, %d success, %d failed\n", total, success, failed)
+
+							// Ensure we actually sent meaningful traffic
+							Expect(total).To(BeNumerically(">=", 10), "Should have sent at least 10 requests during test")
+
+							// Verify 503 errors are bounded (not unlimited failures)
+							count503 := 0
+							for _, err := range errors {
+								if err == expectedPodRestartError {
+									count503++
+								}
+							}
+
+							GinkgoWriter.Printf("503 errors during pod restart: %d\n", count503)
+							if count503 > 0 {
+								GinkgoWriter.Printf("First few 503 errors (expected during pod restart):\n")
+								shown := 0
+								for _, err := range errors {
+									if err == expectedPodRestartError && shown < 3 {
+										GinkgoWriter.Printf("  - %s\n", err)
+										shown++
+									}
+								}
+							}
+
+							// Assert: 503 errors should be limited (pod restart is brief)
+							// Allow up to 10 503s (generous for slow OCP pod restart)
+							Expect(count503).To(BeNumerically("<=", 10),
+								"503 errors should be limited to pod restart window (≤10), got %d", count503)
+
+							// Critical assertion: Verify traffic RECOVERED after 503s
+							// Look for consecutive successes AFTER the disruption
+							pods := &corev1.PodList{}
+							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+							Expect(pods.Items).To(HaveLen(1))
+							clientPod := pods.Items[0].Name
+							targetService := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+
+							GinkgoWriter.Printf("Verifying sustained recovery (10 consecutive requests)...\n")
+
+							// Verify sustained recovery using MustPassRepeatedly
+							// All 10 attempts must succeed (200ms interval between attempts)
+							Eventually(func() error {
+								return common.CheckHTTPConnectivity(
+									k, stableClientNamespace, clientPod, "sleep", targetService, 5, "200")
+							}).WithPolling(200*time.Millisecond).MustPassRepeatedly(10).Should(Succeed(),
+								"Traffic should be stable after recovery (all 10 consecutive requests must succeed)")
+
+							// Summary
+							GinkgoWriter.Printf("\n=== Migration Traffic Pattern Summary ===\n")
+							GinkgoWriter.Printf("Total requests during migration: %d\n", total)
+							GinkgoWriter.Printf("503 errors (pod restart): %d (≤10 acceptable)\n", count503)
+							GinkgoWriter.Printf("Recovery stability: 10/10 consecutive successes (verified with MustPassRepeatedly)\n")
+							GinkgoWriter.Printf("========================================\n")
+
+							Success(fmt.Sprintf("Traffic recovered successfully after %d 503 errors during pod restart", count503))
+						})
+
+						It("verifies cross-mode communication works", func(ctx SpecContext) {
+							// Final verification: stable client (sidecar) can communicate with httpbin (ambient)
+							pods := &corev1.PodList{}
+							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+							Expect(pods.Items).To(HaveLen(1))
+
+							clientPod := pods.Items[0].Name
+							Eventually(func() error {
+								targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+								return common.CheckHTTPConnectivity(k, stableClientNamespace, clientPod, "sleep", targetURL, 5, "200")
+							}).Should(Succeed())
+							Success("Cross-mode communication verified: sidecar client → ambient server")
+						})
+					})
+				})
+		})
+	})

--- a/tests/e2e/migration/migration_coexistence_test.go
+++ b/tests/e2e/migration/migration_coexistence_test.go
@@ -93,328 +93,277 @@ var _ = Describe("Migration Sidecar-Ambient Coexistence Validation", Ordered,
 				clr.Cleanup(ctx)
 			})
 
-			Context("Sidecar-Ambient Coexistence with Continuous Traffic", Ordered,
-				Label("migration-coexistence-traffic"), func() {
-					BeforeAll(func(ctx SpecContext) {
-						// Create and deploy stable client (never migrates, always stays in sidecar mode)
-						Expect(k.CreateNamespace(stableClientNamespace)).To(Succeed())
-						Expect(k.Label("namespace", stableClientNamespace, "istio-injection", "enabled")).To(Succeed())
-						Expect(k.WithNamespace(stableClientNamespace).ApplyKustomize("sleep")).To(Succeed())
-						Success("Stable sleep client deployed with sidecar injection")
-
+			Context("Sidecar-Ambient Coexistence with Continuous Traffic", Ordered, func() {
+				BeforeAll(func(ctx SpecContext) {
+					// Create and deploy stable client (never migrates, always stays in sidecar mode)
+					Expect(k.CreateNamespace(stableClientNamespace)).To(Succeed())
+					Expect(k.Label("namespace", stableClientNamespace, "istio-injection", "enabled")).To(Succeed())
+					Expect(k.WithNamespace(stableClientNamespace).ApplyKustomize("sleep")).To(Succeed())
+					Success("Stable sleep client deployed with sidecar injection")
+					Eventually(func(g Gomega) {
+						pods := &corev1.PodList{}
+						g.Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace))).To(Succeed())
+						g.Expect(pods.Items).To(HaveLen(1))
+						pod := pods.Items[0]
+						g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+						for _, containerStatus := range pod.Status.ContainerStatuses {
+							g.Expect(containerStatus.Ready).To(BeTrue(),
+								"Container %s should be ready", containerStatus.Name)
+						}
+						g.Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
+							"Stable client pod should have sidecar injected")
+					}).Should(Succeed())
+					Success("Stable client ready with sidecar")
+				})
+				When("server workloads are deployed in sidecar mode", func() {
+					It("creates and labels namespace for sidecar injection", func(ctx SpecContext) {
+						Expect(k.CreateNamespace(workloadNamespace)).To(Succeed())
+						Expect(k.Label("namespace", workloadNamespace, "istio-injection", "enabled")).To(Succeed())
+						Success(fmt.Sprintf("Namespace %s created and labeled for sidecar injection", workloadNamespace))
+					})
+					It("deploys httpbin server in sidecar mode", func(ctx SpecContext) {
+						// Only deploy httpbin - client is in stable-client namespace
+						Expect(k.WithNamespace(workloadNamespace).ApplyKustomize("httpbin")).To(Succeed())
+						Success("Httpbin server deployed in sidecar mode")
+					})
+					It("waits for httpbin pod to be ready with sidecar", func(ctx SpecContext) {
+						Eventually(func(g Gomega) {
+							pods := &corev1.PodList{}
+							g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+							g.Expect(pods.Items).To(HaveLen(1), "Expected 1 pod (httpbin)")
+							pod := pods.Items[0]
+							g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+							g.Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
+								"Pod %s should have istio-proxy in either containers or init containers", pod.Name)
+						}).Should(Succeed())
+						Success("Httpbin running with sidecar")
+					})
+					It("verifies initial traffic works from stable client", func(ctx SpecContext) {
+						// Get stable client pod (never migrated)
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						Expect(pods.Items).To(HaveLen(1))
+						clientPod := pods.Items[0].Name
+						GinkgoWriter.Printf("Using stable client: %s (in namespace %s)\n", clientPod, stableClientNamespace)
+						Eventually(func() error {
+							// Stable client (sidecar mode) → httpbin (sidecar mode)
+							targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+							return common.CheckHTTPConnectivity(k, stableClientNamespace, clientPod, "sleep", targetURL, 5, "200")
+						}).Should(Succeed())
+						Success("Traffic flows from stable client to httpbin (both sidecar mode)")
+					})
+				})
+				When("namespace is switched to ambient mode during traffic", func() {
+					var (
+						stats      *common.HTTPTrafficStats
+						cancelFunc context.CancelFunc
+					)
+					// Ensure continuous traffic is stopped when this When block completes
+					AfterAll(func() {
+						if cancelFunc != nil {
+							GinkgoWriter.Printf("Cleaning up: stopping any remaining continuous traffic...\n")
+							cancelFunc()
+							time.Sleep(500 * time.Millisecond)
+						}
+					})
+					It("starts continuous traffic from stable client", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						Expect(pods.Items).To(HaveLen(1))
+						clientPod := pods.Items[0].Name
+						GinkgoWriter.Printf("Using stable client pod: %s (in namespace %s)\n", clientPod, stableClientNamespace)
+						// Start continuous traffic from stable client → httpbin server
+						// Client stays in sidecar mode, server will migrate to ambient
+						// Background context is used so traffic continues
+						// across multiple It blocks until we explicitly stop it
+						targetService := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+						stats, cancelFunc = common.StartContinuousHTTPTraffic(
+							context.Background(), k, stableClientNamespace, clientPod, "sleep",
+							targetService, 100*time.Millisecond, nil)
+						// Wait for baseline traffic to establish (use Eventually to handle slower OCP clusters)
+						GinkgoWriter.Printf("Waiting for baseline traffic to establish (target: >=5 successful requests)...\n")
+						var total, success, failed int64
+						var errors []string
+						Eventually(func(g Gomega) {
+							total, success, failed, errors = stats.GetStats()
+							GinkgoWriter.Printf("[Baseline check] %d total, %d success, %d failed\n", total, success, failed)
+							g.Expect(success).To(BeNumerically(">=", 5), "Should have at least 5 successful requests for baseline")
+						}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+						total, success, failed, errors = stats.GetStats()
+						GinkgoWriter.Printf("Baseline traffic established: %d total, %d success, %d failed\n", total, success, failed)
+						if failed > 0 && len(errors) > 0 {
+							GinkgoWriter.Printf("Baseline errors (showing first 5):\n")
+							for i, errMsg := range errors {
+								if i >= 5 {
+									break
+								}
+								GinkgoWriter.Printf("  [%d] %s\n", i+1, errMsg)
+							}
+						}
+						Success("Continuous traffic started from stable client")
+					})
+					It("migrates Istio to ambient profile while traffic is running", func(ctx SpecContext) {
+						GinkgoWriter.Printf("Updating Istio to ambient profile...\n")
+						patch := fmt.Sprintf(`{"spec":{"profile":"ambient","values":{"pilot":{"trustedZtunnelNamespace":"%s"}}}}`, ztunnelNamespace)
+						Expect(k.Patch("istio", istioName, "merge", patch)).To(Succeed())
+						common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl)
+						Success("Istio updated to ambient profile")
+					})
+					It("migrates IstioCNI to ambient profile while traffic is running", func(ctx SpecContext) {
+						GinkgoWriter.Printf("Updating IstioCNI to ambient profile...\n")
+						Expect(k.Patch("istiocni", istioCniName, "merge", `{"spec":{"profile":"ambient"}}`)).To(Succeed())
+						common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
+						Success("IstioCNI updated to ambient profile")
+					})
+					It("deploys ZTunnel while traffic is running", func(ctx SpecContext) {
+						GinkgoWriter.Printf("Deploying ZTunnel...\n")
+						common.CreateZTunnel(k, version.Name)
+						common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl)
+						Success("ZTunnel deployed and ready")
+					})
+					It("updates server namespace to revision-based injection for HBONE-aware sidecars", func(ctx SpecContext) {
+						GinkgoWriter.Printf("Waiting for sidecar injector webhook to be recreated...\n")
+						Eventually(func(g Gomega) {
+							webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
+							g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
+						}).Should(Succeed())
+						Success("Sidecar injector webhook is ready")
+						// Update namespace to use revision-based injection (HBONE-aware sidecars)
+						ns := &corev1.Namespace{}
+						Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
+						delete(ns.Labels, "istio-injection")
+						ns.Labels["istio.io/rev"] = "default"
+						Expect(cl.Update(ctx, ns)).To(Succeed())
+						Success("Namespace updated to revision-based injection for HBONE-aware sidecars")
+					})
+					It("restarts httpbin to get HBONE-aware sidecars while traffic is running", func(ctx SpecContext) {
+						GinkgoWriter.Printf("Restarting httpbin to get HBONE-aware sidecars...\n")
+						_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
+						Expect(err).NotTo(HaveOccurred())
+						Eventually(func(g Gomega) {
+							_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
+							g.Expect(err).NotTo(HaveOccurred())
+						}).Should(Succeed())
+						Success("Httpbin restarted with HBONE-aware sidecars")
+					})
+					It("removes revision label and adds ambient label while traffic is running", func(ctx SpecContext) {
+						// Remove revision-based injection and add ambient label
+						// This is the final step to pure ambient mode
+						ns := &corev1.Namespace{}
+						Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
+						delete(ns.Labels, "istio.io/rev")
+						ns.Labels["istio.io/dataplane-mode"] = "ambient"
+						Expect(cl.Update(ctx, ns)).To(Succeed())
+						Success("Namespace switched to ambient mode (client stays in sidecar mode, traffic still running)")
+					})
+					It("restarts httpbin server to apply pure ambient mode while traffic is running", func(ctx SpecContext) {
+						GinkgoWriter.Printf("Restarting httpbin server (stable client stays running)...\n")
+						// Only restart httpbin server - stable client pod stays running in different namespace
+						_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
+						Expect(err).NotTo(HaveOccurred(), "Failed to restart httpbin")
+						Eventually(func(g Gomega) {
+							_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
+							g.Expect(err).NotTo(HaveOccurred())
+						}).Should(Succeed())
+						Success("Httpbin restarted in ambient mode (client never restarted, traffic continuous)")
+					})
+					It("waits for httpbin server to be ready in ambient mode", func(ctx SpecContext) {
+						Eventually(func(g Gomega) {
+							pods := &corev1.PodList{}
+							g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+							g.Expect(pods.Items).To(HaveLen(1), "Expected only httpbin pod in server namespace")
+							pod := pods.Items[0]
+							g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+							g.Expect(pod.Spec.Containers).To(HaveLen(1), "Httpbin should not have sidecar in ambient mode")
+							g.Expect(pod.Annotations).To(HaveKey("ambient.istio.io/redirection"))
+						}).Should(Succeed())
+						Success("Httpbin server running in ambient mode without sidecar")
+						// Verify stable client still has sidecar (never migrated)
 						Eventually(func(g Gomega) {
 							pods := &corev1.PodList{}
 							g.Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace))).To(Succeed())
 							g.Expect(pods.Items).To(HaveLen(1))
-
-							pod := pods.Items[0]
-							g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
-
-							for _, containerStatus := range pod.Status.ContainerStatuses {
-								g.Expect(containerStatus.Ready).To(BeTrue(),
-									"Container %s should be ready", containerStatus.Name)
-							}
-
-							g.Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
-								"Stable client pod should have sidecar injected")
+							clientPod := pods.Items[0]
+							g.Expect(clientPod.Status.Phase).To(Equal(corev1.PodRunning))
+							g.Expect(common.HasSidecarInjected(clientPod)).To(BeTrue(), "Stable client should still have sidecar")
 						}).Should(Succeed())
-						Success("Stable client ready with sidecar")
+						Success("Stable client still running in sidecar mode (never migrated)")
 					})
-
-					When("server workloads are deployed in sidecar mode", func() {
-						It("creates and labels namespace for sidecar injection", func(ctx SpecContext) {
-							Expect(k.CreateNamespace(workloadNamespace)).To(Succeed())
-							Expect(k.Label("namespace", workloadNamespace, "istio-injection", "enabled")).To(Succeed())
-							Success(fmt.Sprintf("Namespace %s created and labeled for sidecar injection", workloadNamespace))
-						})
-
-						It("deploys httpbin server in sidecar mode", func(ctx SpecContext) {
-							// Only deploy httpbin - client is in stable-client namespace
-							Expect(k.WithNamespace(workloadNamespace).ApplyKustomize("httpbin")).To(Succeed())
-							Success("Httpbin server deployed in sidecar mode")
-						})
-
-						It("waits for httpbin pod to be ready with sidecar", func(ctx SpecContext) {
-							Eventually(func(g Gomega) {
-								pods := &corev1.PodList{}
-								g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
-								g.Expect(pods.Items).To(HaveLen(1), "Expected 1 pod (httpbin)")
-
-								pod := pods.Items[0]
-								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
-								g.Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
-									"Pod %s should have istio-proxy in either containers or init containers", pod.Name)
-							}).Should(Succeed())
-							Success("Httpbin running with sidecar")
-						})
-
-						It("verifies initial traffic works from stable client", func(ctx SpecContext) {
-							// Get stable client pod (never migrated)
-							pods := &corev1.PodList{}
-							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
-							Expect(pods.Items).To(HaveLen(1))
-
-							clientPod := pods.Items[0].Name
-							GinkgoWriter.Printf("Using stable client: %s (in namespace %s)\n", clientPod, stableClientNamespace)
-
-							Eventually(func() error {
-								// Stable client (sidecar mode) → httpbin (sidecar mode)
-								targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
-								return common.CheckHTTPConnectivity(k, stableClientNamespace, clientPod, "sleep", targetURL, 5, "200")
-							}).Should(Succeed())
-							Success("Traffic flows from stable client to httpbin (both sidecar mode)")
-						})
-					})
-
-					When("namespace is switched to ambient mode during traffic", func() {
-						var (
-							stats      *common.HTTPTrafficStats
-							cancelFunc context.CancelFunc
-						)
-
-						// Ensure continuous traffic is stopped when this When block completes
-						AfterAll(func() {
-							if cancelFunc != nil {
-								GinkgoWriter.Printf("Cleaning up: stopping any remaining continuous traffic...\n")
-								cancelFunc()
-								time.Sleep(500 * time.Millisecond)
+					It("verifies traffic recovers after brief disruption during migration", func(ctx SpecContext) {
+						// Key insight: During pod restart, we expect:
+						// 1. Some 503 errors (pod terminating/starting) - ACCEPTABLE
+						// 2. Then traffic RESUMES successfully - CRITICAL
+						// 3. Sustained success after recovery - PROVES STABILITY
+						GinkgoWriter.Printf("Letting continuous traffic run for 5 more seconds during ambient mode...\n")
+						time.Sleep(5 * time.Second)
+						GinkgoWriter.Printf("Stopping continuous traffic and analyzing recovery pattern...\n")
+						if cancelFunc != nil {
+							cancelFunc()
+						}
+						time.Sleep(500 * time.Millisecond) // Allow final requests to complete
+						// Analyze the traffic pattern
+						total, success, failed, errors := stats.GetStats()
+						GinkgoWriter.Printf("Total traffic: %d requests, %d success, %d failed\n", total, success, failed)
+						// Ensure we actually sent meaningful traffic
+						Expect(total).To(BeNumerically(">=", 10), "Should have sent at least 10 requests during test")
+						// Verify 503 errors are bounded (not unlimited failures)
+						count503 := 0
+						for _, err := range errors {
+							if err == expectedPodRestartError {
+								count503++
 							}
-						})
-
-						It("starts continuous traffic from stable client", func(ctx SpecContext) {
-							pods := &corev1.PodList{}
-							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
-							Expect(pods.Items).To(HaveLen(1))
-							clientPod := pods.Items[0].Name
-							GinkgoWriter.Printf("Using stable client pod: %s (in namespace %s)\n", clientPod, stableClientNamespace)
-
-							// Start continuous traffic from stable client → httpbin server
-							// Client stays in sidecar mode, server will migrate to ambient
-							// Background context is used so traffic continues
-							// across multiple It blocks until we explicitly stop it
-							targetService := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
-							stats, cancelFunc = common.StartContinuousHTTPTraffic(
-								context.Background(), k, stableClientNamespace, clientPod, "sleep",
-								targetService, 100*time.Millisecond, nil)
-
-							// Wait for baseline traffic to establish (use Eventually to handle slower OCP clusters)
-							GinkgoWriter.Printf("Waiting for baseline traffic to establish (target: >=5 successful requests)...\n")
-							var total, success, failed int64
-							var errors []string
-
-							Eventually(func(g Gomega) {
-								total, success, failed, errors = stats.GetStats()
-								GinkgoWriter.Printf("[Baseline check] %d total, %d success, %d failed\n", total, success, failed)
-								g.Expect(success).To(BeNumerically(">=", 5), "Should have at least 5 successful requests for baseline")
-							}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
-
-							total, success, failed, errors = stats.GetStats()
-							GinkgoWriter.Printf("Baseline traffic established: %d total, %d success, %d failed\n", total, success, failed)
-
-							if failed > 0 && len(errors) > 0 {
-								GinkgoWriter.Printf("Baseline errors (showing first 5):\n")
-								for i, errMsg := range errors {
-									if i >= 5 {
-										break
-									}
-									GinkgoWriter.Printf("  [%d] %s\n", i+1, errMsg)
-								}
-							}
-							Success("Continuous traffic started from stable client")
-						})
-
-						It("migrates Istio to ambient profile while traffic is running", func(ctx SpecContext) {
-							GinkgoWriter.Printf("Updating Istio to ambient profile...\n")
-							patch := fmt.Sprintf(`{"spec":{"profile":"ambient","values":{"pilot":{"trustedZtunnelNamespace":"%s"}}}}`, ztunnelNamespace)
-							Expect(k.Patch("istio", istioName, "merge", patch)).To(Succeed())
-							common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl)
-							Success("Istio updated to ambient profile")
-						})
-
-						It("migrates IstioCNI to ambient profile while traffic is running", func(ctx SpecContext) {
-							GinkgoWriter.Printf("Updating IstioCNI to ambient profile...\n")
-							Expect(k.Patch("istiocni", istioCniName, "merge", `{"spec":{"profile":"ambient"}}`)).To(Succeed())
-							common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
-							Success("IstioCNI updated to ambient profile")
-						})
-
-						It("deploys ZTunnel while traffic is running", func(ctx SpecContext) {
-							GinkgoWriter.Printf("Deploying ZTunnel...\n")
-							common.CreateZTunnel(k, version.Name)
-							common.AwaitCondition(ctx, v1.ZTunnelConditionReady, kube.Key("default"), &v1.ZTunnel{}, k, cl)
-							Success("ZTunnel deployed and ready")
-						})
-
-						It("updates server namespace to revision-based injection for HBONE-aware sidecars", func(ctx SpecContext) {
-							GinkgoWriter.Printf("Waiting for sidecar injector webhook to be recreated...\n")
-							Eventually(func(g Gomega) {
-								webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
-								g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
-							}).Should(Succeed())
-							Success("Sidecar injector webhook is ready")
-
-							// Update namespace to use revision-based injection (HBONE-aware sidecars)
-							ns := &corev1.Namespace{}
-							Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
-							delete(ns.Labels, "istio-injection")
-							ns.Labels["istio.io/rev"] = "default"
-							Expect(cl.Update(ctx, ns)).To(Succeed())
-							Success("Namespace updated to revision-based injection for HBONE-aware sidecars")
-						})
-
-						It("restarts httpbin to get HBONE-aware sidecars while traffic is running", func(ctx SpecContext) {
-							GinkgoWriter.Printf("Restarting httpbin to get HBONE-aware sidecars...\n")
-							_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
-							Expect(err).NotTo(HaveOccurred())
-
-							Eventually(func(g Gomega) {
-								_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
-								g.Expect(err).NotTo(HaveOccurred())
-							}).Should(Succeed())
-							Success("Httpbin restarted with HBONE-aware sidecars")
-						})
-
-						It("removes revision label and adds ambient label while traffic is running", func(ctx SpecContext) {
-							// Remove revision-based injection and add ambient label
-							// This is the final step to pure ambient mode
-							ns := &corev1.Namespace{}
-							Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
-							delete(ns.Labels, "istio.io/rev")
-							ns.Labels["istio.io/dataplane-mode"] = "ambient"
-							Expect(cl.Update(ctx, ns)).To(Succeed())
-							Success("Namespace switched to ambient mode (client stays in sidecar mode, traffic still running)")
-						})
-
-						It("restarts httpbin server to apply pure ambient mode while traffic is running", func(ctx SpecContext) {
-							GinkgoWriter.Printf("Restarting httpbin server (stable client stays running)...\n")
-
-							// Only restart httpbin server - stable client pod stays running in different namespace
-							_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
-							Expect(err).NotTo(HaveOccurred(), "Failed to restart httpbin")
-
-							Eventually(func(g Gomega) {
-								_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
-								g.Expect(err).NotTo(HaveOccurred())
-							}).Should(Succeed())
-
-							Success("Httpbin restarted in ambient mode (client never restarted, traffic continuous)")
-						})
-
-						It("waits for httpbin server to be ready in ambient mode", func(ctx SpecContext) {
-							Eventually(func(g Gomega) {
-								pods := &corev1.PodList{}
-								g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
-								g.Expect(pods.Items).To(HaveLen(1), "Expected only httpbin pod in server namespace")
-
-								pod := pods.Items[0]
-								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
-								g.Expect(pod.Spec.Containers).To(HaveLen(1), "Httpbin should not have sidecar in ambient mode")
-								g.Expect(pod.Annotations).To(HaveKey("ambient.istio.io/redirection"))
-							}).Should(Succeed())
-							Success("Httpbin server running in ambient mode without sidecar")
-
-							// Verify stable client still has sidecar (never migrated)
-							Eventually(func(g Gomega) {
-								pods := &corev1.PodList{}
-								g.Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace))).To(Succeed())
-								g.Expect(pods.Items).To(HaveLen(1))
-
-								clientPod := pods.Items[0]
-								g.Expect(clientPod.Status.Phase).To(Equal(corev1.PodRunning))
-								g.Expect(common.HasSidecarInjected(clientPod)).To(BeTrue(), "Stable client should still have sidecar")
-							}).Should(Succeed())
-							Success("Stable client still running in sidecar mode (never migrated)")
-						})
-
-						It("verifies traffic recovers after brief disruption during migration", func(ctx SpecContext) {
-							// Key insight: During pod restart, we expect:
-							// 1. Some 503 errors (pod terminating/starting) - ACCEPTABLE
-							// 2. Then traffic RESUMES successfully - CRITICAL
-							// 3. Sustained success after recovery - PROVES STABILITY
-
-							GinkgoWriter.Printf("Letting continuous traffic run for 5 more seconds during ambient mode...\n")
-							time.Sleep(5 * time.Second)
-
-							GinkgoWriter.Printf("Stopping continuous traffic and analyzing recovery pattern...\n")
-							if cancelFunc != nil {
-								cancelFunc()
-							}
-							time.Sleep(500 * time.Millisecond) // Allow final requests to complete
-
-							// Analyze the traffic pattern
-							total, success, failed, errors := stats.GetStats()
-							GinkgoWriter.Printf("Total traffic: %d requests, %d success, %d failed\n", total, success, failed)
-
-							// Ensure we actually sent meaningful traffic
-							Expect(total).To(BeNumerically(">=", 10), "Should have sent at least 10 requests during test")
-
-							// Verify 503 errors are bounded (not unlimited failures)
-							count503 := 0
+						}
+						GinkgoWriter.Printf("503 errors during pod restart: %d\n", count503)
+						if count503 > 0 {
+							GinkgoWriter.Printf("First few 503 errors (expected during pod restart):\n")
+							shown := 0
 							for _, err := range errors {
-								if err == expectedPodRestartError {
-									count503++
+								if err == expectedPodRestartError && shown < 3 {
+									GinkgoWriter.Printf("  - %s\n", err)
+									shown++
 								}
 							}
-
-							GinkgoWriter.Printf("503 errors during pod restart: %d\n", count503)
-							if count503 > 0 {
-								GinkgoWriter.Printf("First few 503 errors (expected during pod restart):\n")
-								shown := 0
-								for _, err := range errors {
-									if err == expectedPodRestartError && shown < 3 {
-										GinkgoWriter.Printf("  - %s\n", err)
-										shown++
-									}
-								}
-							}
-
-							// Assert: 503 errors should be limited (pod restart is brief)
-							// Allow up to 10 503s (generous for slow OCP pod restart)
-							Expect(count503).To(BeNumerically("<=", 10),
-								"503 errors should be limited to pod restart window (≤10), got %d", count503)
-
-							// Critical assertion: Verify traffic RECOVERED after 503s
-							// Look for consecutive successes AFTER the disruption
-							pods := &corev1.PodList{}
-							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
-							Expect(pods.Items).To(HaveLen(1))
-							clientPod := pods.Items[0].Name
-							targetService := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
-
-							GinkgoWriter.Printf("Verifying sustained recovery (10 consecutive requests)...\n")
-
-							// Verify sustained recovery using MustPassRepeatedly
-							// All 10 attempts must succeed (200ms interval between attempts)
-							Eventually(func() error {
-								return common.CheckHTTPConnectivity(
-									k, stableClientNamespace, clientPod, "sleep", targetService, 5, "200")
-							}).WithPolling(200*time.Millisecond).MustPassRepeatedly(10).Should(Succeed(),
-								"Traffic should be stable after recovery (all 10 consecutive requests must succeed)")
-
-							// Summary
-							GinkgoWriter.Printf("\n=== Migration Traffic Pattern Summary ===\n")
-							GinkgoWriter.Printf("Total requests during migration: %d\n", total)
-							GinkgoWriter.Printf("503 errors (pod restart): %d (≤10 acceptable)\n", count503)
-							GinkgoWriter.Printf("Recovery stability: 10/10 consecutive successes (verified with MustPassRepeatedly)\n")
-							GinkgoWriter.Printf("========================================\n")
-
-							Success(fmt.Sprintf("Traffic recovered successfully after %d 503 errors during pod restart", count503))
-						})
-
-						It("verifies cross-mode communication works", func(ctx SpecContext) {
-							// Final verification: stable client (sidecar) can communicate with httpbin (ambient)
-							pods := &corev1.PodList{}
-							Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
-							Expect(pods.Items).To(HaveLen(1))
-
-							clientPod := pods.Items[0].Name
-							Eventually(func() error {
-								targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
-								return common.CheckHTTPConnectivity(k, stableClientNamespace, clientPod, "sleep", targetURL, 5, "200")
-							}).Should(Succeed())
-							Success("Cross-mode communication verified: sidecar client → ambient server")
-						})
+						}
+						// Assert: 503 errors should be limited (pod restart is brief)
+						// Allow up to 10 503s (generous for slow OCP pod restart)
+						Expect(count503).To(BeNumerically("<=", 10),
+							"503 errors should be limited to pod restart window (≤10), got %d", count503)
+						// Critical assertion: Verify traffic RECOVERED after 503s
+						// Look for consecutive successes AFTER the disruption
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						Expect(pods.Items).To(HaveLen(1))
+						clientPod := pods.Items[0].Name
+						targetService := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+						GinkgoWriter.Printf("Verifying sustained recovery (10 consecutive requests)...\n")
+						// Verify sustained recovery using MustPassRepeatedly
+						// All 10 attempts must succeed (200ms interval between attempts)
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(
+								k, stableClientNamespace, clientPod, "sleep", targetService, 5, "200")
+						}).WithPolling(200*time.Millisecond).MustPassRepeatedly(10).Should(Succeed(),
+							"Traffic should be stable after recovery (all 10 consecutive requests must succeed)")
+						// Summary
+						GinkgoWriter.Printf("\n=== Migration Traffic Pattern Summary ===\n")
+						GinkgoWriter.Printf("Total requests during migration: %d\n", total)
+						GinkgoWriter.Printf("503 errors (pod restart): %d (≤10 acceptable)\n", count503)
+						GinkgoWriter.Printf("Recovery stability: 10/10 consecutive successes (verified with MustPassRepeatedly)\n")
+						GinkgoWriter.Printf("========================================\n")
+						Success(fmt.Sprintf("Traffic recovered successfully after %d 503 errors during pod restart", count503))
+					})
+					It("verifies cross-mode communication works", func(ctx SpecContext) {
+						// Final verification: stable client (sidecar) can communicate with httpbin (ambient)
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(stableClientNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						Expect(pods.Items).To(HaveLen(1))
+						clientPod := pods.Items[0].Name
+						Eventually(func() error {
+							targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+							return common.CheckHTTPConnectivity(k, stableClientNamespace, clientPod, "sleep", targetURL, 5, "200")
+						}).Should(Succeed())
+						Success("Cross-mode communication verified: sidecar client → ambient server")
 					})
 				})
+			})
 		})
 	})

--- a/tests/e2e/migration/migration_procedure_test.go
+++ b/tests/e2e/migration/migration_procedure_test.go
@@ -1,0 +1,586 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"fmt"
+	"time"
+
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
+	"github.com/istio-ecosystem/sail-operator/pkg/kube"
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/cleaner"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Migration Procedure Validation", Ordered,
+	Label("migration", "migration-procedure", "slow"), func() {
+		// Tests the complete migration workflow from sidecar to ambient mode.
+		// Validates L4 connectivity via ztunnel and L7 policy enforcement via waypoint in a single namespace.
+		// Migration flow: sidecar → HBONE coexistence → pure ambient → waypoint activation
+		SetDefaultEventuallyTimeout(time.Duration(defaultTimeout) * time.Second)
+		SetDefaultEventuallyPollingInterval(time.Second)
+
+		version := istioversion.GetLatestAmbientVersion()
+
+		Context(fmt.Sprintf("Migration from sidecar to ambient with Istio %s version", version.Version), func() {
+			var clr cleaner.Cleaner
+			workloadNamespace := "workload-migration"
+
+			BeforeAll(func(ctx SpecContext) {
+				clr = cleaner.New(cl)
+				clr.Record(ctx)
+
+				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(ztunnelNamespace)).To(Succeed())
+				Expect(k.CreateNamespace(workloadNamespace)).To(Succeed())
+
+				common.CreateIstioCNI(k, version.Name)
+				common.AwaitCondition(ctx, v1.IstioCNIConditionReady, kube.Key(istioCniName), &v1.IstioCNI{}, k, cl)
+				Success("IstioCNI created (no profile - sidecar mode)")
+
+				Eventually(func(g Gomega) {
+					daemonset := &appsv1.DaemonSet{}
+					g.Expect(cl.Get(ctx, kube.Key("istio-cni-node", istioCniNamespace), daemonset)).To(Succeed(), "Error getting IstioCNI DaemonSet")
+					g.Expect(daemonset.Status.NumberAvailable).
+						To(Equal(daemonset.Status.CurrentNumberScheduled), "CNI DaemonSet Pods not Available")
+				}).Should(Succeed(), "CNI DaemonSet Pods are not Available")
+				Success("CNI DaemonSet is running")
+
+				common.CreateIstio(k, version.Name)
+				common.AwaitCondition(ctx, v1.IstioConditionReady, kube.Key(istioName), &v1.Istio{}, k, cl)
+				Success("Istio created (default profile - sidecar mode)")
+
+				common.AwaitDeployment(ctx, "istiod", k, cl)
+				Success("Istiod deployment is ready")
+
+				// Wait for sidecar injector webhook to be ready (required for injection to work)
+				Eventually(func(g Gomega) {
+					webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
+					g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed(), "Sidecar injector webhook should exist")
+				}).Should(Succeed(), "Waiting for istio-sidecar-injector webhook to be created")
+				Success("Sidecar injector webhook is ready")
+			})
+
+			AfterAll(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					common.LogDebugInfo(common.Ambient, k)
+					if keepOnFailure {
+						return
+					}
+				}
+				clr.Cleanup(ctx)
+			})
+
+			Context("Sidecar to Ambient Migration", Ordered, func() {
+				// Tests the complete migration workflow from sidecar to ambient mode.
+				// Migration is performed without active traffic, and connectivity is verified after completion.
+				// Validates: migration procedure correctness, coexistence mode (HBONE-aware sidecars),
+				// L4 connectivity via ztunnel, and L7 policy enforcement via waypoint.
+
+				When("workloads are deployed with sidecar injection", func() {
+					BeforeAll(func(ctx SpecContext) {
+						Expect(k.Label("namespace", workloadNamespace, "istio-injection", "enabled")).To(Succeed(), "Error labeling namespace for sidecar injection")
+						Expect(k.WithNamespace(workloadNamespace).ApplyKustomize("httpbin")).To(Succeed(), "Error deploying httpbin")
+						Expect(k.WithNamespace(workloadNamespace).ApplyKustomize("sleep")).To(Succeed(), "Error deploying sleep")
+						Success("Httpbin and sleep workloads deployed with sidecar injection enabled")
+					})
+
+					samplePods := &corev1.PodList{}
+					It("updates the pods status to Running", func(ctx SpecContext) {
+						Eventually(common.CheckPodsReady).WithArguments(ctx, cl, workloadNamespace).Should(Succeed(), "Error checking status of sample pods")
+						Expect(cl.List(ctx, samplePods, client.InNamespace(workloadNamespace))).To(Succeed(), "Error getting pods in workload namespace")
+						Success("Workload pods are ready")
+					})
+
+					It("has sidecars injected", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed(), "Error getting pods in workload namespace")
+						Expect(pods.Items).NotTo(BeEmpty(), "Expected at least one pod")
+
+						for _, pod := range pods.Items {
+							Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
+								"Pod %s should have istio-proxy in either containers or init containers", pod.Name)
+						}
+						Success("All pods have istio-proxy sidecar injected")
+					})
+
+					It("verifies L4 connectivity in sidecar mode", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						Expect(pods.Items).To(HaveLen(1))
+						sleepPod := pods.Items[0].Name
+
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/get", 5, "200")
+						}).Should(Succeed())
+						Success("L4 connectivity verified in sidecar mode")
+					})
+				})
+
+				When("L7 policies are deployed for sidecar mode", func() {
+					It("deploys VirtualService for httpbin", func(ctx SpecContext) {
+						// VirtualService configures L7 traffic routing for httpbin service:
+						// - Routes all requests matching prefix "/" to httpbin:8000
+						// - Sets request timeout to 10 seconds
+						// - Configures retry policy: up to 3 attempts with 2-second per-try timeout
+						// This validates that L7 routing works correctly in both sidecar and waypoint modes.
+						// Expected behavior:
+						//   - In sidecar mode: Envoy sidecar processes the VirtualService rules
+						//   - In waypoint mode: Waypoint gateway processes the VirtualService rules
+						virtualServiceYAML := fmt.Sprintf(`
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: httpbin
+  namespace: %s
+spec:
+  hosts:
+  - httpbin
+  http:
+  - match:
+    - uri:
+        prefix: "/"
+    route:
+    - destination:
+        host: httpbin
+        port:
+          number: 8000
+    timeout: 10s
+    retries:
+      attempts: 3
+      perTryTimeout: 2s`, workloadNamespace)
+
+						Expect(k.CreateFromString(virtualServiceYAML)).To(Succeed())
+						Success("VirtualService created for sidecar mode")
+					})
+
+					It("deploys AuthorizationPolicy for httpbin", func(ctx SpecContext) {
+						authzPolicyYAML := fmt.Sprintf(`
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-authz
+  namespace: %s
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: ["/deny"]`, workloadNamespace)
+
+						Expect(k.CreateFromString(authzPolicyYAML)).To(Succeed())
+						Success("AuthorizationPolicy created for sidecar mode")
+					})
+
+					It("verifies L7 traffic routing works in sidecar mode", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						sleepPod := pods.Items[0].Name
+
+						// Test that VirtualService routes traffic correctly
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/get", 5, "200")
+						}).Should(Succeed())
+						Success("VirtualService routing verified in sidecar mode")
+					})
+
+					It("verifies L7 AuthorizationPolicy is enforced in sidecar mode", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						sleepPod := pods.Items[0].Name
+
+						// Test allowed path
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/get", 5, "200")
+						}).Should(Succeed())
+
+						// Test denied path
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/deny", 5, "403")
+						}).Should(Succeed())
+
+						Success("AuthorizationPolicy enforcement verified in sidecar mode")
+					})
+				})
+
+				When("configures Istio and IstioCNI in ambient mode", func() {
+					It("updates Istio to ambient profile", func(ctx SpecContext) {
+						patch := fmt.Sprintf(`{"spec":{"profile":"ambient","values":{"pilot":{"trustedZtunnelNamespace":"%s"}}}}`, ztunnelNamespace)
+						Expect(k.Patch("istio", istioName, "merge", patch)).To(Succeed())
+						Success("Istio updated to ambient profile with trustedZtunnelNamespace")
+					})
+
+					It("waits for Istio to reconcile with ambient profile", func(ctx SpecContext) {
+						istio := &v1.Istio{}
+						Eventually(func(g Gomega) {
+							g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed())
+							g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReconciled, metav1.ConditionTrue))
+							g.Expect(istio).To(HaveConditionStatus(v1.IstioConditionReady, metav1.ConditionTrue))
+						}).Should(Succeed())
+						Success("Istio reconciled with ambient profile")
+					})
+
+					It("updates IstioCNI to ambient profile", func(ctx SpecContext) {
+						patch := `{"spec":{"profile":"ambient"}}`
+						Expect(k.Patch("istiocni", istioCniName, "merge", patch)).To(Succeed())
+						Success("IstioCNI updated to ambient profile")
+					})
+
+					It("waits for IstioCNI to reconcile with ambient profile", func(ctx SpecContext) {
+						istioCNI := &v1.IstioCNI{}
+						Eventually(func(g Gomega) {
+							g.Expect(cl.Get(ctx, kube.Key(istioCniName), istioCNI)).To(Succeed())
+							g.Expect(istioCNI).To(HaveConditionStatus(v1.IstioCNIConditionReconciled, metav1.ConditionTrue))
+							g.Expect(istioCNI).To(HaveConditionStatus(v1.IstioCNIConditionReady, metav1.ConditionTrue))
+						}).Should(Succeed())
+						Success("IstioCNI reconciled with ambient profile")
+					})
+
+					It("creates ZTunnel CR", func(ctx SpecContext) {
+						common.CreateZTunnel(k, version.Name)
+						Success("ZTunnel CR created")
+					})
+
+					It("waits for ZTunnel to be Ready", func(ctx SpecContext) {
+						ztunnel := &v1.ZTunnel{}
+						Eventually(func(g Gomega) {
+							g.Expect(cl.Get(ctx, kube.Key("default"), ztunnel)).To(Succeed())
+							g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReconciled, metav1.ConditionTrue))
+							g.Expect(ztunnel).To(HaveConditionStatus(v1.ZTunnelConditionReady, metav1.ConditionTrue))
+						}).Should(Succeed())
+						Success("ZTunnel is Ready")
+					})
+
+					It("verifies ZTunnel DaemonSet is running", func(ctx SpecContext) {
+						Eventually(func(g Gomega) {
+							daemonset := &appsv1.DaemonSet{}
+							g.Expect(cl.Get(ctx, kube.Key("ztunnel", ztunnelNamespace), daemonset)).To(Succeed())
+							g.Expect(daemonset.Status.NumberAvailable).To(Equal(daemonset.Status.CurrentNumberScheduled))
+						}).Should(Succeed())
+						Success("ZTunnel DaemonSet is running")
+					})
+				})
+
+				When("workloads are restarted to get HBONE-aware sidecars", func() {
+					It("waits for sidecar injector webhook to be recreated", func(ctx SpecContext) {
+						// After switching to ambient profile, the webhook is recreated
+						// Wait for it to exist before restarting pods
+						Eventually(func(g Gomega) {
+							webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
+							g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed(), "Sidecar injector webhook should exist in coexistence mode")
+						}).Should(Succeed(), "Waiting for istio-sidecar-injector webhook to be recreated")
+						Success("Sidecar injector webhook is ready")
+					})
+
+					It("restarts deployments to get HBONE-aware sidecars", func(ctx SpecContext) {
+						// Restart pods with existing istio-injection=enabled label
+						// The ambient-configured webhook will inject HBONE-aware sidecars
+						_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
+						Expect(err).NotTo(HaveOccurred(), "Failed to restart deployment")
+						Success("Deployment restart initiated")
+
+						Eventually(func(g Gomega) {
+							_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
+							g.Expect(err).NotTo(HaveOccurred(), "Rollout status check failed")
+						}).Should(Succeed(), "Waiting for deployment rollout to complete")
+						Success("Deployment rollout completed")
+					})
+
+					It("waits for pods to be ready after restart", func(ctx SpecContext) {
+						Eventually(func(g Gomega) {
+							pods := &corev1.PodList{}
+							g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+							g.Expect(pods.Items).NotTo(BeEmpty())
+
+							for _, pod := range pods.Items {
+								g.Expect(pod.DeletionTimestamp).To(BeNil(), "Pod %s should not be terminating", pod.Name)
+							}
+
+							for _, pod := range pods.Items {
+								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "Pod %s should be running", pod.Name)
+
+								readyCount := 0
+								for _, condition := range pod.Status.Conditions {
+									if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+										readyCount++
+									}
+								}
+								g.Expect(readyCount).To(Equal(1), "Pod %s should have Ready condition", pod.Name)
+							}
+						}).Should(Succeed(), "Waiting for pods to be fully ready without any terminating")
+						Success("Pods are ready after restart")
+					})
+
+					It("verifies sidecars are present after switching to ambient profile", func(ctx SpecContext) {
+						// After switching to ambient profile and restarting pods, verify istio-proxy still exists
+						// Use the same check as the initial sidecar verification
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed(), "Error getting pods in workload namespace")
+						Expect(pods.Items).NotTo(BeEmpty(), "Expected at least one pod")
+
+						for _, pod := range pods.Items {
+							Expect(common.HasSidecarInjected(pod)).To(BeTrue(),
+								"Pod %s should have istio-proxy in either containers or init containers", pod.Name)
+						}
+						Success("All pods still have istio-proxy after switching to ambient profile")
+					})
+
+					It("verifies HBONE capability is enabled in sidecars", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+						Expect(pods.Items).NotTo(BeEmpty())
+
+						pod := pods.Items[0]
+						Expect(common.HasSidecarInjected(pod)).To(BeTrue(), "istio-proxy container not found in pod %s", pod.Name)
+						Expect(common.HasHBONEEnabled(pod)).To(BeTrue(), "ISTIO_META_ENABLE_HBONE env var not set to 'true' in istio-proxy container")
+						Success("HBONE capability verified in sidecar (ISTIO_META_ENABLE_HBONE=true)")
+					})
+
+					It("verifies L4 connectivity works with HBONE-aware sidecars", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						Expect(pods.Items).To(HaveLen(1))
+						sleepPod := pods.Items[0].Name
+
+						Eventually(func() error {
+							targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", targetURL, 5, "200")
+						}).Should(Succeed())
+						Success("L4 connectivity verified with HBONE-aware sidecars in coexistence mode")
+					})
+				})
+
+				When("namespace is switched to ambient mode", func() {
+					It("removes sidecar injection label and adds ambient label", func(ctx SpecContext) {
+						// Remove istio-injection label and add ambient dataplane mode
+						ns := &corev1.Namespace{}
+						Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
+						delete(ns.Labels, "istio-injection")
+						ns.Labels["istio.io/dataplane-mode"] = "ambient"
+						Expect(cl.Update(ctx, ns)).To(Succeed())
+						Success(fmt.Sprintf("Namespace %s switched to ambient mode", workloadNamespace))
+					})
+
+					It("restarts httpbin pods to remove sidecars", func(ctx SpecContext) {
+						_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/httpbin")
+						Expect(err).NotTo(HaveOccurred(), "Failed to restart deployment")
+						Success("Deployment restart initiated")
+
+						Eventually(func(g Gomega) {
+							_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/httpbin")
+							g.Expect(err).NotTo(HaveOccurred(), "Rollout status check failed")
+						}).Should(Succeed(), "Waiting for deployment rollout to complete")
+						Success("Deployment rollout completed")
+					})
+
+					It("restarts sleep deployment to remove sidecars", func(ctx SpecContext) {
+						_, err := k.WithNamespace(workloadNamespace).RolloutRestart("deployment/sleep")
+						Expect(err).NotTo(HaveOccurred(), "Failed to restart sleep deployment")
+
+						Eventually(func(g Gomega) {
+							_, err := k.WithNamespace(workloadNamespace).RolloutStatus("deployment/sleep")
+							g.Expect(err).NotTo(HaveOccurred(), "Rollout status check failed")
+						}).Should(Succeed(), "Waiting for sleep deployment rollout to complete")
+						Success("Sleep deployment rollout completed")
+					})
+
+					It("waits for pods to be ready in ambient mode without sidecar", func(ctx SpecContext) {
+						Eventually(func(g Gomega) {
+							pods := &corev1.PodList{}
+							g.Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+
+							// Filter out waypoint pods
+							workloadPods := []corev1.Pod{}
+							for _, pod := range pods.Items {
+								if pod.DeletionTimestamp == nil {
+									isWaypoint := false
+									for key := range pod.Labels {
+										if key == "gateway.istio.io/managed" || key == "gateway.networking.k8s.io/gateway-name" {
+											isWaypoint = true
+											break
+										}
+									}
+									if !isWaypoint {
+										workloadPods = append(workloadPods, pod)
+									}
+								}
+							}
+
+							g.Expect(workloadPods).NotTo(BeEmpty(), "Expected at least one workload pod")
+
+							for _, pod := range workloadPods {
+								g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "Pod %s should be running", pod.Name)
+								g.Expect(pod.Spec.Containers).To(HaveLen(1), "Pod %s should have 1 container (no sidecar in ambient mode)", pod.Name)
+								g.Expect(pod.Annotations).To(HaveKey("ambient.istio.io/redirection"), "Ambient redirection annotation should be present")
+							}
+						}).Should(Succeed())
+						Success("Pods running in ambient mode without sidecars")
+					})
+
+					It("verifies workloads are registered with ztunnel", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace))).To(Succeed())
+						Expect(pods.Items).NotTo(BeEmpty())
+
+						// Verify pods are detected by ztunnel
+						Eventually(func(g Gomega) {
+							for _, pod := range pods.Items {
+								// Check pod annotations indicate ambient mode
+								g.Expect(pod.Annotations).To(HaveKey("ambient.istio.io/redirection"))
+							}
+						}).Should(Succeed())
+						Success("Workloads registered with ztunnel")
+					})
+
+					It("verifies L4 connectivity in ambient mode", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace), client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						Expect(pods.Items).To(HaveLen(1))
+
+						clientPod := pods.Items[0].Name
+						Eventually(func() error {
+							// Test connectivity to httpbin service (should go through ztunnel)
+							targetURL := fmt.Sprintf("httpbin.%s.svc.cluster.local:8000/get", workloadNamespace)
+							return common.CheckHTTPConnectivity(k, workloadNamespace, clientPod, "sleep", targetURL, 5, "200")
+						}).Should(Succeed())
+						Success("L4 connectivity verified in ambient mode via ztunnel")
+					})
+				})
+
+				When("waypoint is deployed for L7 processing", func() {
+					It("deploys waypoint Gateway", func(ctx SpecContext) {
+						waypointYAML := fmt.Sprintf(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  namespace: %s
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE`, workloadNamespace)
+
+						Expect(k.CreateFromString(waypointYAML)).To(Succeed())
+						Success("Waypoint Gateway created")
+					})
+
+					It("waits for waypoint deployment to be ready", func(ctx SpecContext) {
+						Eventually(func(g Gomega) {
+							deployment := &appsv1.Deployment{}
+							g.Expect(cl.Get(ctx, kube.Key("waypoint", workloadNamespace), deployment)).To(Succeed())
+							g.Expect(deployment.Status.ReadyReplicas).To(BeNumerically(">", 0))
+						}).Should(Succeed())
+						Success("Waypoint deployment is ready")
+					})
+
+					It("updates AuthorizationPolicy to target waypoint", func(ctx SpecContext) {
+						// Delete the old sidecar-mode AuthorizationPolicy
+						Expect(k.WithNamespace(workloadNamespace).Delete("authorizationpolicy", "httpbin-authz")).To(Succeed())
+
+						// Create new AuthorizationPolicy targeting waypoint
+						authzPolicyYAML := fmt.Sprintf(`
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-authz
+  namespace: %s
+spec:
+  targetRefs:
+  - kind: Gateway
+    group: gateway.networking.k8s.io
+    name: waypoint
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: ["/deny"]`, workloadNamespace)
+
+						Expect(k.CreateFromString(authzPolicyYAML)).To(Succeed())
+						Success("AuthorizationPolicy updated to target waypoint")
+					})
+
+					It("verifies waypoint is not yet processing traffic (dormant)", func(ctx SpecContext) {
+						ns := &corev1.Namespace{}
+						Expect(cl.Get(ctx, kube.Key(workloadNamespace), ns)).To(Succeed())
+						Expect(ns.Labels).NotTo(HaveKey("istio.io/use-waypoint"))
+						Success("Waypoint is dormant (not activated yet)")
+					})
+				})
+
+				When("waypoint is activated for L7 processing", func() {
+					It("labels namespace to activate waypoint", func(ctx SpecContext) {
+						Expect(k.Label("namespace", workloadNamespace, "istio.io/use-waypoint", "waypoint")).To(Succeed())
+						Success("Waypoint activated")
+					})
+
+					It("verifies VirtualService routing works via waypoint", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						sleepPod := pods.Items[0].Name
+
+						// VirtualService should continue to work (routes traffic through waypoint now)
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/get", 5, "200")
+						}).Should(Succeed())
+						Success("VirtualService routing verified via waypoint")
+					})
+
+					It("verifies L7 AuthorizationPolicy is enforced via waypoint", func(ctx SpecContext) {
+						pods := &corev1.PodList{}
+						Expect(cl.List(ctx, pods, client.InNamespace(workloadNamespace),
+							client.MatchingLabels{"app": "sleep"})).To(Succeed())
+						sleepPod := pods.Items[0].Name
+
+						// Test allowed path
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/get", 5, "200")
+						}).Should(Succeed())
+
+						// Test denied path (L7 policy enforcement)
+						Eventually(func() error {
+							return common.CheckHTTPConnectivity(k, workloadNamespace, sleepPod, "sleep", "httpbin:8000/deny", 5, "403")
+						}).Should(Succeed())
+
+						Success("L7 AuthorizationPolicy successfully enforced via waypoint")
+					})
+				})
+			})
+		})
+	})

--- a/tests/e2e/migration/migration_suite_test.go
+++ b/tests/e2e/migration/migration_suite_test.go
@@ -1,0 +1,79 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
+	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	cl                    client.Client
+	err                   error
+	controlPlaneNamespace = common.ControlPlaneNamespace
+	istioName             = env.Get("ISTIO_NAME", "default")
+	istioCniNamespace     = common.IstioCniNamespace
+	ztunnelNamespace      = common.ZtunnelNamespace
+	istioCniName          = env.Get("ISTIOCNI_NAME", "default")
+	multicluster          = env.GetBool("MULTICLUSTER", false)
+	keepOnFailure         = env.GetBool("KEEP_ON_FAILURE", false)
+	defaultTimeout        = env.GetInt("DEFAULT_TEST_TIMEOUT", 180)
+
+	k kubectl.Kubectl
+)
+
+func TestMigration(t *testing.T) {
+	if multicluster {
+		t.Skip("Skipping the Migration tests in multicluster environment")
+	}
+
+	RegisterFailHandler(Fail)
+	setup()
+	RunSpecs(t, "Migration Test Suite")
+}
+
+func setup() {
+	GinkgoWriter.Println("************ Running Setup ************")
+
+	GinkgoWriter.Println("Initializing k8s client")
+	cl, err = k8sclient.InitK8sClient("")
+	Expect(err).NotTo(HaveOccurred())
+
+	k = kubectl.New()
+
+	// Install Gateway API CRDs if not already present (needed for waypoint)
+	ctx := context.Background()
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	err = cl.Get(ctx, client.ObjectKey{Name: "gateways.gateway.networking.k8s.io"}, crd)
+	if err != nil {
+		GinkgoWriter.Println("Gateway API CRDs not found, installing from upstream")
+		Expect(k.Apply("https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml")).
+			To(Succeed(), "Failed to install Gateway API CRDs")
+		GinkgoWriter.Println("Gateway API CRDs installed (standard channel v1.2.0)")
+	} else {
+		GinkgoWriter.Println("Gateway API CRDs already present in cluster")
+	}
+}

--- a/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
+++ b/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
@@ -42,7 +42,7 @@ const (
 	externalIstioName = "external-istiod"
 )
 
-var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-external"), Ordered, func() {
+var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-external", "slow", "sidecar"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 

--- a/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
+++ b/tests/e2e/multicluster/multicluster_externalcontrolplane_test.go
@@ -167,7 +167,8 @@ kind: ServiceAccount
 metadata:
   name: istiod-service-account
 `
-						k1.WithNamespace(externalControlPlaneNamespace).CreateFromString(externalSVCAccountYAML)
+						Expect(k1.WithNamespace(externalControlPlaneNamespace).CreateFromString(externalSVCAccountYAML)).To(
+							Succeed(), "Failed to create istiod service account on Cluster #1")
 
 						apiURLCluster2, err := k2.GetClusterAPIURL()
 						Expect(apiURLCluster2).NotTo(BeEmpty(), "API URL is empty for the Cluster #2")

--- a/tests/e2e/multicluster/multicluster_multiprimary_test.go
+++ b/tests/e2e/multicluster/multicluster_multiprimary_test.go
@@ -35,7 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-multiprimary"), Ordered, func() {
+var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-multiprimary", "slow"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -41,7 +41,7 @@ import (
 	"istio.io/istio/pkg/ptr"
 )
 
-var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-primaryremote"), Ordered, func() {
+var _ = Describe("Multicluster deployment models", Label("multicluster", "multicluster-primaryremote", "slow", "sidecar"), Ordered, func() {
 	profile := "default"
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)

--- a/tests/e2e/multicluster/multicluster_primaryremote_test.go
+++ b/tests/e2e/multicluster/multicluster_primaryremote_test.go
@@ -159,13 +159,15 @@ values:
 						Expect(RemoteClusterAPIURL).NotTo(BeEmpty(), "API URL is empty for Remote Cluster")
 						Expect(err).NotTo(HaveOccurred())
 
-						// Wait for the remote Istio CR to be created, this can be moved to a condition verification, but the resource it not will be Ready at this point
-						time.Sleep(5 * time.Second)
-
 						// Install a remote secret in Primary cluster that provides access to the Remote cluster API server.
+						// Wrap in Eventually: CreateRemoteSecret may fail until the remote Istio service account is provisioned.
 						By("Creating Remote Secret on Primary Cluster")
-						secret, err := istioctl.CreateRemoteSecret(kubeconfig2, controlPlaneNamespace, "remote", RemoteClusterAPIURL)
-						Expect(err).NotTo(HaveOccurred())
+						var secret string
+						Eventually(func() error {
+							var err error
+							secret, err = istioctl.CreateRemoteSecret(kubeconfig2, controlPlaneNamespace, "remote", RemoteClusterAPIURL)
+							return err
+						}).ShouldNot(HaveOccurred(), "Remote secret generation failed")
 						Expect(k1.WithNamespace(controlPlaneNamespace).ApplyString(secret)).To(Succeed(), "Remote secret creation failed on Primary Cluster")
 					})
 

--- a/tests/e2e/multicontrolplane/multi_control_plane_test.go
+++ b/tests/e2e/multicontrolplane/multi_control_plane_test.go
@@ -32,7 +32,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-var _ = Describe("Multi control plane deployment model", Label("smoke", "multicontrol-plane"), Ordered, func() {
+var _ = Describe("Multi control plane deployment model", Label("multi-control-plane", "slow", "sidecar"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -292,17 +292,17 @@ spec:
 
 			DeferCleanup(func(ctx SpecContext) {
 				Step("Restoring the original APIServer TLS settings")
-				apiServer := &configv1.APIServer{}
-				err := cl.Get(ctx, apiServerKey, apiServer)
-				Expect(err).NotTo(HaveOccurred(), "Failed to get APIServer")
-				apiServer.Spec.TLSSecurityProfile = originalTLSProfile
-				// TLSAdherence cannot be set back to NoOpinion once set,
-				// so only restore it if the original was a non-empty value.
-				if originalTLSAdherence != configv1.TLSAdherencePolicyNoOpinion {
-					apiServer.Spec.TLSAdherence = originalTLSAdherence
-				}
-				err = cl.Update(ctx, apiServer)
-				Expect(err).NotTo(HaveOccurred(), "Failed to update APIServer TLS settings")
+				Eventually(func(g Gomega) {
+					apiServer := &configv1.APIServer{}
+					g.Expect(cl.Get(ctx, apiServerKey, apiServer)).To(Succeed(), "Failed to get APIServer")
+					apiServer.Spec.TLSSecurityProfile = originalTLSProfile
+					// TLSAdherence cannot be set back to NoOpinion once set,
+					// so only restore it if the original was a non-empty value.
+					if originalTLSAdherence != configv1.TLSAdherencePolicyNoOpinion {
+						apiServer.Spec.TLSAdherence = originalTLSAdherence
+					}
+					g.Expect(cl.Update(ctx, apiServer)).To(Succeed(), "Failed to update APIServer TLS settings")
+				}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 			})
 
 			Step("Creating Istio")
@@ -393,7 +393,8 @@ spec:
 				g.Expect(rev.Spec.Values.Pilot.ExtraContainerArgs).To(
 					ContainElement(ContainSubstring("--tls-cipher-suites=")),
 					"IstioRevision should have --tls-cipher-suites in pilot.extraContainerArgs")
-			}).Should(Succeed(), "IstioRevision is not syncing TLS settings but should be")
+			}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+				"IstioRevision is not syncing TLS settings but should be")
 
 			Step("Verifying metrics endpoint accepts the custom cipher")
 			Eventually(func() bool {

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -227,7 +227,7 @@ spec:
 	// a specific TLS 1.2 cipher) and the TLS settings synced to the IstioRevision resource.
 	// Test 1 runs on all OpenShift clusters. Tests 2 and 3 require OpenShift >= 4.22
 	// because the TLSAdherence field was introduced in 4.22.
-	Describe("TLS profile change", Label("openshift"), func() {
+	Describe("TLS profile change", Label("tls-profile"), func() {
 		var ocpMinorVersion int
 		var ocpMajorVersion int
 

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -90,10 +90,16 @@ var (
 var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
 	SetDefaultEventuallyPollingInterval(time.Second)
+	debugInfoLogged := false
 	clr := cleaner.New(cl)
 	BeforeAll(func(ctx SpecContext) {
 		clr.Record(ctx)
 		DeferCleanup(func(ctx SpecContext) {
+			if CurrentSpecReport().Failed() {
+				common.LogDebugInfo(common.Operator, k)
+				debugInfoLogged = true
+			}
+
 			clr.Cleanup(ctx)
 		})
 	})
@@ -423,7 +429,7 @@ spec:
 			return
 		}
 
-		if CurrentSpecReport().Failed() {
+		if CurrentSpecReport().Failed() && !debugInfoLogged {
 			common.LogDebugInfo(common.Operator, k)
 		}
 	})

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -54,8 +54,10 @@ const (
 )
 
 const (
-	SleepNamespace   = "sleep"
-	HttpbinNamespace = "httpbin"
+	SleepNamespace       = "sleep"
+	HttpbinNamespace     = "httpbin"
+	SleepContainerName   = "sleep"
+	HttpbinContainerName = "httpbin"
 
 	// maxJUnitErrorMessageSize is the maximum size (in bytes) for error messages
 	// written to junit XML files. Messages exceeding this size will be truncated.
@@ -537,9 +539,9 @@ func withClusterName(m string, k kubectl.Kubectl) string {
 	return m + " on " + k.ClusterName
 }
 
-func CheckPodConnectivity(podName, srcNamespace, destNamespace string, k kubectl.Kubectl) {
+func CheckPodConnectivity(podName, containerName, srcNamespace, destNamespace string, k kubectl.Kubectl) {
 	command := fmt.Sprintf(`curl -o /dev/null -s -w "%%{http_code}\n" httpbin.%s.svc.cluster.local:8000/get`, destNamespace)
-	response, err := k.WithNamespace(srcNamespace).Exec(podName, srcNamespace, command)
+	response, err := k.WithNamespace(srcNamespace).Exec(podName, containerName, command)
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error connecting to the %q pod", podName))
 	Expect(response).To(ContainSubstring("200"), fmt.Sprintf("Unexpected response from %s pod", podName))
 }
@@ -574,4 +576,45 @@ func EnsureNamespaceWithCleanup(k kubectl.Kubectl, namespace string) {
 			Log(fmt.Sprintf("Failed to delete namespace: %s", err))
 		}
 	})
+}
+
+// GetProxyVersion extracts the Istio proxy version from a pod using istioctl proxy-status
+func GetProxyVersion(podName, namespace string) (*semver.Version, error) {
+	proxyStatus, err := istioctl.GetProxyStatus("--namespace " + namespace)
+	if err != nil {
+		return nil, fmt.Errorf("error getting sidecar version: %w", err)
+	}
+
+	lines := strings.Split(proxyStatus, "\n")
+	colSplit := regexp.MustCompile(`\s{2,}`)
+
+	versionIdx := -1
+	headers := colSplit.Split(strings.TrimSpace(lines[0]), -1)
+	for i, header := range headers {
+		if header == "VERSION" {
+			versionIdx = i
+			break
+		}
+	}
+	if versionIdx == -1 {
+		return nil, fmt.Errorf("VERSION header not found")
+	}
+
+	var versionStr string
+	for _, line := range lines[1:] {
+		if strings.Contains(line, podName+"."+namespace) {
+			values := colSplit.Split(strings.TrimSpace(line), -1)
+			versionStr = values[versionIdx]
+			break
+		}
+	}
+
+	if versionStr == "" {
+		return nil, fmt.Errorf("pod %s not found in proxy status output for namespace %s", podName, namespace)
+	}
+	version, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return version, fmt.Errorf("error parsing sidecar version %q: %w", versionStr, err)
+	}
+	return version, err
 }

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -38,8 +36,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"istio.io/istio/pkg/ptr"
 )
 
 type testSuite string
@@ -158,252 +154,6 @@ func CheckNamespaceEmpty(ctx SpecContext, cl client.Client, ns string) {
 	}).Should(BeEmpty(), "No Services should be present in the namespace")
 }
 
-func LogDebugInfo(suite testSuite, kubectls ...kubectl.Kubectl) {
-	artifactsDir := env.Get("ARTIFACTS", "/tmp/artifacts")
-	printDebug := env.GetBool("E2E_PRINT_DEBUG", false)
-
-	if printDebug {
-		GinkgoWriter.Println()
-		GinkgoWriter.Println("The test run has failures and the debug information is as follows:")
-		GinkgoWriter.Println()
-	}
-	for _, k := range kubectls {
-		clusterName := k.ClusterName
-		if clusterName == "" {
-			clusterName = "default"
-		}
-
-		if printDebug && k.ClusterName != "" {
-			GinkgoWriter.Println("=========================================================")
-			GinkgoWriter.Println("CLUSTER:", k.ClusterName)
-			GinkgoWriter.Println("=========================================================")
-		}
-		logOperatorDebugInfo(k, artifactsDir, clusterName, printDebug)
-		if printDebug {
-			GinkgoWriter.Println("=========================================================")
-		}
-		logIstioDebugInfo(k, artifactsDir, clusterName, printDebug)
-		if printDebug {
-			GinkgoWriter.Println("=========================================================")
-		}
-		logCNIDebugInfo(k, artifactsDir, clusterName, printDebug)
-		if printDebug {
-			GinkgoWriter.Println("=========================================================")
-		}
-		logCertsDebugInfo(k, artifactsDir, clusterName, printDebug)
-		if printDebug {
-			GinkgoWriter.Println("=========================================================")
-		}
-		logSampleNamespacesDebugInfo(k, suite, artifactsDir, clusterName, printDebug)
-		if printDebug {
-			GinkgoWriter.Println("=========================================================")
-			GinkgoWriter.Println()
-		}
-
-		if suite == Ambient {
-			logZtunnelDebugInfo(k, artifactsDir, clusterName, printDebug)
-			var buf strings.Builder
-			describe, err := k.WithNamespace(SleepNamespace).Describe("deployment", "sleep")
-			logDebugElement("=====sleep deployment describe=====", describe, err, &buf, printDebug)
-			describe, err = k.WithNamespace(HttpbinNamespace).Describe("deployment", "httpbin")
-			logDebugElement("=====httpbin deployment describe=====", describe, err, &buf, printDebug)
-			writeDebugFile(artifactsDir, clusterName, "ambient-deployments", &buf)
-		}
-	}
-}
-
-// writeDebugFile writes the collected debug information to a file under the artifacts directory.
-func writeDebugFile(artifactsDir, clusterName, section string, buf *strings.Builder) {
-	debugDir := filepath.Join(artifactsDir, "debug", clusterName)
-	if err := os.MkdirAll(debugDir, 0o755); err != nil {
-		GinkgoWriter.Printf("Warning: failed to create debug directory %s: %v\n", debugDir, err)
-		return
-	}
-
-	fileName := filepath.Join(debugDir, section+".log")
-	if err := os.WriteFile(fileName, []byte(buf.String()), 0o644); err != nil {
-		GinkgoWriter.Printf("Warning: failed to write debug file %s: %v\n", fileName, err)
-		return
-	}
-	GinkgoWriter.Printf("Debug info written to %s\n", fileName)
-}
-
-func logOperatorDebugInfo(k kubectl.Kubectl, artifactsDir, clusterName string, printDebug bool) {
-	var buf strings.Builder
-	k = k.WithNamespace(OperatorNamespace)
-	operator, err := k.GetYAML("deployment", deploymentName)
-	logDebugElement("=====Operator Deployment YAML=====", operator, err, &buf, printDebug)
-
-	logs, err := k.Logs("deploy/"+deploymentName, ptr.Of(120*time.Second))
-	logDebugElement("=====Operator logs=====", logs, err, &buf, printDebug)
-
-	events, err := k.GetEvents()
-	logDebugElement("=====Events in "+OperatorNamespace+"=====", events, err, &buf, printDebug)
-
-	pods, err := k.GetPods("", "-o wide")
-	logDebugElement("=====Pods in "+OperatorNamespace+"=====", pods, err, &buf, printDebug)
-
-	describe, err := k.Describe("deployment", deploymentName)
-	logDebugElement("=====Operator Deployment describe=====", describe, err, &buf, printDebug)
-	writeDebugFile(artifactsDir, clusterName, "operator", &buf)
-}
-
-func logIstioDebugInfo(k kubectl.Kubectl, artifactsDir, clusterName string, printDebug bool) {
-	var buf strings.Builder
-	resource, err := k.GetYAML("istio", istioName)
-	logDebugElement("=====Istio YAML=====", resource, err, &buf, printDebug)
-
-	output, err := k.WithNamespace(ControlPlaneNamespace).GetPods("", "-o wide")
-	logDebugElement("=====Pods in "+ControlPlaneNamespace+"=====", output, err, &buf, printDebug)
-
-	logs, err := k.WithNamespace(ControlPlaneNamespace).Logs("deploy/istiod", ptr.Of(120*time.Second))
-	logDebugElement("=====Istiod logs=====", logs, err, &buf, printDebug)
-
-	events, err := k.WithNamespace(ControlPlaneNamespace).GetEvents()
-	logDebugElement("=====Events in "+ControlPlaneNamespace+"=====", events, err, &buf, printDebug)
-
-	// Running istioctl proxy-status to get the status of the proxies.
-	proxyStatus, err := istioctl.GetProxyStatus()
-	logDebugElement("=====Istioctl Proxy Status=====", proxyStatus, err, &buf, printDebug)
-	writeDebugFile(artifactsDir, clusterName, "istio", &buf)
-}
-
-func logCNIDebugInfo(k kubectl.Kubectl, artifactsDir, clusterName string, printDebug bool) {
-	var buf strings.Builder
-	resource, err := k.GetYAML("istiocni", istioCniName)
-	logDebugElement("=====IstioCNI YAML=====", resource, err, &buf, printDebug)
-
-	ds, err := k.WithNamespace(IstioCniNamespace).GetYAML("daemonset", "istio-cni-node")
-	logDebugElement("=====Istio CNI DaemonSet YAML=====", ds, err, &buf, printDebug)
-
-	events, err := k.WithNamespace(IstioCniNamespace).GetEvents()
-	logDebugElement("=====Events in "+IstioCniNamespace+"=====", events, err, &buf, printDebug)
-
-	pods, err := k.WithNamespace(IstioCniNamespace).GetPods("", "-o wide")
-	logDebugElement("=====Pods in "+IstioCniNamespace+"=====", pods, err, &buf, printDebug)
-
-	describe, err := k.WithNamespace(IstioCniNamespace).Describe("daemonset", "istio-cni-node")
-	logDebugElement("=====Istio CNI DaemonSet describe=====", describe, err, &buf, printDebug)
-
-	logs, err := k.WithNamespace(IstioCniNamespace).Logs("daemonset/istio-cni-node", ptr.Of(120*time.Second))
-	logDebugElement("=====Istio CNI logs=====", logs, err, &buf, printDebug)
-	writeDebugFile(artifactsDir, clusterName, "cni", &buf)
-}
-
-func logZtunnelDebugInfo(k kubectl.Kubectl, artifactsDir, clusterName string, printDebug bool) {
-	var buf strings.Builder
-	resource, err := k.GetYAML("ztunnel", "default")
-	logDebugElement("=====ZTunnel YAML=====", resource, err, &buf, printDebug)
-
-	ds, err := k.WithNamespace(ZtunnelNamespace).GetYAML("daemonset", "ztunnel")
-	logDebugElement("=====ZTunnel DaemonSet YAML=====", ds, err, &buf, printDebug)
-
-	events, err := k.WithNamespace(ZtunnelNamespace).GetEvents()
-	logDebugElement("=====Events in "+ZtunnelNamespace+"=====", events, err, &buf, printDebug)
-
-	describe, err := k.WithNamespace(ZtunnelNamespace).Describe("daemonset", "ztunnel")
-	logDebugElement("=====ZTunnel DaemonSet describe=====", describe, err, &buf, printDebug)
-
-	logs, err := k.WithNamespace(ZtunnelNamespace).Logs("daemonset/ztunnel", ptr.Of(120*time.Second))
-	logDebugElement("=====ztunnel logs=====", logs, err, &buf, printDebug)
-	writeDebugFile(artifactsDir, clusterName, "ztunnel", &buf)
-}
-
-func logCertsDebugInfo(k kubectl.Kubectl, artifactsDir, clusterName string, printDebug bool) {
-	var buf strings.Builder
-	certs, err := k.WithNamespace(ControlPlaneNamespace).GetSecret("cacerts")
-	logDebugElement("=====CA certs in "+ControlPlaneNamespace+"=====", certs, err, &buf, printDebug)
-	writeDebugFile(artifactsDir, clusterName, "certs", &buf)
-}
-
-func logSampleNamespacesDebugInfo(k kubectl.Kubectl, suite testSuite, artifactsDir, clusterName string, printDebug bool) {
-	// Common sample namespaces used across different test suites
-	sampleNamespaces := []string{SleepNamespace, HttpbinNamespace}
-
-	// Add additional namespaces based on test suite
-	switch suite {
-	case MultiCluster, ControlPlane, MultiControlPlane:
-		sampleNamespaces = append(sampleNamespaces, "sample")
-	case DualStack:
-		// Dual-stack tests use specific namespaces for TCP services
-		sampleNamespaces = append(sampleNamespaces, "dual-stack", "ipv4", "ipv6")
-	}
-
-	for _, ns := range sampleNamespaces {
-		var buf strings.Builder
-		logSampleNamespaceInfo(k, ns, &buf, printDebug)
-		writeDebugFile(artifactsDir, clusterName, "namespace-"+ns, &buf)
-	}
-}
-
-func logSampleNamespaceInfo(k kubectl.Kubectl, namespace string, buf *strings.Builder, printDebug bool) {
-	// Check if namespace exists
-	nsInfo, err := k.GetYAML("namespace", namespace)
-	if err != nil {
-		logDebugElement("=====Namespace "+namespace+" (not found)=====", "", err, buf, printDebug)
-		return
-	}
-	logDebugElement("=====Namespace "+namespace+" YAML=====", nsInfo, err, buf, printDebug)
-
-	// Get pods in the namespace with wide output for more details
-	pods, err := k.WithNamespace(namespace).GetPods("", "-o wide")
-	logDebugElement("=====Pods in "+namespace+"=====", pods, err, buf, printDebug)
-
-	// Get events in the namespace
-	events, err := k.WithNamespace(namespace).GetEvents()
-	logDebugElement("=====Events in "+namespace+"=====", events, err, buf, printDebug)
-
-	// Get deployments
-	deployments, err := k.WithNamespace(namespace).GetYAML("deployments", "")
-	logDebugElement("=====Deployments in "+namespace+"=====", deployments, err, buf, printDebug)
-
-	// Get services
-	services, err := k.WithNamespace(namespace).GetYAML("services", "")
-	logDebugElement("=====Services in "+namespace+"=====", services, err, buf, printDebug)
-
-	// Describe failed or non-ready pods specifically
-	logFailedPodsDetails(k, namespace, buf, printDebug)
-}
-
-func logFailedPodsDetails(k kubectl.Kubectl, namespace string, buf *strings.Builder, printDebug bool) {
-	describe, err := k.WithNamespace(namespace).Describe("pods", "")
-	logDebugElement("=====Pod descriptions in "+namespace+"=====", describe, err, buf, printDebug)
-}
-
-// truncateForJUnit truncates strings that exceed maxJUnitErrorMessageSize
-// to prevent junit XML files from becoming excessively large.
-func truncateForJUnit(s string) string {
-	if len(s) <= maxJUnitErrorMessageSize {
-		return s
-	}
-
-	const truncationMsg = "\n\n... [truncated due to size limit] ..."
-	truncateAt := maxJUnitErrorMessageSize - len(truncationMsg)
-	if truncateAt < 0 {
-		truncateAt = 0
-	}
-
-	return s[:truncateAt] + truncationMsg
-}
-
-func logDebugElement(caption string, info string, err error, buf *strings.Builder, printDebug bool) {
-	buf.WriteString("\n" + caption + ":\n")
-	if err != nil {
-		buf.WriteString(Indent(err.Error()) + "\n")
-	} else {
-		buf.WriteString(Indent(strings.TrimSpace(info)) + "\n")
-	}
-
-	if printDebug {
-		GinkgoWriter.Println("\n" + caption + ":")
-		if err != nil {
-			GinkgoWriter.Println(Indent(truncateForJUnit(err.Error())))
-		} else {
-			GinkgoWriter.Println(Indent(truncateForJUnit(strings.TrimSpace(info))))
-		}
-	}
-}
-
 func GetVersionFromIstiod() (*semver.Version, error) {
 	k := kubectl.New()
 	output, err := k.WithNamespace(ControlPlaneNamespace).Exec("deploy/istiod", "", "pilot-discovery version")
@@ -482,12 +232,11 @@ spec:
 
 func CreateZTunnel(k kubectl.Kubectl, version string, specs ...string) {
 	yaml := `
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: ZTunnel
 metadata:
   name: default
 spec:
-  profile: ambient
   version: %s
   namespace: %s`
 	yaml = fmt.Sprintf(yaml, version, ZtunnelNamespace)
@@ -539,11 +288,23 @@ func withClusterName(m string, k kubectl.Kubectl) string {
 	return m + " on " + k.ClusterName
 }
 
-func CheckPodConnectivity(podName, containerName, srcNamespace, destNamespace string, k kubectl.Kubectl) {
+// CheckPodConnectivityWithError tests connectivity from podName to httpbin in destNamespace
+// and returns an error instead of calling Expect directly. This allows callers wrapped in
+// Eventually to retry on transient failures (e.g. 503 during proxy startup/upgrade).
+func CheckPodConnectivityWithError(podName, containerName, srcNamespace, destNamespace string, k kubectl.Kubectl) error {
 	command := fmt.Sprintf(`curl -o /dev/null -s -w "%%{http_code}\n" httpbin.%s.svc.cluster.local:8000/get`, destNamespace)
 	response, err := k.WithNamespace(srcNamespace).Exec(podName, containerName, command)
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error connecting to the %q pod", podName))
-	Expect(response).To(ContainSubstring("200"), fmt.Sprintf("Unexpected response from %s pod", podName))
+	if err != nil {
+		return fmt.Errorf("error connecting to the %q pod: %w", podName, err)
+	}
+	if !strings.Contains(response, "200") {
+		return fmt.Errorf("unexpected response from %s pod: %s", podName, strings.TrimSpace(response))
+	}
+	return nil
+}
+
+func CheckPodConnectivity(podName, containerName, srcNamespace, destNamespace string, k kubectl.Kubectl) {
+	Expect(CheckPodConnectivityWithError(podName, containerName, srcNamespace, destNamespace, k)).To(Succeed())
 }
 
 func HaveContainersThat(matcher types.GomegaMatcher) types.GomegaMatcher {
@@ -582,7 +343,7 @@ func EnsureNamespaceWithCleanup(k kubectl.Kubectl, namespace string) {
 func GetProxyVersion(podName, namespace string) (*semver.Version, error) {
 	proxyStatus, err := istioctl.GetProxyStatus("--namespace " + namespace)
 	if err != nil {
-		return nil, fmt.Errorf("error getting sidecar version: %w", err)
+		return nil, fmt.Errorf("error getting proxy version: %w", err)
 	}
 
 	lines := strings.Split(proxyStatus, "\n")
@@ -604,8 +365,10 @@ func GetProxyVersion(podName, namespace string) (*semver.Version, error) {
 	for _, line := range lines[1:] {
 		if strings.Contains(line, podName+"."+namespace) {
 			values := colSplit.Split(strings.TrimSpace(line), -1)
-			versionStr = values[versionIdx]
-			break
+			if versionIdx < len(values) {
+				versionStr = values[versionIdx]
+				break
+			}
 		}
 	}
 
@@ -614,7 +377,50 @@ func GetProxyVersion(podName, namespace string) (*semver.Version, error) {
 	}
 	version, err := semver.NewVersion(versionStr)
 	if err != nil {
-		return version, fmt.Errorf("error parsing sidecar version %q: %w", versionStr, err)
+		return version, fmt.Errorf("error parsing proxy version %q: %w", versionStr, err)
 	}
 	return version, err
+}
+
+// GetIstioProxyContainer finds and returns the istio-proxy container from a pod
+// It checks both regular containers and init containers (for persistent init containers in K8s 1.28+)
+// Returns the container if found, nil otherwise
+func GetIstioProxyContainer(pod corev1.Pod) *corev1.Container {
+	// Check regular containers
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == "istio-proxy" {
+			return &pod.Spec.Containers[i]
+		}
+	}
+
+	// Check init containers
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == "istio-proxy" {
+			return &pod.Spec.InitContainers[i]
+		}
+	}
+
+	return nil
+}
+
+// HasSidecarInjected checks if a pod has the istio-proxy sidecar injected
+func HasSidecarInjected(pod corev1.Pod) bool {
+	return GetIstioProxyContainer(pod) != nil
+}
+
+// HasHBONEEnabled checks if the istio-proxy sidecar has HBONE capability enabled
+// by verifying the ISTIO_META_ENABLE_HBONE environment variable is set to "true"
+func HasHBONEEnabled(pod corev1.Pod) bool {
+	container := GetIstioProxyContainer(pod)
+	if container == nil {
+		return false
+	}
+
+	for _, env := range container.Env {
+		if env.Name == "ISTIO_META_ENABLE_HBONE" && env.Value == "true" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/tests/e2e/util/common/gather_log.go
+++ b/tests/e2e/util/common/gather_log.go
@@ -1,0 +1,501 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/istioctl"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// Supported resource types for debug collection
+const (
+	ResourceTypeDeployment = "deployment"
+	ResourceTypeDaemonSet  = "daemonset"
+	ResourceTypeConfigMap  = "configmap"
+	ResourceTypeSecret     = "secret"
+	ResourceTypeIstio      = "istio"
+	ResourceTypeIstioCNI   = "istiocni"
+	ResourceTypeZTunnel    = "ztunnel"
+)
+
+// resourceSpec defines a resource to collect during debug gathering
+type resourceSpec struct {
+	resourceType    string // "deployment", "daemonset", "configmap", "secret", "istio", "istiocni", "ztunnel"
+	name            string // resource name
+	includeDescribe bool   // whether to collect kubectl describe output
+	outputCaption   string // caption for console output
+	outputFilename  string // filename for file output (without extension)
+}
+
+// debugConfig defines what debug information to collect for a namespace
+type debugConfig struct {
+	namespace           string
+	customResources     []resourceSpec                                                               // Custom resources (Istio, IstioCNI, ZTunnel)
+	workloads           []resourceSpec                                                               // Deployments, DaemonSets
+	additionalResources []resourceSpec                                                               // ConfigMaps, Secrets, etc.
+	customActions       []func(k kubectl.Kubectl, artifactsDir, clusterName string, printDebug bool) // Custom collection logic
+}
+
+// collectProxyStatus collects istioctl proxy-status output
+func collectProxyStatus(k kubectl.Kubectl, artifactsDir, clusterName string, printDebug bool) {
+	proxyStatus, err := istioctl.GetProxyStatus()
+	writeDebugFile(artifactsDir, clusterName, ControlPlaneNamespace, "proxy-status.txt", formatOutput(proxyStatus, err))
+	if printDebug {
+		printDebugOutput("=====Istioctl Proxy Status=====", proxyStatus, err)
+	}
+}
+
+// buildOperatorInfrastructureConfigs returns debug configurations for Sail operator, Istio, IstioCNI, and ZTunnel namespaces
+func buildOperatorInfrastructureConfigs(suite testSuite) []debugConfig {
+	// Common configs for all test suites
+	configs := []debugConfig{
+		// Operator namespace
+		{
+			namespace: OperatorNamespace,
+			workloads: []resourceSpec{
+				{
+					resourceType:    ResourceTypeDeployment,
+					name:            deploymentName,
+					includeDescribe: true,
+					outputCaption:   "Operator Deployment YAML",
+					outputFilename:  "deployment-" + deploymentName,
+				},
+			},
+		},
+		// Istio control plane namespace
+		{
+			namespace: ControlPlaneNamespace,
+			customResources: []resourceSpec{
+				{
+					resourceType:   ResourceTypeIstio,
+					name:           istioName,
+					outputCaption:  "Istio YAML",
+					outputFilename: "istio-cr",
+				},
+			},
+			additionalResources: []resourceSpec{
+				{
+					resourceType:   ResourceTypeConfigMap,
+					name:           "istio",
+					outputCaption:  "Istio Mesh ConfigMap",
+					outputFilename: "configmap-istio",
+				},
+				{
+					resourceType:   ResourceTypeSecret,
+					name:           "cacerts",
+					outputCaption:  "CA certs in " + ControlPlaneNamespace,
+					outputFilename: "secret-cacerts",
+				},
+			},
+			customActions: []func(kubectl.Kubectl, string, string, bool){
+				collectProxyStatus,
+			},
+		},
+		// CNI namespace
+		{
+			namespace: IstioCniNamespace,
+			customResources: []resourceSpec{
+				{
+					resourceType:   ResourceTypeIstioCNI,
+					name:           istioCniName,
+					outputCaption:  "IstioCNI YAML",
+					outputFilename: "istiocni-cr",
+				},
+			},
+			workloads: []resourceSpec{
+				{
+					resourceType:    ResourceTypeDaemonSet,
+					name:            "istio-cni-node",
+					includeDescribe: true,
+					outputCaption:   "Istio CNI DaemonSet YAML",
+					outputFilename:  "daemonset-istio-cni-node",
+				},
+			},
+		},
+	}
+
+	// Add ZTunnel config for Ambient test suite
+	if suite == Ambient {
+		configs = append(configs, debugConfig{
+			namespace: ZtunnelNamespace,
+			customResources: []resourceSpec{
+				{
+					resourceType:   ResourceTypeZTunnel,
+					name:           "default",
+					outputCaption:  "ZTunnel YAML",
+					outputFilename: "ztunnel-cr",
+				},
+			},
+			workloads: []resourceSpec{
+				{
+					resourceType:    ResourceTypeDaemonSet,
+					name:            "ztunnel",
+					includeDescribe: true,
+					outputCaption:   "ZTunnel DaemonSet YAML",
+					outputFilename:  "daemonset-ztunnel",
+				},
+			},
+		})
+	}
+
+	return configs
+}
+
+// LogDebugInfo collects comprehensive debug information from Kubernetes clusters when tests fail.
+// It organizes output by cluster and namespace, writing individual files for each debug element.
+//
+// Debug information includes:
+// - Custom Resource YAMLs (Istio, IstioCNI, ZTunnel)
+// - Deployment/DaemonSet YAMLs and descriptions
+// - Pod lists and individual pod logs (current and previous)
+// - Events, metrics, and resource status
+// - Namespace-specific resources (deployments, services, endpoints, network policies)
+//
+// Output structure: $ARTIFACTS/debug/<cluster-name>/<namespace>/<file>
+//
+// Environment variables:
+// - ARTIFACTS: Base directory for debug output (default: /tmp/artifacts)
+// - E2E_PRINT_DEBUG: When true, also prints debug info to console (default: false)
+func LogDebugInfo(suite testSuite, kubectls ...kubectl.Kubectl) {
+	artifactsDir := env.Get("ARTIFACTS", "/tmp/artifacts")
+	printDebug := env.GetBool("E2E_PRINT_DEBUG", false)
+
+	if printDebug {
+		GinkgoWriter.Println()
+		GinkgoWriter.Println("The test run has failures and the debug information is as follows:")
+		GinkgoWriter.Println()
+	}
+
+	// Get debug configurations for this test suite
+	configs := buildOperatorInfrastructureConfigs(suite)
+
+	for _, k := range kubectls {
+		clusterName := k.ClusterName
+		if clusterName == "" {
+			clusterName = "default"
+		}
+
+		if printDebug && k.ClusterName != "" {
+			GinkgoWriter.Println("=========================================================")
+			GinkgoWriter.Println("CLUSTER:", k.ClusterName)
+			GinkgoWriter.Println("=========================================================")
+		}
+
+		// Collect debug info in parallel
+		var wg sync.WaitGroup
+
+		// Collect debug info for each configured namespace
+		wg.Add(len(configs))
+		for _, config := range configs {
+			go func(cfg debugConfig) {
+				defer wg.Done()
+				collectDebugInfo(k, artifactsDir, clusterName, cfg, printDebug)
+			}(config)
+		}
+
+		// Collect sample namespace info
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			logTestApplicationNamespaces(k, suite, artifactsDir, clusterName, printDebug)
+		}()
+
+		wg.Wait()
+
+		if printDebug {
+			GinkgoWriter.Println("=========================================================")
+			GinkgoWriter.Println()
+		}
+	}
+}
+
+// writeDebugFile writes the collected debug information to a file under the artifacts directory.
+// Files are organized by cluster and namespace: $ARTIFACTS/debug/<cluster-name>/<namespace>/<filename>
+func writeDebugFile(artifactsDir, clusterName, namespace, filename, content string) error {
+	debugDir := filepath.Join(artifactsDir, "debug", clusterName, namespace)
+	if err := os.MkdirAll(debugDir, 0o755); err != nil {
+		GinkgoWriter.Printf("Warning: failed to create debug directory %s: %v\n", debugDir, err)
+		return err
+	}
+
+	filePath := filepath.Join(debugDir, filename)
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		GinkgoWriter.Printf("Warning: failed to write debug file %s: %v\n", filePath, err)
+		return err
+	}
+	return nil
+}
+
+// printDebugOutput prints debug information to GinkgoWriter when E2E_PRINT_DEBUG is enabled
+func printDebugOutput(caption, content string, err error) {
+	GinkgoWriter.Println("\n" + caption + ":")
+	if err != nil {
+		GinkgoWriter.Println(Indent(truncateForJUnit(err.Error())))
+	} else {
+		GinkgoWriter.Println(Indent(truncateForJUnit(strings.TrimSpace(content))))
+	}
+}
+
+// formatOutput formats content or error message for writing to file
+func formatOutput(content string, err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return strings.TrimSpace(content)
+}
+
+func getPodsInNamespace(k kubectl.Kubectl, namespace string) ([]string, error) {
+	podList, err := k.WithNamespace(namespace).GetPods("", "-o name")
+	if err != nil {
+		return nil, err
+	}
+
+	var pods []string
+	lines := strings.Split(strings.TrimSpace(podList), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Remove "pod/" prefix if present
+		podName := strings.TrimPrefix(line, "pod/")
+		pods = append(pods, podName)
+	}
+	return pods, nil
+}
+
+// collectResource collects a single resource based on its specification
+func collectResource(k kubectl.Kubectl, artifactsDir, clusterName, namespace string, spec resourceSpec, printDebug bool) {
+	// Collect the resource YAML (kubectl will error if resource type is invalid)
+	content, err := k.GetYAML(spec.resourceType, spec.name)
+
+	// Write YAML output
+	writeDebugFile(artifactsDir, clusterName, namespace, spec.outputFilename+".yaml", formatOutput(content, err))
+	if printDebug {
+		printDebugOutput("====="+spec.outputCaption+"=====", content, err)
+	}
+
+	// If requested, also collect describe output
+	if spec.includeDescribe && (spec.resourceType == ResourceTypeDeployment || spec.resourceType == ResourceTypeDaemonSet) {
+		describe, descErr := k.Describe(spec.resourceType, spec.name)
+		writeDebugFile(artifactsDir, clusterName, namespace, spec.outputFilename+"-describe.txt", formatOutput(describe, descErr))
+		if printDebug {
+			printDebugOutput("====="+spec.outputCaption+" describe=====", describe, descErr)
+		}
+	}
+}
+
+// collectCommonNamespaceResources collects common resources present in all namespaces
+func collectCommonNamespaceResources(k kubectl.Kubectl, artifactsDir, clusterName, namespace string, printDebug bool) {
+	// Events
+	events, err := k.GetEvents()
+	writeDebugFile(artifactsDir, clusterName, namespace, "events.txt", formatOutput(events, err))
+	if printDebug {
+		printDebugOutput("=====Events in "+namespace+"=====", events, err)
+	}
+
+	// Pods list
+	pods, err := k.GetPods("", "-o wide")
+	writeDebugFile(artifactsDir, clusterName, namespace, "pods.txt", formatOutput(pods, err))
+	if printDebug {
+		printDebugOutput("=====Pods in "+namespace+"=====", pods, err)
+	}
+
+	// Resource metrics
+	metrics, err := k.TopPods()
+	writeDebugFile(artifactsDir, clusterName, namespace, "metrics.txt", formatOutput(metrics, err))
+	if printDebug {
+		printDebugOutput("=====Resource metrics in "+namespace+"=====", metrics, err)
+	}
+}
+
+// collectDebugInfo is a generic function to collect debug information based on configuration
+func collectDebugInfo(k kubectl.Kubectl, artifactsDir, clusterName string, config debugConfig, printDebug bool) {
+	namespace := config.namespace
+
+	// Collect custom resources (these are typically cluster-scoped or collected before setting namespace)
+	for _, spec := range config.customResources {
+		collectResource(k, artifactsDir, clusterName, namespace, spec, printDebug)
+	}
+
+	// Set namespace context for namespaced resources
+	k = k.WithNamespace(namespace)
+
+	// Collect workload resources (deployments, daemonsets)
+	for _, spec := range config.workloads {
+		collectResource(k, artifactsDir, clusterName, namespace, spec, printDebug)
+	}
+
+	// Collect common namespace resources (events, pods, metrics)
+	collectCommonNamespaceResources(k, artifactsDir, clusterName, namespace, printDebug)
+
+	// Collect additional resources (configmaps, secrets, etc.)
+	for _, spec := range config.additionalResources {
+		collectResource(k, artifactsDir, clusterName, namespace, spec, printDebug)
+	}
+
+	// Execute custom actions (like istioctl commands)
+	for _, action := range config.customActions {
+		action(k, artifactsDir, clusterName, printDebug)
+	}
+
+	// Collect individual pod logs
+	collectPodsLogsInNamespace(k, artifactsDir, clusterName, namespace, printDebug)
+}
+
+// collectPodsLogsInNamespace collects logs from all pods in a namespace
+func collectPodsLogsInNamespace(k kubectl.Kubectl, artifactsDir, clusterName, namespace string, printDebug bool) {
+	pods, err := getPodsInNamespace(k, namespace)
+	if err != nil {
+		if printDebug {
+			printDebugOutput("=====Failed to get pods in "+namespace+"=====", "", err)
+		}
+		writeDebugFile(artifactsDir, clusterName, namespace, "pods-error.txt", formatOutput("", err))
+		return
+	}
+
+	for _, podName := range pods {
+		// Collect current logs
+		logs, err := k.WithNamespace(namespace).Logs(podName, nil)
+		filename := "pod-" + podName + ".log"
+		writeDebugFile(artifactsDir, clusterName, namespace, filename, formatOutput(logs, err))
+		if printDebug {
+			printDebugOutput("=====Logs for pod "+podName+"=====", logs, err)
+		}
+
+		// Collect previous logs if available
+		prevLogs, err := k.WithNamespace(namespace).LogsPrevious(podName, nil)
+		if err == nil && prevLogs != "" {
+			prevFilename := "pod-" + podName + "-previous.log"
+			writeDebugFile(artifactsDir, clusterName, namespace, prevFilename, prevLogs)
+			if printDebug {
+				printDebugOutput("=====Previous logs for pod "+podName+" (container restarted)=====", prevLogs, nil)
+			}
+		}
+	}
+}
+
+func logTestApplicationNamespaces(k kubectl.Kubectl, suite testSuite, artifactsDir, clusterName string, printDebug bool) {
+	// Common sample namespaces used across different test suites
+	sampleNamespaces := []string{SleepNamespace, HttpbinNamespace}
+
+	// Add additional namespaces based on test suite
+	switch suite {
+	case MultiCluster, ControlPlane, MultiControlPlane:
+		sampleNamespaces = append(sampleNamespaces, "sample")
+	case DualStack:
+		// Dual-stack tests use specific namespaces for TCP services
+		sampleNamespaces = append(sampleNamespaces, "dual-stack", "ipv4", "ipv6")
+	}
+
+	for _, ns := range sampleNamespaces {
+		logTestApplicationNamespace(k, ns, artifactsDir, clusterName, printDebug)
+	}
+}
+
+func logTestApplicationNamespace(k kubectl.Kubectl, namespace, artifactsDir, clusterName string, printDebug bool) {
+	// Check if namespace exists
+	nsInfo, err := k.GetYAML("namespace", namespace)
+	if err != nil {
+		// Namespace doesn't exist, write error and return
+		writeDebugFile(artifactsDir, clusterName, namespace, "namespace-not-found.txt", formatOutput("", err))
+		if printDebug {
+			printDebugOutput("=====Namespace "+namespace+" (not found)=====", "", err)
+		}
+		return
+	}
+
+	writeDebugFile(artifactsDir, clusterName, namespace, "namespace.yaml", formatOutput(nsInfo, nil))
+	if printDebug {
+		printDebugOutput("=====Namespace "+namespace+" YAML=====", nsInfo, nil)
+	}
+
+	k = k.WithNamespace(namespace)
+
+	pods, err := k.GetPods("", "-o wide")
+	writeDebugFile(artifactsDir, clusterName, namespace, "pods.txt", formatOutput(pods, err))
+	if printDebug {
+		printDebugOutput("=====Pods in "+namespace+"=====", pods, err)
+	}
+
+	podDescribe, err := k.Describe("pods", "")
+	writeDebugFile(artifactsDir, clusterName, namespace, "pods-describe.txt", formatOutput(podDescribe, err))
+	if printDebug {
+		printDebugOutput("=====Pod descriptions in "+namespace+"=====", podDescribe, err)
+	}
+
+	events, err := k.GetEvents()
+	writeDebugFile(artifactsDir, clusterName, namespace, "events.txt", formatOutput(events, err))
+	if printDebug {
+		printDebugOutput("=====Events in "+namespace+"=====", events, err)
+	}
+
+	deployments, err := k.GetYAML("deployments", "")
+	writeDebugFile(artifactsDir, clusterName, namespace, "deployments.yaml", formatOutput(deployments, err))
+	if printDebug {
+		printDebugOutput("=====Deployments in "+namespace+"=====", deployments, err)
+	}
+
+	services, err := k.GetYAML("services", "")
+	writeDebugFile(artifactsDir, clusterName, namespace, "services.yaml", formatOutput(services, err))
+	if printDebug {
+		printDebugOutput("=====Services in "+namespace+"=====", services, err)
+	}
+
+	endpoints, err := k.GetYAML("endpoints", "")
+	writeDebugFile(artifactsDir, clusterName, namespace, "endpoints.yaml", formatOutput(endpoints, err))
+	if printDebug {
+		printDebugOutput("=====Endpoints in "+namespace+"=====", endpoints, err)
+	}
+
+	networkPolicies, err := k.GetYAML("networkpolicies", "")
+	writeDebugFile(artifactsDir, clusterName, namespace, "networkpolicies.yaml", formatOutput(networkPolicies, err))
+	if printDebug {
+		printDebugOutput("=====NetworkPolicies in "+namespace+"=====", networkPolicies, err)
+	}
+
+	metrics, err := k.TopPods()
+	writeDebugFile(artifactsDir, clusterName, namespace, "metrics.txt", formatOutput(metrics, err))
+	if printDebug {
+		printDebugOutput("=====Resource metrics in "+namespace+"=====", metrics, err)
+	}
+
+	collectPodsLogsInNamespace(k, artifactsDir, clusterName, namespace, printDebug)
+}
+
+// truncateForJUnit truncates strings that exceed maxJUnitErrorMessageSize
+// to prevent junit XML files from becoming excessively large.
+func truncateForJUnit(s string) string {
+	if len(s) <= maxJUnitErrorMessageSize {
+		return s
+	}
+
+	const truncationMsg = "\n\n... [truncated due to size limit] ..."
+	truncateAt := maxJUnitErrorMessageSize - len(truncationMsg)
+	if truncateAt < 0 {
+		truncateAt = 0
+	}
+
+	return s[:truncateAt] + truncationMsg
+}

--- a/tests/e2e/util/common/http_traffic.go
+++ b/tests/e2e/util/common/http_traffic.go
@@ -1,0 +1,159 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// CheckHTTPConnectivity performs an HTTP GET request from a source pod to a target URL
+// and verifies that the response matches the expected HTTP status code.
+// The targetURL can be a short name (e.g., "httpbin:8000/get") or a fully qualified URL.
+// The expectedStatus should be the expected HTTP status code (e.g., "200", "403", "503").
+// Returns nil if the check succeeds, or an error describing what failed.
+// Designed for use with Eventually: Eventually(func() error { return CheckHTTPConnectivity(...) }).Should(Succeed())
+func CheckHTTPConnectivity(
+	k kubectl.Kubectl,
+	namespace string,
+	podName string,
+	containerName string,
+	targetURL string,
+	timeoutSeconds int,
+	expectedStatus string,
+) error {
+	cmd := fmt.Sprintf("curl -s -o /dev/null -w '%%{http_code}' %s --max-time %d", targetURL, timeoutSeconds)
+	status, err := k.WithNamespace(namespace).Exec(podName, containerName, cmd)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	if status != expectedStatus {
+		return fmt.Errorf("expected HTTP status %s, got %s", expectedStatus, status)
+	}
+	return nil
+}
+
+// HTTPTrafficStats tracks continuous HTTP traffic statistics with thread-safe counters
+type HTTPTrafficStats struct {
+	totalRequests   atomic.Int64
+	failedRequests  atomic.Int64
+	successRequests atomic.Int64
+	mu              sync.Mutex
+	errors          []string
+}
+
+// RecordSuccess increments the success counter
+func (ts *HTTPTrafficStats) RecordSuccess() {
+	ts.totalRequests.Add(1)
+	ts.successRequests.Add(1)
+}
+
+// RecordFailure increments the failure counter and stores the error message
+func (ts *HTTPTrafficStats) RecordFailure(errMsg string) {
+	ts.totalRequests.Add(1)
+	ts.failedRequests.Add(1)
+	ts.mu.Lock()
+	ts.errors = append(ts.errors, errMsg)
+	ts.mu.Unlock()
+}
+
+// GetStats returns the current statistics (total, success, failed, errors)
+func (ts *HTTPTrafficStats) GetStats() (total, success, failed int64, errors []string) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.totalRequests.Load(), ts.successRequests.Load(), ts.failedRequests.Load(), append([]string{}, ts.errors...)
+}
+
+// StartContinuousHTTPTraffic starts sending continuous HTTP GET requests in the background.
+// If existingStats is nil, creates a new stats object. Otherwise reuses the existing one.
+// Returns the stats tracker and a cancel function to stop the traffic.
+// The kubectl instance k must be accessible (typically via closure in test context).
+func StartContinuousHTTPTraffic(
+	ctx context.Context,
+	k kubectl.Kubectl,
+	namespace string,
+	clientPod string,
+	containerName string,
+	targetURL string,
+	interval time.Duration,
+	existingStats *HTTPTrafficStats,
+) (*HTTPTrafficStats, context.CancelFunc) {
+	stats := existingStats
+	if stats == nil {
+		stats = &HTTPTrafficStats{}
+	}
+
+	trafficCtx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Log(fmt.Sprintf("[Traffic] Starting continuous traffic from %s to %s (interval: %v)", clientPod, targetURL, interval))
+
+		// sendRequest spawns a goroutine to send a request without blocking the ticker
+		sendRequest := func() {
+			go func() {
+				defer GinkgoRecover()
+				defer func() {
+					if r := recover(); r != nil {
+						errMsg := fmt.Sprintf("panic in sendRequest: %v", r)
+						stats.RecordFailure(errMsg)
+						Log(fmt.Sprintf("[Traffic] %s", errMsg))
+					}
+				}()
+
+				cmd := fmt.Sprintf("curl -s -o /dev/null -w '%%{http_code}' %s --max-time 2", targetURL)
+				output, err := k.WithNamespace(namespace).Exec(clientPod, containerName, cmd)
+				if err != nil {
+					errMsg := fmt.Sprintf("request failed: %v", err)
+					stats.RecordFailure(errMsg)
+					Log(fmt.Sprintf("[Traffic] %s", errMsg))
+				} else if output != "200" {
+					errMsg := fmt.Sprintf("unexpected status code: %s", output)
+					stats.RecordFailure(errMsg)
+					Log(fmt.Sprintf("[Traffic] %s", errMsg))
+				} else {
+					stats.RecordSuccess()
+				}
+			}()
+		}
+
+		// Send first request immediately
+		sendRequest()
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-trafficCtx.Done():
+				Log("[Traffic] Stopping continuous traffic (context cancelled)")
+				return
+			case <-ticker.C:
+				sendRequest()
+			}
+		}
+	}()
+
+	return stats, cancel
+}

--- a/tests/e2e/util/common/workload_validator.go
+++ b/tests/e2e/util/common/workload_validator.go
@@ -1,0 +1,206 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR Condition OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/istio-ecosystem/sail-operator/pkg/kube"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DataplaneMode represents the Istio dataplane mode
+type DataplaneMode string
+
+const (
+	// DataplaneModeSidecar represents sidecar mode (proxy injected as sidecar container)
+	DataplaneModeSidecar DataplaneMode = "sidecar"
+	// DataplaneModeAmbient represents ambient mode (proxy in ZTunnel DaemonSet)
+	DataplaneModeAmbient DataplaneMode = "ambient"
+)
+
+// WorkloadValidator manages test workload deployment and validation
+type WorkloadValidator struct {
+	K             kubectl.Kubectl
+	Cl            client.Client
+	Namespace     string
+	DataplaneMode DataplaneMode
+}
+
+// DeployWorkload deploys sample workloads (sleep + httpbin) based on dataplane mode
+func (w *WorkloadValidator) DeployWorkload(ctx context.Context) error {
+	// Create workload namespace
+	if err := w.K.CreateNamespace(w.Namespace); err != nil {
+		return fmt.Errorf("failed to create namespace %s: %w", w.Namespace, err)
+	}
+
+	// Label namespace based on dataplane mode
+	switch w.DataplaneMode {
+	case DataplaneModeSidecar:
+		if err := w.K.Label("namespace", w.Namespace, "istio-injection", "enabled"); err != nil {
+			return fmt.Errorf("failed to label namespace for sidecar injection: %w", err)
+		}
+	case DataplaneModeAmbient:
+		if err := w.K.Label("namespace", w.Namespace, "istio.io/dataplane-mode", "ambient"); err != nil {
+			return fmt.Errorf("failed to label namespace for ambient mode: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported dataplane mode: %s", w.DataplaneMode)
+	}
+
+	// Create httpbin namespace if it doesn't exist
+	if err := w.K.CreateNamespace(HttpbinNamespace); err != nil {
+		// Ignore error if namespace already exists
+		if !strings.Contains(err.Error(), "already exists") {
+			return fmt.Errorf("failed to create httpbin namespace: %w", err)
+		}
+	}
+
+	// Label httpbin namespace based on dataplane mode
+	switch w.DataplaneMode {
+	case DataplaneModeSidecar:
+		if err := w.K.Label("namespace", HttpbinNamespace, "istio-injection", "enabled"); err != nil {
+			return fmt.Errorf("failed to label httpbin namespace for sidecar injection: %w", err)
+		}
+	case DataplaneModeAmbient:
+		if err := w.K.Label("namespace", HttpbinNamespace, "istio.io/dataplane-mode", "ambient"); err != nil {
+			return fmt.Errorf("failed to label httpbin namespace for ambient mode: %w", err)
+		}
+	}
+
+	// Deploy sleep in workload namespace
+	if err := w.K.WithNamespace(w.Namespace).ApplyKustomize(SleepContainerName); err != nil {
+		return fmt.Errorf("failed to deploy sleep: %w", err)
+	}
+
+	// Deploy httpbin in httpbin namespace
+	if err := w.K.WithNamespace(HttpbinNamespace).ApplyKustomize(HttpbinContainerName); err != nil {
+		return fmt.Errorf("failed to deploy httpbin: %w", err)
+	}
+
+	return nil
+}
+
+// ValidateConnectivity validates that workloads can communicate
+func (w *WorkloadValidator) ValidateConnectivity(ctx context.Context) error {
+	// Wait for pods to be ready in workload namespace
+	if err := CheckPodsReady(ctx, w.Cl, w.Namespace); err != nil {
+		return fmt.Errorf("workload pods not ready in %s: %w", w.Namespace, err)
+	}
+
+	// Wait for pods to be ready in httpbin namespace
+	if err := CheckPodsReady(ctx, w.Cl, HttpbinNamespace); err != nil {
+		return fmt.Errorf("httpbin pods not ready in %s: %w", HttpbinNamespace, err)
+	}
+
+	// Get sleep pod
+	sleepPods := &corev1.PodList{}
+	if err := w.Cl.List(ctx, sleepPods, client.InNamespace(w.Namespace)); err != nil {
+		return fmt.Errorf("failed to list pods in %s: %w", w.Namespace, err)
+	}
+	if len(sleepPods.Items) == 0 {
+		return fmt.Errorf("no pods found in %s namespace", w.Namespace)
+	}
+
+	// Test connectivity from sleep to httpbin
+	CheckPodConnectivity(sleepPods.Items[0].Name, SleepContainerName, w.Namespace, HttpbinNamespace, w.K)
+	return nil
+}
+
+// ValidateProxyVersion validates proxy version based on dataplane mode
+func (w *WorkloadValidator) ValidateProxyVersion(ctx context.Context, expectedVersion *semver.Version) error {
+	switch w.DataplaneMode {
+	case DataplaneModeSidecar:
+		return w.validateSidecarProxyVersion(ctx, expectedVersion)
+	case DataplaneModeAmbient:
+		return w.validateZTunnelVersion(ctx, expectedVersion)
+	default:
+		return fmt.Errorf("unsupported dataplane mode: %s", w.DataplaneMode)
+	}
+}
+
+// validateSidecarProxyVersion checks proxy container version in workload pods
+func (w *WorkloadValidator) validateSidecarProxyVersion(ctx context.Context, expectedVersion *semver.Version) error {
+	pods := &corev1.PodList{}
+	if err := w.Cl.List(ctx, pods, client.InNamespace(w.Namespace)); err != nil {
+		return fmt.Errorf("failed to list pods in %s: %w", w.Namespace, err)
+	}
+
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no pods found in %s namespace", w.Namespace)
+	}
+
+	for _, pod := range pods.Items {
+		proxyVersion, err := GetProxyVersion(pod.Name, w.Namespace)
+		if err != nil {
+			return fmt.Errorf("failed to get proxy version for pod %s: %w", pod.Name, err)
+		}
+		if !proxyVersion.Equal(expectedVersion) {
+			return fmt.Errorf("pod %s has proxy version %s, expected %s",
+				pod.Name, proxyVersion, expectedVersion)
+		}
+	}
+	return nil
+}
+
+// validateZTunnelVersion checks ZTunnel DaemonSet version by reading image tag
+func (w *WorkloadValidator) validateZTunnelVersion(ctx context.Context, expectedVersion *semver.Version) error {
+	daemonset := &appsv1.DaemonSet{}
+	if err := w.Cl.Get(ctx, kube.Key("ztunnel", ZtunnelNamespace), daemonset); err != nil {
+		return fmt.Errorf("failed to get ZTunnel DaemonSet: %w", err)
+	}
+
+	// Extract version from ZTunnel container image tag
+	// Image format: gcr.io/istio-release/ztunnel:1.29.2
+	for _, container := range daemonset.Spec.Template.Spec.Containers {
+		if container.Name == "istio-proxy" {
+			parts := strings.Split(container.Image, ":")
+			if len(parts) != 2 {
+				return fmt.Errorf("unexpected ZTunnel image format: %s", container.Image)
+			}
+			tag := parts[1]
+
+			// Parse version from tag
+			version, err := semver.NewVersion(tag)
+			if err != nil {
+				return fmt.Errorf("failed to parse ZTunnel version from tag %s: %w", tag, err)
+			}
+
+			if !version.Equal(expectedVersion) {
+				return fmt.Errorf("ZTunnel has version %s, expected %s", version, expectedVersion)
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("istio-proxy container not found in ZTunnel DaemonSet")
+}
+
+// Cleanup removes workload and httpbin namespaces
+// Note: In practice, cleanup is handled by the cleaner.New() pattern in tests,
+// so this method is a no-op.
+func (w *WorkloadValidator) Cleanup(ctx context.Context) error {
+	// Cleanup is handled by cleaner.New() in the test setup
+	// which records the initial state and cleans up everything created during the test
+	return nil
+}

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -185,6 +185,17 @@ func (k Kubectl) Delete(kind, name string) error {
 	return nil
 }
 
+// DeleteIgnoreNotFound deletes a resource and succeeds if the resource does not exist.
+// Use this in teardown blocks where the resource may not have been created due to an earlier failure.
+func (k Kubectl) DeleteIgnoreNotFound(kind, name string) error {
+	cmd := k.build(" delete " + kind + " " + name + " --ignore-not-found=true")
+	_, err := k.executeCommand(cmd)
+	if err != nil {
+		return fmt.Errorf("error deleting resource: %w", err)
+	}
+	return nil
+}
+
 // Patch patches a resource
 func (k Kubectl) Patch(kind, name, patchType, patch string) error {
 	cmd := k.build(fmt.Sprintf(" patch %s %s --type=%s -p=%q", kind, name, patchType, patch))
@@ -310,6 +321,27 @@ func (k Kubectl) Logs(pod string, since *time.Duration) (string, error) {
 	return output, nil
 }
 
+// LogsPrevious returns the logs from the previous instance of a container
+func (k Kubectl) LogsPrevious(pod string, since *time.Duration) (string, error) {
+	cmd := k.build(fmt.Sprintf(" logs %s --previous %s", pod, sinceFlag(since)))
+	output, err := shell.ExecuteCommand(cmd)
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+// TopPods returns resource utilization for pods in namespace
+func (k Kubectl) TopPods() (string, error) {
+	cmd := k.build(" top pods --no-headers")
+	output, err := shell.ExecuteCommand(cmd)
+	if err != nil {
+		// metrics-server may not be available, don't fail
+		return "", nil
+	}
+	return output, nil
+}
+
 // Label adds a label to the specified resource
 func (k Kubectl) Label(kind, name, labelKey, labelValue string) error {
 	_, err := k.executeCommand(k.build(fmt.Sprintf(" label %s %s %s=%s", kind, name, labelKey, labelValue)))
@@ -320,6 +352,26 @@ func (k Kubectl) Label(kind, name, labelKey, labelValue string) error {
 func (k Kubectl) LabelNamespaced(kind, namespace, name, labelKey, labelValue string) error {
 	_, err := k.executeCommand(k.build(fmt.Sprintf(" label %s -n %s %s %s=%s", kind, namespace, name, labelKey, labelValue)))
 	return err
+}
+
+// RolloutRestart restarts a deployment using kubectl rollout restart
+func (k Kubectl) RolloutRestart(resource string) (string, error) {
+	cmd := k.build(fmt.Sprintf(" rollout restart %s", resource))
+	output, err := k.executeCommand(cmd)
+	if err != nil {
+		return "", fmt.Errorf("error restarting rollout: %w, output: %s", err, output)
+	}
+	return output, nil
+}
+
+// RolloutStatus waits for a rollout to complete
+func (k Kubectl) RolloutStatus(resource string) (string, error) {
+	cmd := k.build(fmt.Sprintf(" rollout status %s", resource))
+	output, err := k.executeCommand(cmd)
+	if err != nil {
+		return "", fmt.Errorf("error checking rollout status: %w, output: %s", err, output)
+	}
+	return output, nil
 }
 
 // executeCommand handles running the command and then resets the namespace automatically

--- a/tests/e2e/util/update/status_helpers.go
+++ b/tests/e2e/util/update/status_helpers.go
@@ -1,0 +1,157 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR Condition OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package update
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/kube"
+	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AwaitRevisionCount waits for Istio CR to have the expected number of revisions in use
+func AwaitRevisionCount(ctx context.Context, cl client.Client, istioName string, expectedCount int32) {
+	Eventually(func(g Gomega) {
+		istio := &v1.Istio{}
+		g.Expect(cl.Get(ctx, kube.Key(istioName), istio)).To(Succeed(), "Failed to get Istio CR")
+		g.Expect(istio.Status.Revisions.InUse).To(Equal(expectedCount),
+			fmt.Sprintf("Expected %d revisions in use, got %d", expectedCount, istio.Status.Revisions.InUse))
+	}).Should(Succeed(), fmt.Sprintf("Istio CR should have %d revisions in use", expectedCount))
+}
+
+// AwaitIstioRevisionInUse waits for IstioRevision to have the expected InUse condition status
+func AwaitIstioRevisionInUse(ctx context.Context, cl client.Client, revisionName, namespace string, expectedInUse bool) {
+	expectedStatus := metav1.ConditionTrue
+	if !expectedInUse {
+		expectedStatus = metav1.ConditionFalse
+	}
+
+	Eventually(func(g Gomega) {
+		revision := &v1.IstioRevision{}
+		g.Expect(cl.Get(ctx, kube.Key(revisionName, namespace), revision)).To(Succeed(), "Failed to get IstioRevision")
+		g.Expect(revision).To(HaveConditionStatus(v1.IstioRevisionConditionInUse, expectedStatus),
+			fmt.Sprintf("Expected IstioRevision %s InUse=%v", revisionName, expectedInUse))
+	}).Should(Succeed(), fmt.Sprintf("IstioRevision %s should have InUse=%v", revisionName, expectedInUse))
+}
+
+// ValidateComponentVersion validates that a component has the expected version
+func ValidateComponentVersion(ctx context.Context, cl client.Client, componentType, name, namespace string, expectedVersion *semver.Version) error {
+	switch componentType {
+	case "IstioCNI":
+		return validateIstioCNIVersion(ctx, cl, name, expectedVersion)
+	case "ZTunnel":
+		return validateZTunnelVersion(ctx, cl, name, expectedVersion)
+	case "Deployment":
+		return validateDeploymentVersion(ctx, cl, name, namespace, expectedVersion)
+	default:
+		return fmt.Errorf("unsupported component type: %s", componentType)
+	}
+}
+
+// validateIstioCNIVersion validates IstioCNI DaemonSet version
+func validateIstioCNIVersion(ctx context.Context, cl client.Client, name string, expectedVersion *semver.Version) error {
+	cni := &v1.IstioCNI{}
+	if err := cl.Get(ctx, kube.Key(name), cni); err != nil {
+		return fmt.Errorf("failed to get IstioCNI CR: %w", err)
+	}
+
+	// Parse version from CR status or spec
+	var versionStr string
+	if cni.Status.ObservedGeneration > 0 && cni.Spec.Version != "" {
+		versionStr = cni.Spec.Version
+	} else {
+		return fmt.Errorf("IstioCNI CR %s has no version set", name)
+	}
+
+	// Extract semver from version string (may be "v1.29.2" or just "1.29.2")
+	versionStr = strings.TrimPrefix(versionStr, "v")
+	version, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse IstioCNI version %q: %w", versionStr, err)
+	}
+
+	if !version.Equal(expectedVersion) {
+		return fmt.Errorf("IstioCNI has version %s, expected %s", version, expectedVersion)
+	}
+	return nil
+}
+
+// validateZTunnelVersion validates ZTunnel DaemonSet version
+func validateZTunnelVersion(ctx context.Context, cl client.Client, name string, expectedVersion *semver.Version) error {
+	ztunnel := &v1.ZTunnel{}
+	if err := cl.Get(ctx, kube.Key(name), ztunnel); err != nil {
+		return fmt.Errorf("failed to get ZTunnel CR: %w", err)
+	}
+
+	// Parse version from CR spec
+	var versionStr string
+	if ztunnel.Spec.Version != "" {
+		versionStr = ztunnel.Spec.Version
+	} else {
+		return fmt.Errorf("ZTunnel CR %s has no version set", name)
+	}
+
+	// Extract semver from version string
+	versionStr = strings.TrimPrefix(versionStr, "v")
+	version, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse ZTunnel version %q: %w", versionStr, err)
+	}
+
+	if !version.Equal(expectedVersion) {
+		return fmt.Errorf("ZTunnel has version %s, expected %s", version, expectedVersion)
+	}
+	return nil
+}
+
+// validateDeploymentVersion validates Deployment version by reading image tag
+func validateDeploymentVersion(ctx context.Context, cl client.Client, name, namespace string, expectedVersion *semver.Version) error {
+	deployment := &appsv1.Deployment{}
+	if err := cl.Get(ctx, kube.Key(name, namespace), deployment); err != nil {
+		return fmt.Errorf("failed to get Deployment: %w", err)
+	}
+
+	// Extract version from first container image tag
+	if len(deployment.Spec.Template.Spec.Containers) == 0 {
+		return fmt.Errorf("Deployment %s has no containers", name)
+	}
+
+	image := deployment.Spec.Template.Spec.Containers[0].Image
+	parts := strings.Split(image, ":")
+	if len(parts) != 2 {
+		return fmt.Errorf("unexpected image format: %s", image)
+	}
+
+	tag := parts[1]
+	version, err := semver.NewVersion(tag)
+	if err != nil {
+		return fmt.Errorf("failed to parse version from image tag %q: %w", tag, err)
+	}
+
+	if !version.Equal(expectedVersion) {
+		return fmt.Errorf("Deployment has version %s, expected %s", version, expectedVersion)
+	}
+	return nil
+}

--- a/tests/e2e/util/update/version_selection.go
+++ b/tests/e2e/util/update/version_selection.go
@@ -1,0 +1,50 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR Condition OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package update
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
+)
+
+// GetTwoConsecutiveAmbientVersions returns consecutive minor versions for ambient mode.
+// Ambient requires:
+//   - Istio >= 1.24.0
+//   - Istio >= 1.28.0 on FIPS clusters
+func GetTwoConsecutiveAmbientVersions(fipsCluster bool) (baseVer, newVer istioversion.VersionInfo, err error) {
+	minVersion := "1.24.0"
+	if fipsCluster {
+		minVersion = "1.28.0"
+	}
+	minVer, err := semver.NewVersion(minVersion)
+	if err != nil {
+		return baseVer, newVer, fmt.Errorf("failed to parse minimum version %q: %w", minVersion, err)
+	}
+	return istioversion.GetTwoConsecutiveMinorVersions(minVer)
+}
+
+// GetTwoConsecutiveSidecarVersions returns consecutive minor versions for sidecar mode.
+// No special version constraints for sidecar mode.
+func GetTwoConsecutiveSidecarVersions() (baseVer, newVer istioversion.VersionInfo, err error) {
+	minVer, err := semver.NewVersion("1.0.0")
+	if err != nil {
+		return baseVer, newVer, fmt.Errorf("failed to parse minimum version: %w", err)
+	}
+	return istioversion.GetTwoConsecutiveMinorVersions(minVer)
+}


### PR DESCRIPTION
#### What type of PR is this?

- [x] Test

#### What this PR does / why we need it:

Manual cherry-pick resolving issue #2126.

The automated cherry-pick of #2026 onto `release-1.30` failed because several e2e test files that were added in main never got the `cherrypick/release-1.30` label and were therefore absent from the branch. This PR manually brings those commits in and then applies the label-organization change from #2026.

**Commits included (in chronological order):**
- #1938 — Add Ambient "targetref" and "validation" tests
- #1908 — Add Ambient e2e dependency tests
- #1917 — Add Ambient and refactor control plane update tests
- #2007 — Improve tests logs gathering
- #1974 — Add E2E migration test
- #2026 — test: organization of labels used on e2e test *(the original cherry-pick target)*
- #2064 — Reorganize e2e logs gathering
- #2073 — Fix flaky e2e tests across test suites

One conflict was resolved during the cherry-pick of #2007: `e2e_utils.go` conflicted with the `E2E_PRINT_DEBUG` feature already present in release-1.30 (from #2045). The upstream/main version of that file (which correctly integrates both changes) was used as the resolution.

#### Which issue(s) this PR fixes:

Fixes #2126

Related Issue/PR #2026, #1938, #1908, #1917, #2007, #1974, #2064, #2073

#### Additional information:

🤖 Generated with [Claude Code](https://claude.ai/claude-code) via `/jira:solve https://github.com/istio-ecosystem/sail-operator/issues/2126`