### PR TITLE
transformer: strip v1alpha3 and v1beta1 prefixes from fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,21 +160,22 @@ The operator generates `api/v1/values_types.gen.go` from upstream Istio protobuf
 2. Applies transformations per `transform.yaml`: removes imports, replaces types, filters/preserves types, renames fields
 3. Merges all processed files into one output file (`api/v1/values_types.gen.go`)
 
-### Common breakage pattern
+### Auto-resolution of type references
 
-When upstream Istio adds new fields or structs that reference types from removed imports (e.g. `v1alpha3.SomeType`), the generated file will have dangling type references. The error looks like:
+When upstream Istio adds new fields that reference types from removed imports (e.g. `v1alpha3.ClientTLSSettings`), the transformer **automatically strips the package prefix** via `renameImports` entries (`v1alpha3: ""`, `v1beta1: ""`). If the referenced type is already preserved locally (via `preserveTypes`), no manual intervention is needed.
 
-```
-use of unimported package "v1alpha3"
-unknown type v1alpha3.SomeNewType
-```
+This means `replaceFieldTypes` entries are only needed when:
+- The field type must map to a **different** type (e.g. `ReadinessProbe` → `*k8sv1.Probe`)
+- The field type must map to a **k8s or standard library** type (e.g. `LabelSelector` → `*metav1.LabelSelector`)
+- The field type needs a **structural change** (e.g. wrapping in a map or slice)
 
-### How to fix
+### When manual fixes are still needed
 
-1. **Identify the new type references**: The error message shows the unknown types
-2. **Find the source**: Check which upstream `.pb.go` file defines the type (usually in `istio.io/api/networking/v1alpha3/`)
-3. **Preserve the type**: Add it and any sub-types (nested structs, enums) to `preserveTypes` in the relevant input file section of `transform.yaml`
-4. **Replace field type references**: Add `replaceFieldTypes` entries in the input file section where the type is *used* (e.g. `config.pb.go`), mapping `StructName.FieldName` to the local type (without import prefix)
+If the build fails with an unknown type after `make gen`, it means upstream added a reference to a type that is **not yet preserved locally**:
+
+1. **Find the source**: Check which upstream `.pb.go` file defines the type
+2. **Preserve the type**: Add it and any sub-types (nested structs, enums) to `preserveTypes` in the relevant input file section of `transform.yaml`
+3. If the type should map to a k8s type instead of being preserved, add a `replaceFieldTypes` entry
 
 ### Key files
 

--- a/hack/api_transformer/main.go
+++ b/hack/api_transformer/main.go
@@ -970,13 +970,17 @@ func (t *FileTransformer) renameImports(file *ast.File) {
 			if node.Sel != nil && node.X != nil {
 				if ident, ok := node.X.(*ast.Ident); ok {
 					if newName, found := t.Transformations.RenameImports[ident.Name]; found {
+						if newName == "" {
+							cursor.Replace(node.Sel)
+							return false
+						}
 						ident.Name = newName
 					}
 				}
 			}
 		case *ast.ImportSpec:
 			if node.Name != nil {
-				if newName, found := t.Transformations.RenameImports[node.Name.Name]; found {
+				if newName, found := t.Transformations.RenameImports[node.Name.Name]; found && newName != "" {
 					node.Name.Name = newName
 				}
 			}

--- a/hack/api_transformer/transform.yaml
+++ b/hack/api_transformer/transform.yaml
@@ -22,6 +22,9 @@ globalTransformations:
   - k8s.io/apimachinery/pkg/apis/meta/v1
   - k8s.io/api/core/v1
   - unsafe
+  renameImports:
+    v1alpha3: ""  # strip prefix; types from this package are preserved locally
+    v1beta1: ""   # strip prefix; types from this package are preserved locally
   addImports:
     metav1: k8s.io/apimachinery/pkg/apis/meta/v1
     k8sv1: k8s.io/api/core/v1
@@ -168,15 +171,7 @@ inputFiles:
       MeshConfig_ExtensionProvider_EnvoyFileAccessLogProvider_LogFormat_Labels.Labels: "map[string]string"
       MeshConfig_ExtensionProvider_EnvoyOpenTelemetryLogProvider_LogFormat.Labels: "map[string]string"
       MeshConfig.DefaultConfig: "*MeshConfigProxyConfig"
-      MeshConfig.TcpKeepalive: "*ConnectionPoolSettingsTCPSettingsTcpKeepalive"
-      MeshConfig.LocalityLbSetting: "*LocalityLoadBalancerSetting"
-      MeshConfig.DefaultHttpRetryPolicy: "*HTTPRetry"
-      MeshConfig_DefaultTrafficPolicy.ConnectionPool: "*ConnectionPoolSettings"
-      MeshConfig_DefaultTrafficPolicy.OutlierDetection: "*OutlierDetection"
       MeshConfig.DiscoverySelectors: "[]*metav1.LabelSelector"
-      ConfigSource.TlsSettings: "*ClientTLSSettings"
-      MeshConfig_CA.TlsSettings: "*ClientTLSSettings"
-      MeshConfig_OutboundTrafficPolicy.Tls: "*ClientTLSSettings"
       MeshConfig_ServiceScopeConfigs.NamespaceSelector: "*metav1.LabelSelector"
       MeshConfig_ServiceScopeConfigs.ServicesSelector: "*metav1.LabelSelector"
     removeTypes:
@@ -195,11 +190,7 @@ inputFiles:
     renameTypes:
       ProxyConfig: MeshConfigProxyConfig
     replaceFieldTypes:
-      RemoteService.TcpKeepalive: "*ConnectionPoolSettingsTCPSettingsTcpKeepalive"
-      RemoteService.TlsSettings: "*ClientTLSSettings"
-      Tracing.TlsSettings: "*ClientTLSSettings"
       ProxyConfig.ReadinessProbe: "*k8sv1.Probe"
-      ProxyConfig.Image: "*ProxyImage"
 
 - module: istio.io/api
   path: /networking/v1beta1/proxy_config.pb.go
@@ -208,8 +199,6 @@ inputFiles:
     - '*'
     preserveTypes:
     - ProxyImage
-    replaceFieldTypes:
-      ProxyConfig.Selector: "*WorkloadSelector"
 
 - module: istio.io/api
   path: /type/v1beta1/selector.pb.go


### PR DESCRIPTION
This removes one source of problems with the update-deps script, when pre-existing types are used for new fields.