### PR TITLE
webhook controller: remove probing and replace with event monitoring

### DIFF
--- a/changelog/webhook-event-failure-detection.yaml
+++ b/changelog/webhook-event-failure-detection.yaml
@@ -1,0 +1,8 @@
+category: changed
+title: Detect remote istiod webhook failures from cluster events instead of probing
+description: |
+  The webhook controller no longer actively probes the remote istiod's readiness
+  endpoint. It now passively detects webhook call failures from cluster events and
+  marks the webhook and its owning IstioRevision as not-ready for a short degraded
+  window after a failure. The length of this window is configurable via the
+  WEBHOOK_DEGRADED_WINDOW environment variable (default 2 minutes).

--- a/controllers/istiorevision/istiorevision_controller.go
+++ b/controllers/istiorevision/istiorevision_controller.go
@@ -365,7 +365,7 @@ func (r *Reconciler) determineReadyCondition(ctx context.Context, rev *v1.IstioR
 		webhook := admissionv1.MutatingWebhookConfiguration{}
 		webhookKey := injectionWebhookKey(rev)
 		if err := r.Client.Get(ctx, webhookKey, &webhook); err == nil {
-			switch webhook.Annotations[constants.WebhookReadinessProbeStatusAnnotationKey] {
+			switch webhook.Annotations[constants.WebhookReadinessStatusAnnotationKey] {
 			case "true":
 				c.Status = metav1.ConditionTrue
 				c.Reason = v1.ConditionReason(v1.IstioRevisionConditionReady)
@@ -375,7 +375,7 @@ func (r *Reconciler) determineReadyCondition(ctx context.Context, rev *v1.IstioR
 			default:
 				c.Reason = v1.IstioRevisionReasonRemoteIstiodNotReady
 				c.Message = fmt.Sprintf("invalid or missing annotation %s on MutatingWebhookConfiguration %s",
-					constants.WebhookReadinessProbeStatusAnnotationKey, webhookKey.Name)
+					constants.WebhookReadinessStatusAnnotationKey, webhookKey.Name)
 			}
 		} else if apierrors.IsNotFound(err) {
 			c.Reason = v1.IstioRevisionReasonRemoteIstiodNotReady

--- a/controllers/istiorevision/istiorevision_controller.go
+++ b/controllers/istiorevision/istiorevision_controller.go
@@ -365,17 +365,17 @@ func (r *Reconciler) determineReadyCondition(ctx context.Context, rev *v1.IstioR
 		webhook := admissionv1.MutatingWebhookConfiguration{}
 		webhookKey := injectionWebhookKey(rev)
 		if err := r.Client.Get(ctx, webhookKey, &webhook); err == nil {
-			switch webhook.Annotations[constants.WebhookReadinessProbeStatusAnnotationKey] {
+			switch webhook.Annotations[constants.WebhookReadinessStatusAnnotationKey] {
 			case "true":
 				c.Status = metav1.ConditionTrue
 				c.Reason = v1.ConditionReason(v1.IstioRevisionConditionReady)
 			case "false":
 				c.Reason = v1.IstioRevisionReasonRemoteIstiodNotReady
-				c.Message = "readiness probe on remote istiod failed"
+				c.Message = webhookNotReadyMessage(webhook.Annotations)
 			default:
 				c.Reason = v1.IstioRevisionReasonRemoteIstiodNotReady
 				c.Message = fmt.Sprintf("invalid or missing annotation %s on MutatingWebhookConfiguration %s",
-					constants.WebhookReadinessProbeStatusAnnotationKey, webhookKey.Name)
+					constants.WebhookReadinessStatusAnnotationKey, webhookKey.Name)
 			}
 		} else if apierrors.IsNotFound(err) {
 			c.Reason = v1.IstioRevisionReasonRemoteIstiodNotReady
@@ -388,6 +388,15 @@ func (r *Reconciler) determineReadyCondition(ctx context.Context, rev *v1.IstioR
 		}
 	}
 	return c, nil
+}
+
+// webhookNotReadyMessage derives a human-readable message from the webhook configuration's
+// readiness annotations, falling back to a generic message.
+func webhookNotReadyMessage(annotations map[string]string) string {
+	if reason := annotations[constants.WebhookReadinessReasonAnnotationKey]; reason != "" {
+		return reason
+	}
+	return "remote istiod is not ready"
 }
 
 func (r *Reconciler) determineDependenciesHealthyCondition(ctx context.Context, rev *v1.IstioRevision) (v1.StatusCondition, error) {

--- a/controllers/istiorevision/istiorevision_controller_test.go
+++ b/controllers/istiorevision/istiorevision_controller_test.go
@@ -605,7 +605,7 @@ func TestDetermineReadyCondition(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "istio-sidecar-injector",
 						Annotations: map[string]string{
-							constants.WebhookReadinessProbeStatusAnnotationKey: "true",
+							constants.WebhookReadinessStatusAnnotationKey: "true",
 						},
 					},
 				},
@@ -624,7 +624,7 @@ func TestDetermineReadyCondition(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "istio-sidecar-injector",
 						Annotations: map[string]string{
-							constants.WebhookReadinessProbeStatusAnnotationKey: "false",
+							constants.WebhookReadinessStatusAnnotationKey: "false",
 						},
 					},
 				},
@@ -651,7 +651,7 @@ func TestDetermineReadyCondition(t *testing.T) {
 				Type:    v1.IstioRevisionConditionReady,
 				Status:  metav1.ConditionFalse,
 				Reason:  v1.IstioRevisionReasonRemoteIstiodNotReady,
-				Message: "invalid or missing annotation sailoperator.io/readinessProbe.status on MutatingWebhookConfiguration istio-sidecar-injector",
+				Message: "invalid or missing annotation sailoperator.io/readiness.status on MutatingWebhookConfiguration istio-sidecar-injector",
 			},
 		},
 		{

--- a/controllers/istiorevision/istiorevision_controller_test.go
+++ b/controllers/istiorevision/istiorevision_controller_test.go
@@ -605,7 +605,7 @@ func TestDetermineReadyCondition(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "istio-sidecar-injector",
 						Annotations: map[string]string{
-							constants.WebhookReadinessProbeStatusAnnotationKey: "true",
+							constants.WebhookReadinessStatusAnnotationKey: "true",
 						},
 					},
 				},
@@ -624,7 +624,7 @@ func TestDetermineReadyCondition(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "istio-sidecar-injector",
 						Annotations: map[string]string{
-							constants.WebhookReadinessProbeStatusAnnotationKey: "false",
+							constants.WebhookReadinessStatusAnnotationKey: "false",
 						},
 					},
 				},
@@ -633,7 +633,28 @@ func TestDetermineReadyCondition(t *testing.T) {
 				Type:    v1.IstioRevisionConditionReady,
 				Status:  metav1.ConditionFalse,
 				Reason:  v1.IstioRevisionReasonRemoteIstiodNotReady,
-				Message: "readiness probe on remote istiod failed",
+				Message: "remote istiod is not ready",
+			},
+		},
+		{
+			name:   "Istiod-remote not ready with reason annotation",
+			values: &v1.Values{Profile: ptr.Of("remote")},
+			clientObjects: []client.Object{
+				&admissionv1.MutatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "istio-sidecar-injector",
+						Annotations: map[string]string{
+							constants.WebhookReadinessStatusAnnotationKey: "false",
+							constants.WebhookReadinessReasonAnnotationKey: "webhooks[].clientConfig.caBundle hasn't been set; check if the remote istiod can access this cluster",
+						},
+					},
+				},
+			},
+			expected: v1.StatusCondition{
+				Type:    v1.IstioRevisionConditionReady,
+				Status:  metav1.ConditionFalse,
+				Reason:  v1.IstioRevisionReasonRemoteIstiodNotReady,
+				Message: "webhooks[].clientConfig.caBundle hasn't been set; check if the remote istiod can access this cluster",
 			},
 		},
 		{
@@ -651,7 +672,7 @@ func TestDetermineReadyCondition(t *testing.T) {
 				Type:    v1.IstioRevisionConditionReady,
 				Status:  metav1.ConditionFalse,
 				Reason:  v1.IstioRevisionReasonRemoteIstiodNotReady,
-				Message: "invalid or missing annotation sailoperator.io/readinessProbe.status on MutatingWebhookConfiguration istio-sidecar-injector",
+				Message: "invalid or missing annotation sailoperator.io/readiness.status on MutatingWebhookConfiguration istio-sidecar-injector",
 			},
 		},
 		{

--- a/controllers/webhook/webhook_controller.go
+++ b/controllers/webhook/webhook_controller.go
@@ -16,13 +16,9 @@ package webhook
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"errors"
-	"fmt"
-	"net"
-	"net/http"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -33,7 +29,9 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/reconciler"
 	"github.com/istio-ecosystem/sail-operator/pkg/revision"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,135 +43,147 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	defaultPeriodSeconds  = 3 // matches the period in the istiod chart
-	defaultTimeoutSeconds = 5 // matches the timeout in the istiod chart
-)
+const minFailureGap = 30 * time.Second
 
-// overrides the default dial context; only used in unit tests
-var customDialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+const webhookFailurePrefix = `failed calling webhook "`
 
-// Reconciler checks the readiness of MutatingWebhookConfiguration pointing to a remote Istio control plane
+type failureEntry struct {
+	prev, last time.Time
+}
+
+// Reconciler determines the readiness of webhook configurations pointing to a remote Istio control plane
+// by observing the webhook configuration's fields and webhook call failure events.
 type Reconciler struct {
 	Config config.ReconcilerConfig
 	client.Client
 	Scheme *runtime.Scheme
-	probe  func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error)
+
+	mu             sync.Mutex
+	failureHistory map[string]failureEntry
 }
 
 func NewReconciler(cfg config.ReconcilerConfig, client client.Client, scheme *runtime.Scheme) *Reconciler {
 	return &Reconciler{
-		Config: cfg,
-		Client: client,
-		Scheme: scheme,
-		probe:  doProbe,
+		Config:         cfg,
+		Client:         client,
+		Scheme:         scheme,
+		failureHistory: make(map[string]failureEntry),
 	}
 }
 
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
-func (r *Reconciler) Reconcile(ctx context.Context, webhook *admissionv1.MutatingWebhookConfiguration) (ctrl.Result, error) {
+func (r *Reconciler) ReconcileMutating(ctx context.Context, webhook *admissionv1.MutatingWebhookConfiguration) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	isReady, err := r.probe(ctx, webhook)
-	reason := ""
-	if err != nil {
-		log.V(3).Error(err, "Probe failed")
-		reason = err.Error()
+	isReady, reason, requeue := r.evaluateReadiness(webhook.Name, len(webhook.Webhooks), webhook.Webhooks[0].ClientConfig)
+	if !isReady {
+		log.V(3).Info("Webhook not ready", "reason", reason)
 	}
 
 	if webhook.Annotations == nil {
 		webhook.Annotations = make(map[string]string)
 	}
-	webhook.Annotations[constants.WebhookReadinessProbeStatusAnnotationKey] = strconv.FormatBool(isReady)
-	webhook.Annotations[constants.WebhookReadinessProbeStatusReasonAnnotationKey] = reason
+	webhook.Annotations[constants.WebhookReadinessStatusAnnotationKey] = strconv.FormatBool(isReady)
+	webhook.Annotations[constants.WebhookReadinessReasonAnnotationKey] = reason
 
-	err = r.Client.Update(ctx, webhook)
+	err := r.Client.Update(ctx, webhook)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{RequeueAfter: getPeriod(webhook)}, nil
+	return ctrl.Result{RequeueAfter: requeue}, nil
 }
 
-func doProbe(ctx context.Context, webhook *admissionv1.MutatingWebhookConfiguration) (bool, error) {
+func (r *Reconciler) ReconcileValidating(ctx context.Context, webhook *admissionv1.ValidatingWebhookConfiguration) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
-	if len(webhook.Webhooks) == 0 {
-		return false, errors.New("mutatingwebhookconfiguration contains no webhooks")
-	}
-	clientConfig := webhook.Webhooks[0].ClientConfig
-	if clientConfig.Service == nil {
-		return false, errors.New("missing webhooks[].clientConfig.service")
+
+	isReady, reason, requeue := r.evaluateReadiness(webhook.Name, len(webhook.Webhooks), webhook.Webhooks[0].ClientConfig)
+	if !isReady {
+		log.V(3).Info("Webhook not ready", "reason", reason)
 	}
 
-	if len(clientConfig.CABundle) == 0 {
-		return false, errors.New("webhooks[].clientConfig.caBundle hasn't been set; check if the remote istiod can access this cluster")
+	if webhook.Annotations == nil {
+		webhook.Annotations = make(map[string]string)
 	}
-	caCertPool := x509.NewCertPool()
-	if ok := caCertPool.AppendCertsFromPEM(clientConfig.CABundle); !ok {
-		return false, errors.New("failed to append CA bundle to cert pool")
-	}
+	webhook.Annotations[constants.WebhookReadinessStatusAnnotationKey] = strconv.FormatBool(isReady)
+	webhook.Annotations[constants.WebhookReadinessReasonAnnotationKey] = reason
 
-	httpClient := http.Client{
-		Timeout: getTimeout(webhook),
-		Transport: &http.Transport{
-			DialContext: customDialContext,
-			TLSClientConfig: &tls.Config{
-				RootCAs:    caCertPool,
-				MinVersion: tls.VersionTLS12,
-			},
-		},
-	}
-
-	url, err := getReadinessProbeURL(clientConfig)
+	err := r.Client.Update(ctx, webhook)
 	if err != nil {
-		return false, err
+		return ctrl.Result{}, err
 	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return false, err
-	}
-
-	log.V(3).Info("Executing readiness probe on remote control plane", "url", req.URL.String())
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		log.V(3).Info("Probe failed", "error", err)
-		return false, err
-	}
-	log.V(3).Info("Probe response", "response", resp.StatusCode)
-
-	return resp.StatusCode == http.StatusOK, nil
+	return ctrl.Result{RequeueAfter: requeue}, nil
 }
 
-func getReadinessProbeURL(config admissionv1.WebhookClientConfig) (string, error) {
-	switch {
-	case config.URL != nil:
-		return "", errors.New("only webhooks pointing to a Service are supported")
+// evaluateReadiness checks readiness (config fields) and health (recent failure events).
+// When degraded, it returns a requeue duration so the controller re-evaluates after the
+// degraded window expires. When not degraded, requeue is zero (watches drive reconciliation).
+func (r *Reconciler) evaluateReadiness(name string, webhookCount int, cc admissionv1.WebhookClientConfig) (bool, string, time.Duration) {
+	if webhookCount == 0 {
+		return false, "webhook configuration contains no webhooks", 0
+	}
+	if cc.Service == nil && cc.URL == nil {
+		return false, "no endpoint configured in webhooks[].clientConfig", 0
+	}
+	if len(cc.CABundle) == 0 {
+		return false, "webhooks[].clientConfig.caBundle hasn't been set; check if the remote istiod can access this cluster", 0
+	}
+	if requeue := r.isDegraded(name); requeue > 0 {
+		return false, "apiserver reported webhook call failures", requeue
+	}
+	return true, "", 0
+}
 
-	case config.Service != nil:
-		svc := config.Service
-		port := 443
-		if svc.Port != nil {
-			port = int(*svc.Port)
+// isDegraded returns how long the webhook should remain in a degraded state.
+// It uses the gap between the two most recent failures to estimate the controller's
+// backoff interval, and clears the degraded state after 2x that gap with no new failures.
+// Returns 0 if not degraded; otherwise the time remaining until the degraded window expires.
+func (r *Reconciler) isDegraded(name string) time.Duration {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.failureHistory[name]
+	if !ok {
+		return 0
+	}
+	gap := minFailureGap
+	if !entry.prev.IsZero() {
+		if g := entry.last.Sub(entry.prev); g > gap {
+			gap = g
 		}
-		return fmt.Sprintf("https://%s.%s.svc:%d/ready", svc.Name, svc.Namespace, port), nil
-
-	default:
-		return "", errors.New("no URL or Service specified in WebhookClientConfig")
 	}
+	remaining := 2*gap - time.Since(entry.last)
+	if remaining <= 0 {
+		delete(r.failureHistory, name)
+		return 0
+	}
+	return remaining
 }
 
-// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) recordFailure(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry := r.failureHistory[name]
+	entry.prev = entry.last
+	entry.last = time.Now()
+	r.failureHistory[name] = entry
+}
+
+// SetupWithManager sets up both the mutating and validating webhook controllers with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := r.setupMutatingController(mgr); err != nil {
+		return err
+	}
+	return r.setupValidatingController(mgr)
+}
+
+func (r *Reconciler) setupMutatingController(mgr ctrl.Manager) error {
 	logger := mgr.GetLogger().WithName("ctrlr").WithName("webhook")
 
-	// objectHandler handles the MutatingWebhookConfiguration watch events
-	objectHandler := wrapEventHandler(logger, &handler.EnqueueRequestForObject{})
+	objectHandler := wrapEventHandler("MutatingWebhookConfiguration", logger, &handler.EnqueueRequestForObject{})
+	failureEventHandler := wrapEventHandler("MutatingWebhookConfiguration", logger,
+		handler.EnqueueRequestsFromMapFunc(r.mapFailureEventToMutatingWebhook))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
@@ -190,8 +200,134 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged
 		// +lint-watches:ignore: IstioRevision (not found in charts, but this is the main resource watched by this controller)
 		Watches(&admissionv1.MutatingWebhookConfiguration{}, objectHandler, builder.WithPredicates(ownedByRemoteIstioRevisionPredicate(mgr.GetClient()))).
+
+		// +lint-watches:ignore: Event (not found in charts, watched for webhook failure detection)
+		Watches(&corev1.Event{}, failureEventHandler, builder.WithPredicates(webhookFailureEventPredicate())).
 		Named("mutatingwebhookconfiguration").
-		Complete(reconciler.NewStandardReconciler[*admissionv1.MutatingWebhookConfiguration](r.Client, r.Reconcile))
+		Complete(reconciler.NewStandardReconciler[*admissionv1.MutatingWebhookConfiguration](r.Client, r.ReconcileMutating))
+}
+
+func (r *Reconciler) setupValidatingController(mgr ctrl.Manager) error {
+	logger := mgr.GetLogger().WithName("ctrlr").WithName("webhook-validating")
+
+	objectHandler := wrapEventHandler("ValidatingWebhookConfiguration", logger, &handler.EnqueueRequestForObject{})
+	failureEventHandler := wrapEventHandler("ValidatingWebhookConfiguration", logger,
+		handler.EnqueueRequestsFromMapFunc(r.mapFailureEventToValidatingWebhook))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{
+			LogConstructor: func(req *reconcile.Request) logr.Logger {
+				log := logger
+				if req != nil {
+					log = log.WithValues("ValidatingWebhookConfiguration", req.Name)
+				}
+				return log
+			},
+			MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles,
+		}).
+
+		// +lint-watches:ignore: IstioRevision (not found in charts, but this is the main resource watched by this controller)
+		Watches(&admissionv1.ValidatingWebhookConfiguration{}, objectHandler, builder.WithPredicates(ownedByRemoteIstioRevisionPredicate(mgr.GetClient()))).
+
+		// +lint-watches:ignore: Event (not found in charts, watched for webhook failure detection)
+		Watches(&corev1.Event{}, failureEventHandler, builder.WithPredicates(webhookFailureEventPredicate())).
+		Named("validatingwebhookconfiguration").
+		Complete(reconciler.NewStandardReconciler[*admissionv1.ValidatingWebhookConfiguration](r.Client, r.ReconcileValidating))
+}
+
+type webhookConfigRef struct {
+	name       string
+	isMutating bool
+}
+
+// mapFailureEventToMutatingWebhook extracts the webhook name from a failure event,
+// resolves it to a MutatingWebhookConfiguration name, records the failure,
+// and enqueues the webhook for reconciliation.
+func (r *Reconciler) mapFailureEventToMutatingWebhook(ctx context.Context, obj client.Object) []reconcile.Request {
+	return r.mapFailureEvent(ctx, obj, true)
+}
+
+// mapFailureEventToValidatingWebhook extracts the webhook name from a failure event,
+// resolves it to a ValidatingWebhookConfiguration name, records the failure,
+// and enqueues the webhook for reconciliation.
+func (r *Reconciler) mapFailureEventToValidatingWebhook(ctx context.Context, obj client.Object) []reconcile.Request {
+	return r.mapFailureEvent(ctx, obj, false)
+}
+
+func (r *Reconciler) mapFailureEvent(ctx context.Context, obj client.Object, wantMutating bool) []reconcile.Request {
+	evt, ok := obj.(*corev1.Event)
+	if !ok {
+		return nil
+	}
+	webhookName := ExtractWebhookName(evt.Message)
+	if webhookName == "" {
+		return nil
+	}
+
+	ref := r.findWebhookConfig(ctx, webhookName)
+	if ref == nil || ref.isMutating != wantMutating {
+		return nil
+	}
+
+	r.recordFailure(ref.name)
+
+	logf.FromContext(ctx).V(3).Info("Detected webhook call failure", "webhook", webhookName, "config", ref.name)
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: ref.name}}}
+}
+
+// findWebhookConfig resolves an individual webhook name (e.g. "sidecar-injector.istio.io")
+// to the webhook configuration that contains it. Searches both Mutating and Validating configurations.
+// Returns nil if not found.
+func (r *Reconciler) findWebhookConfig(ctx context.Context, webhookName string) *webhookConfigRef {
+	var mutatingConfigs admissionv1.MutatingWebhookConfigurationList
+	if err := r.Client.List(ctx, &mutatingConfigs); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to list MutatingWebhookConfigurations")
+	} else {
+		for i := range mutatingConfigs.Items {
+			for j := range mutatingConfigs.Items[i].Webhooks {
+				if mutatingConfigs.Items[i].Webhooks[j].Name == webhookName {
+					return &webhookConfigRef{name: mutatingConfigs.Items[i].Name, isMutating: true}
+				}
+			}
+		}
+	}
+
+	var validatingConfigs admissionv1.ValidatingWebhookConfigurationList
+	if err := r.Client.List(ctx, &validatingConfigs); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to list ValidatingWebhookConfigurations")
+	} else {
+		for i := range validatingConfigs.Items {
+			for j := range validatingConfigs.Items[i].Webhooks {
+				if validatingConfigs.Items[i].Webhooks[j].Name == webhookName {
+					return &webhookConfigRef{name: validatingConfigs.Items[i].Name, isMutating: false}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func ExtractWebhookName(message string) string {
+	_, after, found := strings.Cut(message, webhookFailurePrefix)
+	if !found {
+		return ""
+	}
+	name, _, found := strings.Cut(after, `"`)
+	if !found {
+		return ""
+	}
+	return name
+}
+
+func webhookFailureEventPredicate() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		evt, ok := obj.(*corev1.Event)
+		if !ok {
+			return false
+		}
+		return evt.Type == corev1.EventTypeWarning && strings.Contains(evt.Message, webhookFailurePrefix)
+	})
 }
 
 func ownedByRemoteIstioRevisionPredicate(cl client.Client) predicate.Predicate {
@@ -227,24 +363,6 @@ func IsOwnedByRevisionWithRemoteControlPlane(cl client.Client, obj client.Object
 	return false
 }
 
-func getPeriod(webhook *admissionv1.MutatingWebhookConfiguration) time.Duration {
-	if period, ok := webhook.Annotations[constants.WebhookReadinessProbePeriodSecondsAnnotationKey]; ok {
-		if p, err := strconv.Atoi(period); err == nil {
-			return time.Duration(p) * time.Second
-		}
-	}
-	return defaultPeriodSeconds * time.Second
-}
-
-func getTimeout(webhook *admissionv1.MutatingWebhookConfiguration) time.Duration {
-	if period, ok := webhook.Annotations[constants.WebhookReadinessProbeTimeoutSecondsAnnotationKey]; ok {
-		if p, err := strconv.Atoi(period); err == nil {
-			return time.Duration(p) * time.Second
-		}
-	}
-	return defaultTimeoutSeconds * time.Second
-}
-
-func wrapEventHandler(logger logr.Logger, handler handler.EventHandler) handler.EventHandler {
-	return enqueuelogger.WrapIfNecessary("MutatingWebhookConfiguration", logger, handler)
+func wrapEventHandler(resourceName string, logger logr.Logger, handler handler.EventHandler) handler.EventHandler {
+	return enqueuelogger.WrapIfNecessary(resourceName, logger, handler)
 }

--- a/controllers/webhook/webhook_controller.go
+++ b/controllers/webhook/webhook_controller.go
@@ -16,14 +16,9 @@ package webhook
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"errors"
-	"fmt"
-	"io"
-	"net"
-	"net/http"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -34,7 +29,10 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/reconciler"
 	"github.com/istio-ecosystem/sail-operator/pkg/revision"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,139 +40,236 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	defaultPeriodSeconds  = 3 // matches the period in the istiod chart
-	defaultTimeoutSeconds = 5 // matches the timeout in the istiod chart
-)
+// DefaultDegradedWindow is how long a webhook stays not-ready after a call failure, so an
+// intermittently failing control plane doesn't flap back to ready between events. It applies
+// unless overridden per-webhook via the WebhookDegradedWindowAnnotationKey annotation.
+const DefaultDegradedWindow = 2 * time.Minute
 
-// overrides the default dial context; only used in unit tests
-var customDialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+const failureHistoryCleanupInterval = 30 * time.Second
 
-// Reconciler checks the readiness of MutatingWebhookConfiguration pointing to a remote Istio control plane
+const webhookFailurePrefix = `failed calling webhook "`
+
+// legacyReadinessAnnotationKeys are annotation keys older operator versions used to report
+// readiness-probe results; they are removed when a webhook configuration is reconciled.
+var legacyReadinessAnnotationKeys = []string{
+	"sailoperator.io/readinessProbe.status",
+	"sailoperator.io/readinessProbe.reason",
+	"sailoperator.io/readinessProbe.periodSeconds",
+	"sailoperator.io/readinessProbe.timeoutSeconds",
+}
+
+// failureHistory records, per webhook name, the time of its most recently observed call
+// failure. It is safe for concurrent use.
+type failureHistory struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+}
+
+func newFailureHistory() failureHistory {
+	return failureHistory{entries: make(map[string]time.Time)}
+}
+
+// Add records name as having failed at the given time.
+func (h *failureHistory) Add(name string, at time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.entries[name] = at
+}
+
+// Get returns the last recorded failure time for name, and whether one exists.
+func (h *failureHistory) Get(name string) (time.Time, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	last, ok := h.entries[name]
+	return last, ok
+}
+
+// Remove deletes name from the history, if present.
+func (h *failureHistory) Remove(name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.entries, name)
+}
+
+// RemoveOlderThan deletes entries whose recorded failure is at least window in the past,
+// returning the number removed.
+func (h *failureHistory) RemoveOlderThan(window time.Duration) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	now := time.Now()
+	pruned := 0
+	for name, last := range h.entries {
+		if now.Sub(last) >= window {
+			delete(h.entries, name)
+			pruned++
+		}
+	}
+	return pruned
+}
+
+// Len returns the number of tracked entries.
+func (h *failureHistory) Len() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.entries)
+}
+
+// Reconciler determines the readiness of a MutatingWebhookConfiguration pointing to a remote
+// Istio control plane from the configuration's fields and webhook call failure events.
+//
+// Failure detection is passive: Kubernetes controllers record a Warning event only when an API
+// call fails because a webhook was unreachable. A webhook that receives no API traffic cannot
+// be detected, so the status reports "no known failures" rather than an active health check.
 type Reconciler struct {
 	Config config.ReconcilerConfig
 	client.Client
 	Scheme *runtime.Scheme
-	probe  func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error)
+
+	failureHistory failureHistory
 }
 
 func NewReconciler(cfg config.ReconcilerConfig, client client.Client, scheme *runtime.Scheme) *Reconciler {
 	return &Reconciler{
-		Config: cfg,
-		Client: client,
-		Scheme: scheme,
-		probe:  doProbe,
+		Config:         cfg,
+		Client:         client,
+		Scheme:         scheme,
+		failureHistory: newFailureHistory(),
 	}
 }
 
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
+// Reconcile records a MutatingWebhookConfiguration's readiness in its annotations, updating it
+// only when the readiness (or legacy) annotations changed.
 func (r *Reconciler) Reconcile(ctx context.Context, webhook *admissionv1.MutatingWebhookConfiguration) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	isReady, err := r.probe(ctx, webhook)
-	reason := ""
-	if err != nil {
-		log.V(3).Error(err, "Probe failed")
-		reason = err.Error()
+	result := r.evaluateReadiness(webhook.GetName(), webhook.Webhooks, degradedWindow(log, webhook))
+	if !result.ready {
+		log.V(3).Info("Webhook not ready", "reason", result.reason)
 	}
 
-	if webhook.Annotations == nil {
-		webhook.Annotations = make(map[string]string)
-	}
-	webhook.Annotations[constants.WebhookReadinessProbeStatusAnnotationKey] = strconv.FormatBool(isReady)
-	webhook.Annotations[constants.WebhookReadinessProbeStatusReasonAnnotationKey] = reason
-
-	err = r.Client.Update(ctx, webhook)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	return ctrl.Result{RequeueAfter: getPeriod(webhook)}, nil
-}
-
-func doProbe(ctx context.Context, webhook *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-	log := logf.FromContext(ctx)
-	if len(webhook.Webhooks) == 0 {
-		return false, errors.New("mutatingwebhookconfiguration contains no webhooks")
-	}
-	clientConfig := webhook.Webhooks[0].ClientConfig
-	if clientConfig.Service == nil {
-		return false, errors.New("missing webhooks[].clientConfig.service")
-	}
-
-	if len(clientConfig.CABundle) == 0 {
-		return false, errors.New("webhooks[].clientConfig.caBundle hasn't been set; check if the remote istiod can access this cluster")
-	}
-	caCertPool := x509.NewCertPool()
-	if ok := caCertPool.AppendCertsFromPEM(clientConfig.CABundle); !ok {
-		return false, errors.New("failed to append CA bundle to cert pool")
-	}
-
-	httpClient := http.Client{
-		Timeout: getTimeout(webhook),
-		Transport: &http.Transport{
-			DialContext: customDialContext,
-			TLSClientConfig: &tls.Config{
-				RootCAs:    caCertPool,
-				MinVersion: tls.VersionTLS12,
-			},
-		},
-	}
-
-	url, err := getReadinessProbeURL(clientConfig)
-	if err != nil {
-		return false, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return false, err
-	}
-
-	log.V(3).Info("Executing readiness probe on remote control plane", "url", req.URL.String())
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		log.V(3).Info("Probe failed", "error", err)
-		return false, err
-	}
-	defer func() {
-		// drain and close the body to release the underlying connection. Since httpClient (and its Transport) isn't
-		// reused across probes, close the idle connections so they don't linger indefinitely.
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-		httpClient.CloseIdleConnections()
-	}()
-	log.V(3).Info("Probe response", "response", resp.StatusCode)
-
-	return resp.StatusCode == http.StatusOK, nil
-}
-
-func getReadinessProbeURL(config admissionv1.WebhookClientConfig) (string, error) {
-	switch {
-	case config.URL != nil:
-		return "", errors.New("only webhooks pointing to a Service are supported")
-
-	case config.Service != nil:
-		svc := config.Service
-		port := 443
-		if svc.Port != nil {
-			port = int(*svc.Port)
+	status := strconv.FormatBool(result.ready)
+	annotations := webhook.GetAnnotations()
+	changed := annotations[constants.WebhookReadinessStatusAnnotationKey] != status ||
+		annotations[constants.WebhookReadinessReasonAnnotationKey] != result.reason
+	if !changed {
+		for _, key := range legacyReadinessAnnotationKeys {
+			if _, ok := annotations[key]; ok {
+				changed = true
+				break
+			}
 		}
-		return fmt.Sprintf("https://%s.%s.svc:%d/ready", svc.Name, svc.Namespace, port), nil
-
-	default:
-		return "", errors.New("no URL or Service specified in WebhookClientConfig")
 	}
+	if changed {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[constants.WebhookReadinessStatusAnnotationKey] = status
+		annotations[constants.WebhookReadinessReasonAnnotationKey] = result.reason
+		for _, key := range legacyReadinessAnnotationKeys {
+			delete(annotations, key)
+		}
+		webhook.SetAnnotations(annotations)
+		if err := r.Client.Update(ctx, webhook); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{RequeueAfter: result.requeue}, nil
 }
+
+// readinessResult is the outcome of evaluateReadiness. reason is only set when ready is false;
+// requeue is only set for a degraded webhook, so the controller re-evaluates once the degraded
+// window expires (watches drive reconciliation otherwise).
+type readinessResult struct {
+	ready   bool
+	reason  string
+	requeue time.Duration
+}
+
+func (r *Reconciler) evaluateReadiness(name string, webhooks []admissionv1.MutatingWebhook, degradedWindow time.Duration) readinessResult {
+	if len(webhooks) == 0 {
+		return readinessResult{reason: "webhook configuration contains no webhooks"}
+	}
+	cc := webhooks[0].ClientConfig
+	if cc.Service == nil && cc.URL == nil {
+		return readinessResult{reason: "no endpoint configured in webhooks[].clientConfig"}
+	}
+	if len(cc.CABundle) == 0 {
+		return readinessResult{reason: "webhooks[].clientConfig.caBundle hasn't been set; check if the remote istiod can access this cluster"}
+	}
+	if requeue := r.isDegraded(name, degradedWindow); requeue > 0 {
+		return readinessResult{reason: "webhook call failures reported in cluster events", requeue: requeue}
+	}
+	return readinessResult{ready: true}
+}
+
+// degradedWindow returns the WebhookDegradedWindowAnnotationKey override on webhook, if present
+// and valid, or DefaultDegradedWindow otherwise.
+func degradedWindow(log logr.Logger, webhook *admissionv1.MutatingWebhookConfiguration) time.Duration {
+	value, ok := webhook.GetAnnotations()[constants.WebhookDegradedWindowAnnotationKey]
+	if !ok {
+		return DefaultDegradedWindow
+	}
+	window, err := time.ParseDuration(value)
+	if err != nil {
+		log.Error(err, "invalid "+constants.WebhookDegradedWindowAnnotationKey+" annotation value; using the default",
+			"value", value, "default", DefaultDegradedWindow)
+		return DefaultDegradedWindow
+	}
+	return window
+}
+
+// isDegraded returns the time remaining in the degraded window after a webhook's most recent
+// recorded failure, or 0 if not degraded. It removes the entry once the window has expired.
+func (r *Reconciler) isDegraded(name string, window time.Duration) time.Duration {
+	last, ok := r.failureHistory.Get(name)
+	if !ok {
+		return 0
+	}
+	remaining := window - time.Since(last)
+	if remaining <= 0 {
+		r.failureHistory.Remove(name)
+		return 0
+	}
+	return remaining
+}
+
+func (r *Reconciler) recordFailure(name string) {
+	r.failureHistory.Add(name, time.Now())
+}
+
+// pruneStaleFailures drops failureHistory entries whose degraded window has expired,
+// returning the count. It sweeps the whole map, so it also reclaims entries for deleted
+// configs that isDegraded can never reach.
+func (r *Reconciler) pruneStaleFailures() int {
+	return r.failureHistory.RemoveOlderThan(DefaultDegradedWindow)
+}
+
+func (r *Reconciler) failureHistoryJanitor(log logr.Logger, interval time.Duration) manager.Runnable {
+	return manager.RunnableFunc(func(ctx context.Context) error {
+		wait.Until(func() {
+			if n := r.pruneStaleFailures(); n > 0 {
+				log.V(3).Info("Pruned stale webhook failure history entries", "count", n)
+			}
+		}, interval, ctx.Done())
+		return nil
+	})
+}
+
+// leaderElectionRunnable gates a Runnable to the leader (runs immediately when leader
+// election is disabled).
+type leaderElectionRunnable struct {
+	manager.Runnable
+}
+
+func (leaderElectionRunnable) NeedLeaderElection() bool { return true }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -182,8 +277,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// objectHandler handles the MutatingWebhookConfiguration watch events
 	objectHandler := wrapEventHandler(logger, &handler.EnqueueRequestForObject{})
+	failureEventHandler := wrapEventHandler(logger, handler.EnqueueRequestsFromMapFunc(r.mapFailureEventToWebhook))
 
-	return ctrl.NewControllerManagedBy(mgr).
+	err := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
 			LogConstructor: func(req *reconcile.Request) logr.Logger {
 				log := logger
@@ -196,10 +292,94 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}).
 
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged
-		// +lint-watches:ignore: IstioRevision (not found in charts, but this is the main resource watched by this controller)
 		Watches(&admissionv1.MutatingWebhookConfiguration{}, objectHandler, builder.WithPredicates(ownedByRemoteIstioRevisionPredicate(mgr.GetClient()))).
+		Watches(&corev1.Event{}, failureEventHandler, builder.WithPredicates(webhookFailureEventPredicate())).
 		Named("mutatingwebhookconfiguration").
 		Complete(reconciler.NewStandardReconciler[*admissionv1.MutatingWebhookConfiguration](r.Client, r.Reconcile))
+	if err != nil {
+		return err
+	}
+
+	// Gate the janitor to the leader: only the leader populates failureHistory.
+	return mgr.Add(leaderElectionRunnable{Runnable: r.failureHistoryJanitor(logger, failureHistoryCleanupInterval)})
+}
+
+// mapFailureEventToWebhook resolves a webhook failure event to its owning
+// MutatingWebhookConfiguration, records the failure, and enqueues it for reconciliation.
+func (r *Reconciler) mapFailureEventToWebhook(ctx context.Context, obj client.Object) []reconcile.Request {
+	evt, ok := obj.(*corev1.Event)
+	if !ok {
+		return nil
+	}
+	webhookName := ExtractWebhookName(evt.Message)
+	if webhookName == "" {
+		return nil
+	}
+
+	configName := r.findOwnedWebhookConfig(ctx, webhookName)
+	if configName == "" {
+		return nil
+	}
+
+	r.recordFailure(configName)
+
+	logf.FromContext(ctx).V(3).Info("Detected webhook call failure", "webhook", webhookName, "config", configName)
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: configName}}}
+}
+
+// findOwnedWebhookConfig resolves a webhook name to the MutatingWebhookConfiguration that
+// contains it and is owned by a remote-control-plane IstioRevision, or "" if none exists.
+func (r *Reconciler) findOwnedWebhookConfig(ctx context.Context, webhookName string) string {
+	log := logf.FromContext(ctx)
+	var configs admissionv1.MutatingWebhookConfigurationList
+	if err := r.Client.List(ctx, &configs); err != nil {
+		log.Error(err, "failed to list MutatingWebhookConfigurations")
+		return ""
+	}
+	for i := range configs.Items {
+		for _, webhook := range configs.Items[i].Webhooks {
+			if webhook.Name == webhookName && IsOwnedByRevisionWithRemoteControlPlane(r.Client, &configs.Items[i]) {
+				return configs.Items[i].Name
+			}
+		}
+	}
+	return ""
+}
+
+func ExtractWebhookName(message string) string {
+	_, after, found := strings.Cut(message, webhookFailurePrefix)
+	if !found {
+		return ""
+	}
+	name, _, found := strings.Cut(after, `"`)
+	if !found {
+		return ""
+	}
+	return name
+}
+
+// webhookFailureEventPredicate matches Warning events that report a webhook call failure.
+// Delete and generic events are ignored: an expiring or deleted event is not a new failure, and
+// re-recording it would spuriously mark the webhook as degraded.
+func webhookFailureEventPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isWebhookFailureEvent(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isWebhookFailureEvent(e.ObjectNew)
+		},
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}
+
+func isWebhookFailureEvent(obj client.Object) bool {
+	evt, ok := obj.(*corev1.Event)
+	if !ok {
+		return false
+	}
+	return evt.Type == corev1.EventTypeWarning && strings.Contains(evt.Message, webhookFailurePrefix)
 }
 
 func ownedByRemoteIstioRevisionPredicate(cl client.Client) predicate.Predicate {
@@ -233,24 +413,6 @@ func IsOwnedByRevisionWithRemoteControlPlane(cl client.Client, obj client.Object
 		}
 	}
 	return false
-}
-
-func getPeriod(webhook *admissionv1.MutatingWebhookConfiguration) time.Duration {
-	if period, ok := webhook.Annotations[constants.WebhookReadinessProbePeriodSecondsAnnotationKey]; ok {
-		if p, err := strconv.Atoi(period); err == nil {
-			return time.Duration(p) * time.Second
-		}
-	}
-	return defaultPeriodSeconds * time.Second
-}
-
-func getTimeout(webhook *admissionv1.MutatingWebhookConfiguration) time.Duration {
-	if period, ok := webhook.Annotations[constants.WebhookReadinessProbeTimeoutSecondsAnnotationKey]; ok {
-		if p, err := strconv.Atoi(period); err == nil {
-			return time.Duration(p) * time.Second
-		}
-	}
-	return defaultTimeoutSeconds * time.Second
 }
 
 func wrapEventHandler(logger logr.Logger, handler handler.EventHandler) handler.EventHandler {

--- a/controllers/webhook/webhook_controller_test.go
+++ b/controllers/webhook/webhook_controller_test.go
@@ -16,19 +16,7 @@ package webhook
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
-	"fmt"
-	"math/big"
-	"net"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -40,344 +28,564 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/scheme"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"istio.io/istio/pkg/ptr"
 )
 
 var ctx = context.Background()
 
-func TestReconcile(t *testing.T) {
+func TestReconcileMutating(t *testing.T) {
 	tests := []struct {
-		name         string
-		setup        func(configuration *admissionv1.MutatingWebhookConfiguration)
-		probeFunc    func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error)
-		interceptors interceptor.Funcs
-		expectResult ctrl.Result
-		expectErr    error
-		expectValue  string
+		name          string
+		webhook       *admissionv1.MutatingWebhookConfiguration
+		setup         func(r *Reconciler)
+		interceptors  interceptor.Funcs
+		expectRequeue bool
+		expectErr     error
+		expectStatus  string
+		expectReason  string
 	}{
 		{
-			name: "ready",
-			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-				return true, nil
+			name: "ready when caBundle is set",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+						CABundle: []byte("ca-data"),
+					},
+				}},
 			},
-			expectResult: ctrl.Result{RequeueAfter: defaultPeriodSeconds * time.Second},
-			expectValue:  "true",
+			expectStatus: "true",
 		},
 		{
-			name: "not ready",
-			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-				return false, nil
+			name: "not ready when caBundle is empty",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service: &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+					},
+				}},
 			},
-			expectResult: ctrl.Result{RequeueAfter: defaultPeriodSeconds * time.Second},
-			expectValue:  "false",
-		},
-		{
-			name: "probe error",
-			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-				return false, fmt.Errorf("some error")
-			},
-			expectResult: ctrl.Result{RequeueAfter: defaultPeriodSeconds * time.Second},
-			expectValue:  "false",
+			expectStatus: "false",
 		},
 		{
 			name: "update error",
-			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-				return true, nil
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+						CABundle: []byte("ca-data"),
+					},
+				}},
 			},
 			interceptors: interceptor.Funcs{
 				Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
 					return errors.New("some error")
 				},
 			},
-			expectResult: ctrl.Result{},
 			expectErr:    errors.New("some error"),
-			expectValue:  "",
+			expectStatus: "",
 		},
 		{
-			name: "honors period annotation",
-			setup: func(webhook *admissionv1.MutatingWebhookConfiguration) {
-				webhook.Annotations = map[string]string{
-					constants.WebhookReadinessProbePeriodSecondsAnnotationKey: "123",
+			name: "not ready when recent failure event recorded",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+						CABundle: []byte("ca-data"),
+					},
+				}},
+			},
+			setup: func(r *Reconciler) {
+				r.recordFailure("istio-sidecar-injector")
+				r.recordFailure("istio-sidecar-injector")
+			},
+			expectRequeue: true,
+			expectStatus:  "false",
+			expectReason:  "apiserver reported webhook call failures",
+		},
+		{
+			name: "recovers after failure ages out",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+						CABundle: []byte("ca-data"),
+					},
+				}},
+			},
+			setup: func(r *Reconciler) {
+				r.mu.Lock()
+				r.failureHistory["istio-sidecar-injector"] = failureEntry{
+					prev: time.Now().Add(-12 * time.Minute),
+					last: time.Now().Add(-10 * time.Minute),
 				}
+				r.mu.Unlock()
 			},
-			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-				return true, nil
-			},
-			expectResult: ctrl.Result{RequeueAfter: 123 * time.Second},
-			expectValue:  "true",
+			expectStatus: "true",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			webhook := &admissionv1.MutatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "istio-sidecar-injector",
-				},
-			}
-			if tt.setup != nil {
-				tt.setup(webhook)
-			}
-
 			cl := newFakeClientBuilder().
-				WithObjects(webhook).
+				WithObjects(tt.webhook).
 				WithInterceptorFuncs(tt.interceptors).
 				Build()
 			r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
-			r.probe = tt.probeFunc
+			if tt.setup != nil {
+				tt.setup(r)
+			}
 
-			result, err := r.Reconcile(ctx, webhook)
+			result, err := r.ReconcileMutating(ctx, tt.webhook)
 
-			g.Expect(result).To(Equal(tt.expectResult))
+			if tt.expectRequeue {
+				g.Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+			} else {
+				g.Expect(result.RequeueAfter).To(BeZero())
+			}
 			if tt.expectErr != nil {
 				g.Expect(err).To(Equal(tt.expectErr))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}
 
-			g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
-			g.Expect(webhook.Annotations[constants.WebhookReadinessProbeStatusAnnotationKey]).To(Equal(tt.expectValue), "Unexpected annotation value")
+			if tt.expectStatus != "" {
+				g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), tt.webhook)).To(Succeed())
+				g.Expect(tt.webhook.Annotations[constants.WebhookReadinessStatusAnnotationKey]).To(Equal(tt.expectStatus))
+			}
+			if tt.expectReason != "" {
+				g.Expect(tt.webhook.Annotations[constants.WebhookReadinessReasonAnnotationKey]).To(Equal(tt.expectReason))
+			}
 		})
 	}
 }
 
-func TestDoProbe(t *testing.T) {
+func TestReconcileValidating(t *testing.T) {
+	g := NewWithT(t)
+
+	webhook := &admissionv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "istio-validator"},
+		Webhooks: []admissionv1.ValidatingWebhook{{
+			ClientConfig: admissionv1.WebhookClientConfig{
+				Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+				CABundle: []byte("ca-data"),
+			},
+		}},
+	}
+
+	cl := newFakeClientBuilder().WithObjects(webhook).Build()
+	r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
+
+	result, err := r.ReconcileValidating(ctx, webhook)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(BeZero())
+
+	g.Expect(cl.Get(ctx, kube.Key("istio-validator"), webhook)).To(Succeed())
+	g.Expect(webhook.Annotations[constants.WebhookReadinessStatusAnnotationKey]).To(Equal("true"))
+}
+
+func TestEvaluateReadiness(t *testing.T) {
 	svc := admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"}
-	host := svc.Name + "." + svc.Namespace + ".svc"
-
-	// Generate a self-signed certificate and key
-	certPEM, keyPEM, err := generateSelfSignedCert(host)
-	if err != nil {
-		panic(err)
-	}
-
-	// Load the certificate and key
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		panic(err)
-	}
-
-	// Create a custom TLS configuration using the certificate and key
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
-	}
 
 	tests := []struct {
 		name           string
-		webhook        *admissionv1.MutatingWebhookConfiguration
-		httpStatus     int
-		serverDelay    time.Duration
-		contextTimout  time.Duration
-		maxDuration    time.Duration
-		expectedResult bool
-		expectedError  string
+		webhookName    string
+		webhookCount   int
+		cc             admissionv1.WebhookClientConfig
+		setup          func(r *Reconciler)
+		expectedReady  bool
+		expectedReason string
 	}{
 		{
-			name: "No webhooks",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{},
-			},
-			expectedResult: false,
-			expectedError:  "mutatingwebhookconfiguration contains no webhooks",
+			name:           "no webhooks",
+			webhookName:    "test",
+			webhookCount:   0,
+			cc:             admissionv1.WebhookClientConfig{},
+			expectedReady:  false,
+			expectedReason: "webhook configuration contains no webhooks",
 		},
 		{
-			name: "No service in client config",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{ClientConfig: admissionv1.WebhookClientConfig{Service: nil}},
-				},
-			},
-			expectedResult: false,
-			expectedError:  "missing webhooks[].clientConfig.service",
+			name:           "no endpoint configured",
+			webhookName:    "test",
+			webhookCount:   1,
+			cc:             admissionv1.WebhookClientConfig{},
+			expectedReady:  false,
+			expectedReason: "no endpoint configured in webhooks[].clientConfig",
 		},
 		{
-			name: "Missing CA bundle",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: nil,
-						},
-					},
-				},
-			},
-			expectedResult: false,
-			expectedError:  "webhooks[].clientConfig.caBundle hasn't been set; check if the remote istiod can access this cluster",
+			name:           "missing caBundle with service",
+			webhookName:    "test",
+			webhookCount:   1,
+			cc:             admissionv1.WebhookClientConfig{Service: &svc},
+			expectedReady:  false,
+			expectedReason: "webhooks[].clientConfig.caBundle hasn't been set; check if the remote istiod can access this cluster",
 		},
 		{
-			name: "Invalid CA bundle",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: []byte("invalid"),
-						},
-					},
-				},
-			},
-			expectedResult: false,
-			expectedError:  "failed to append CA bundle to cert pool",
+			name:          "ready with service endpoint",
+			webhookName:   "test",
+			webhookCount:  1,
+			cc:            admissionv1.WebhookClientConfig{Service: &svc, CABundle: []byte("ca")},
+			expectedReady: true,
 		},
 		{
-			name: "Unsuccessful HTTP response",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: certPEM,
-						},
-					},
-				},
+			name:         "ready with URL endpoint",
+			webhookName:  "test",
+			webhookCount: 1,
+			cc: admissionv1.WebhookClientConfig{
+				URL:      ptr.Of("https://remote-istiod.example.com/inject"),
+				CABundle: []byte("ca"),
 			},
-			httpStatus:     http.StatusInternalServerError,
-			expectedResult: false,
-			expectedError:  "",
+			expectedReady: true,
 		},
 		{
-			name: "Successful HTTP response",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: certPEM,
-						},
-					},
-				},
+			name:         "degraded due to recent failure event",
+			webhookName:  "test",
+			webhookCount: 1,
+			cc:           admissionv1.WebhookClientConfig{Service: &svc, CABundle: []byte("ca")},
+			setup: func(r *Reconciler) {
+				r.recordFailure("test")
+				r.recordFailure("test")
 			},
-			httpStatus:     http.StatusOK,
-			expectedResult: true,
-			expectedError:  "",
-		},
-		{
-			name: "Context timeout",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: certPEM,
-						},
-					},
-				},
-			},
-			httpStatus:     http.StatusOK,
-			serverDelay:    10 * time.Second,
-			contextTimout:  1 * time.Second,
-			maxDuration:    1500 * time.Millisecond,
-			expectedResult: false,
-			expectedError:  "context deadline exceeded",
-		},
-		{
-			name: "Default probe timeout",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: certPEM,
-						},
-					},
-				},
-			},
-			httpStatus:     http.StatusOK,
-			serverDelay:    defaultTimeoutSeconds + 10*time.Second,
-			maxDuration:    defaultTimeoutSeconds*time.Second + 500*time.Millisecond,
-			expectedResult: false,
-			expectedError:  "context deadline exceeded",
-		},
-		{
-			name: "Probe timeout annotation",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						constants.WebhookReadinessProbeTimeoutSecondsAnnotationKey: "1",
-					},
-				},
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: certPEM,
-						},
-					},
-				},
-			},
-			httpStatus:     http.StatusOK,
-			serverDelay:    10 * time.Second,
-			maxDuration:    1500 * time.Millisecond,
-			expectedResult: false,
-			expectedError:  "context deadline exceeded",
+			expectedReady:  false,
+			expectedReason: "apiserver reported webhook call failures",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if tt.serverDelay > 0 {
-					delay := time.NewTimer(tt.serverDelay)
-					select {
-					case <-delay.C:
-					case <-r.Context().Done():
-						delay.Stop()
-					}
-				}
-
-				if r.URL.Path == "/ready" {
-					w.WriteHeader(tt.httpStatus)
-				} else {
-					http.Error(w, "Not Found", http.StatusNotFound)
-				}
-			}))
-			server.TLS = tlsConfig
-			server.StartTLS()
-			defer server.Close()
-
-			customDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				if addr == host+":443" {
-					return net.Dial(network, server.Listener.Addr().String())
-				}
-				return net.Dial(network, addr)
+			r := NewReconciler(newReconcilerTestConfig(t), nil, scheme.Scheme)
+			if tt.setup != nil {
+				tt.setup(r)
 			}
-			defer func() {
-				customDialContext = nil
-			}()
+			ready, reason, _ := r.evaluateReadiness(tt.webhookName, tt.webhookCount, tt.cc)
+			g.Expect(ready).To(Equal(tt.expectedReady))
+			g.Expect(reason).To(Equal(tt.expectedReason))
+		})
+	}
+}
 
-			var probeCtx context.Context
-			if tt.contextTimout > 0 {
-				var cancel context.CancelFunc
-				probeCtx, cancel = context.WithTimeout(ctx, tt.contextTimout)
-				defer cancel()
-			} else {
-				probeCtx = ctx
+func TestIsDegraded(t *testing.T) {
+	g := NewWithT(t)
+	r := NewReconciler(newReconcilerTestConfig(t), nil, scheme.Scheme)
+
+	g.Expect(r.isDegraded("test")).To(BeZero(), "no failure recorded")
+
+	// Single failure: uses minFailureGap (30s) as the gap
+	r.recordFailure("test")
+	g.Expect(r.isDegraded("test")).To(BeNumerically(">", 0), "recent single failure")
+
+	// Two failures 1 minute apart: gap=60s, clears after 2*60s=120s
+	r.mu.Lock()
+	r.failureHistory["test"] = failureEntry{
+		prev: time.Now().Add(-5 * time.Minute),
+		last: time.Now().Add(-4 * time.Minute),
+	}
+	r.mu.Unlock()
+	g.Expect(r.isDegraded("test")).To(BeZero(), "failure aged out (4min > 2*60s)")
+
+	// Verify the entry was cleaned up
+	r.mu.Lock()
+	_, exists := r.failureHistory["test"]
+	r.mu.Unlock()
+	g.Expect(exists).To(BeFalse(), "expired entry removed from map")
+
+	// Two failures 5 minutes apart: gap=300s, still degraded within 2*300s window
+	r.mu.Lock()
+	r.failureHistory["test"] = failureEntry{
+		prev: time.Now().Add(-6 * time.Minute),
+		last: time.Now().Add(-1 * time.Minute),
+	}
+	r.mu.Unlock()
+	g.Expect(r.isDegraded("test")).To(BeNumerically(">", 0), "still within 2*gap window")
+}
+
+func TestExtractWebhookName(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{
+			name: "replicaset controller event with connection refused",
+			message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": ` +
+				`Post "https://istiod.istio-system.svc:443/inject": dial tcp: connect: connection refused`,
+			expected: "sidecar-injector.istio.io",
+		},
+		{
+			name: "replicaset controller event with no endpoints",
+			message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": ` +
+				`Post "https://istiod.istio-system.svc:443/inject": no endpoints available for service "istiod"`,
+			expected: "sidecar-injector.istio.io",
+		},
+		{
+			name: "webhook with no further details",
+			message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io"; ` +
+				`no further details available`,
+			expected: "sidecar-injector.istio.io",
+		},
+		{
+			name:     "no match",
+			message:  "some other event message",
+			expected: "",
+		},
+		{
+			name:     "empty message",
+			message:  "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(ExtractWebhookName(tt.message)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestWebhookFailureEventPredicate(t *testing.T) {
+	pred := webhookFailureEventPredicate()
+	tests := []struct {
+		name     string
+		obj      client.Object
+		expected bool
+	}{
+		{
+			name: "matching event with webhook failure message",
+			obj: &corev1.Event{
+				Type:    corev1.EventTypeWarning,
+				Reason:  "FailedCreate",
+				Message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": connection refused`,
+			},
+			expected: true,
+		},
+		{
+			name: "warning event without webhook failure",
+			obj: &corev1.Event{
+				Type:    corev1.EventTypeWarning,
+				Reason:  "FailedCreate",
+				Message: "Error creating: some other error",
+			},
+			expected: false,
+		},
+		{
+			name: "normal event with webhook text",
+			obj: &corev1.Event{
+				Type:    corev1.EventTypeNormal,
+				Message: `failed calling webhook "sidecar-injector.istio.io"`,
+			},
+			expected: false,
+		},
+		{
+			name:     "not an event",
+			obj:      &admissionv1.MutatingWebhookConfiguration{},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(pred.Create(event.CreateEvent{Object: tt.obj})).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestMapFailureEventToMutatingWebhook(t *testing.T) {
+	mutatingConfig := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+		Webhooks: []admissionv1.MutatingWebhook{{
+			Name: "sidecar-injector.istio.io",
+			ClientConfig: admissionv1.WebhookClientConfig{
+				Service: &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+			},
+		}},
+	}
+	validatingConfig := &admissionv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "istio-validator"},
+		Webhooks: []admissionv1.ValidatingWebhook{{
+			Name: "validation.istio.io",
+			ClientConfig: admissionv1.WebhookClientConfig{
+				Service: &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+			},
+		}},
+	}
+
+	tests := []struct {
+		name         string
+		obj          client.Object
+		expectedReqs []reconcile.Request
+		expectFailed bool
+	}{
+		{
+			name: "maps event to mutating webhook config and records failure",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt1", Namespace: "default"},
+				Message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": ` +
+					`Post "https://istiod.istio-system.svc:443/inject": dial tcp: connect: connection refused`,
+			},
+			expectedReqs: []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "istio-sidecar-injector"}}},
+			expectFailed: true,
+		},
+		{
+			name: "ignores validating webhook in mutating mapper",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt2", Namespace: "default"},
+				Message:    `Error creating: Internal error occurred: failed calling webhook "validation.istio.io": connection refused`,
+			},
+		},
+		{
+			name: "ignores webhook name not found in any config",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt3", Namespace: "default"},
+				Message:    `Error creating: Internal error occurred: failed calling webhook "unknown-webhook.example.com": connection refused`,
+			},
+		},
+		{
+			name: "ignores unrelated message",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt4", Namespace: "default"},
+				Message:    "some unrelated message",
+			},
+		},
+		{
+			name: "ignores non-event",
+			obj:  &admissionv1.MutatingWebhookConfiguration{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cl := newFakeClientBuilder().WithObjects(mutatingConfig, validatingConfig).Build()
+			r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
+
+			reqs := r.mapFailureEventToMutatingWebhook(ctx, tt.obj)
+			g.Expect(reqs).To(Equal(tt.expectedReqs))
+
+			if tt.expectFailed {
+				g.Expect(r.isDegraded("istio-sidecar-injector")).To(BeNumerically(">", 0))
 			}
+		})
+	}
+}
 
-			startTime := time.Now()
-			result, err := doProbe(probeCtx, tt.webhook)
-			stopTime := time.Now()
+func TestMapFailureEventToValidatingWebhook(t *testing.T) {
+	mutatingConfig := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+		Webhooks: []admissionv1.MutatingWebhook{{
+			Name: "sidecar-injector.istio.io",
+		}},
+	}
+	validatingConfig := &admissionv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "istio-validator"},
+		Webhooks: []admissionv1.ValidatingWebhook{{
+			Name: "validation.istio.io",
+		}},
+	}
 
-			if tt.maxDuration > 0 {
-				g.Expect(stopTime.Sub(startTime)).To(BeNumerically("<=", tt.maxDuration))
+	tests := []struct {
+		name         string
+		obj          client.Object
+		expectedReqs []reconcile.Request
+		expectFailed bool
+	}{
+		{
+			name: "maps event to validating webhook config and records failure",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt1", Namespace: "default"},
+				Message:    `Error creating: Internal error occurred: failed calling webhook "validation.istio.io": connection refused`,
+			},
+			expectedReqs: []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "istio-validator"}}},
+			expectFailed: true,
+		},
+		{
+			name: "ignores mutating webhook in validating mapper",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt2", Namespace: "default"},
+				Message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": ` +
+					`Post "https://istiod.istio-system.svc:443/inject": connection refused`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cl := newFakeClientBuilder().WithObjects(mutatingConfig, validatingConfig).Build()
+			r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
+
+			reqs := r.mapFailureEventToValidatingWebhook(ctx, tt.obj)
+			g.Expect(reqs).To(Equal(tt.expectedReqs))
+
+			if tt.expectFailed {
+				g.Expect(r.isDegraded("istio-validator")).To(BeNumerically(">", 0))
 			}
+		})
+	}
+}
 
-			g.Expect(result).To(Equal(tt.expectedResult))
-			if tt.expectedError == "" {
-				g.Expect(err).ToNot(HaveOccurred())
-			} else {
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectedError))
-			}
+func TestFindWebhookConfig(t *testing.T) {
+	configs := []client.Object{
+		&admissionv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+			Webhooks: []admissionv1.MutatingWebhook{
+				{Name: "sidecar-injector.istio.io"},
+				{Name: "namespace.sidecar-injector.istio.io"},
+			},
+		},
+		&admissionv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "istio-validator"},
+			Webhooks: []admissionv1.ValidatingWebhook{
+				{Name: "validation.istio.io"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		webhookName string
+		expected    *webhookConfigRef
+	}{
+		{
+			name:        "finds mutating config",
+			webhookName: "sidecar-injector.istio.io",
+			expected:    &webhookConfigRef{name: "istio-sidecar-injector", isMutating: true},
+		},
+		{
+			name:        "finds second webhook in mutating config",
+			webhookName: "namespace.sidecar-injector.istio.io",
+			expected:    &webhookConfigRef{name: "istio-sidecar-injector", isMutating: true},
+		},
+		{
+			name:        "finds validating config",
+			webhookName: "validation.istio.io",
+			expected:    &webhookConfigRef{name: "istio-validator", isMutating: false},
+		},
+		{
+			name:        "returns nil for unknown webhook",
+			webhookName: "unknown.webhook.io",
+			expected:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cl := newFakeClientBuilder().WithObjects(configs...).Build()
+			r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
+			g.Expect(r.findWebhookConfig(ctx, tt.webhookName)).To(Equal(tt.expected))
 		})
 	}
 }
@@ -397,34 +605,28 @@ func TestIsOwnedByRevisionWithRemoteControlPlane(t *testing.T) {
 		},
 		{
 			name: "Owner reference not IstioRevision",
-			ownerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: "someothergroup/v1",
-					Kind:       "SomeKind",
-				},
-			},
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: "someothergroup/v1",
+				Kind:       "SomeKind",
+			}},
 			expected: false,
 		},
 		{
 			name: "IstioRevision not found",
-			ownerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: v1.GroupVersion.String(),
-					Kind:       v1.IstioRevisionKind,
-					Name:       "revision1",
-				},
-			},
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: v1.GroupVersion.String(),
+				Kind:       v1.IstioRevisionKind,
+				Name:       "revision1",
+			}},
 			expected: false,
 		},
 		{
 			name: "IstioRevision fetch error",
-			ownerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: v1.GroupVersion.String(),
-					Kind:       v1.IstioRevisionKind,
-					Name:       "revision1",
-				},
-			},
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: v1.GroupVersion.String(),
+				Kind:       v1.IstioRevisionKind,
+				Name:       "revision1",
+			}},
 			interceptors: interceptor.Funcs{
 				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					return errors.New("some error")
@@ -434,48 +636,37 @@ func TestIsOwnedByRevisionWithRemoteControlPlane(t *testing.T) {
 		},
 		{
 			name: "IstioRevision not using remote profile",
-			ownerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: v1.GroupVersion.String(),
-					Kind:       v1.IstioRevisionKind,
-					Name:       "revision1",
-				},
-			},
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: v1.GroupVersion.String(),
+				Kind:       v1.IstioRevisionKind,
+				Name:       "revision1",
+			}},
 			objects: []client.Object{
 				&v1.IstioRevision{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "revision1",
-					},
-					Spec: v1.IstioRevisionSpec{},
+					ObjectMeta: metav1.ObjectMeta{Name: "revision1"},
+					Spec:       v1.IstioRevisionSpec{},
 				},
 			},
 			expected: false,
 		},
 		{
 			name: "IstioRevision uses remote profile",
-			ownerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: v1.GroupVersion.String(),
-					Kind:       v1.IstioRevisionKind,
-					Name:       "revision1",
-				},
-			},
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: v1.GroupVersion.String(),
+				Kind:       v1.IstioRevisionKind,
+				Name:       "revision1",
+			}},
 			objects: []client.Object{
 				&v1.IstioRevision{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "revision1",
-					},
+					ObjectMeta: metav1.ObjectMeta{Name: "revision1"},
 					Spec: v1.IstioRevisionSpec{
-						Values: &v1.Values{
-							Profile: ptr.Of("remote"),
-						},
+						Values: &v1.Values{Profile: ptr.Of("remote")},
 					},
 				},
 			},
 			expected: true,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
@@ -484,134 +675,16 @@ func TestIsOwnedByRevisionWithRemoteControlPlane(t *testing.T) {
 				WithObjects(tt.objects...).
 				WithInterceptorFuncs(tt.interceptors).
 				Build()
-
 			obj := &admissionv1.MutatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: tt.ownerRefs,
-				},
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: tt.ownerRefs},
 			}
-
-			result := IsOwnedByRevisionWithRemoteControlPlane(cl, obj)
-			g.Expect(result).To(Equal(tt.expected))
-		})
-	}
-}
-
-func TestGetReadinessProbeURL(t *testing.T) {
-	tests := []struct {
-		name      string
-		config    admissionv1.WebhookClientConfig
-		expectURL string
-		expectErr bool
-	}{
-		{
-			name: "URL",
-			config: admissionv1.WebhookClientConfig{
-				URL: ptr.Of("https://some.url"),
-			},
-			expectErr: true,
-		},
-		{
-			name:      "no URL or Service",
-			config:    admissionv1.WebhookClientConfig{},
-			expectErr: true,
-		},
-		{
-			name: "default port",
-			config: admissionv1.WebhookClientConfig{
-				Service: &admissionv1.ServiceReference{
-					Name:      "istiod",
-					Namespace: "istio-system",
-				},
-			},
-			expectURL: "https://istiod.istio-system.svc:443/ready",
-		},
-		{
-			name: "custom port",
-			config: admissionv1.WebhookClientConfig{
-				Service: &admissionv1.ServiceReference{
-					Name:      "istiod",
-					Namespace: "istio-system",
-					Port:      ptr.Of(int32(123)),
-				},
-			},
-			expectURL: "https://istiod.istio-system.svc:123/ready",
-		},
-		{
-			name: "ignores path",
-			config: admissionv1.WebhookClientConfig{
-				Service: &admissionv1.ServiceReference{
-					Name:      "istiod",
-					Namespace: "istio-system",
-					Path:      ptr.Of("/some/path"),
-				},
-			},
-			expectURL: "https://istiod.istio-system.svc:443/ready",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-
-			got, err := getReadinessProbeURL(tt.config)
-
-			g.Expect(got).To(Equal(tt.expectURL))
-			if tt.expectErr {
-				g.Expect(err).To(HaveOccurred())
-			} else {
-				g.Expect(err).ToNot(HaveOccurred())
-			}
+			g.Expect(IsOwnedByRevisionWithRemoteControlPlane(cl, obj)).To(Equal(tt.expected))
 		})
 	}
 }
 
 func newFakeClientBuilder() *fake.ClientBuilder {
-	return fake.NewClientBuilder().
-		WithScheme(scheme.Scheme)
-}
-
-func generateSelfSignedCert(dnsNames ...string) (certPEM []byte, keyPEM []byte, err error) {
-	// Generate a private key
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Create a template for the certificate
-	template := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			Organization: []string{"test"},
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(365 * 24 * time.Hour), // 1 year
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-		DNSNames:              dnsNames,
-	}
-
-	// Generate a self-signed certificate
-	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Encode the certificate and key to PEM format
-	certPEM = pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: certDER,
-	})
-	keyDER, err := x509.MarshalECPrivateKey(privateKey)
-	if err != nil {
-		return nil, nil, err
-	}
-	keyPEM = pem.EncodeToMemory(&pem.Block{
-		Type:  "EC PRIVATE KEY",
-		Bytes: keyDER,
-	})
-
-	return certPEM, keyPEM, nil
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme)
 }
 
 func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {

--- a/controllers/webhook/webhook_controller_test.go
+++ b/controllers/webhook/webhook_controller_test.go
@@ -16,23 +16,12 @@ package webhook
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
-	"fmt"
-	"math/big"
-	"net"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/constants"
@@ -40,11 +29,14 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/scheme"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"istio.io/istio/pkg/ptr"
 )
@@ -53,331 +45,743 @@ var ctx = context.Background()
 
 func TestReconcile(t *testing.T) {
 	tests := []struct {
-		name         string
-		setup        func(configuration *admissionv1.MutatingWebhookConfiguration)
-		probeFunc    func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error)
-		interceptors interceptor.Funcs
-		expectResult ctrl.Result
-		expectErr    error
-		expectValue  string
+		name          string
+		webhook       *admissionv1.MutatingWebhookConfiguration
+		setup         func(r *Reconciler)
+		interceptors  interceptor.Funcs
+		expectRequeue bool
+		expectErr     error
+		expectStatus  string
+		expectReason  string
 	}{
 		{
-			name: "ready",
-			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-				return true, nil
+			name: "ready when caBundle is set",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+						CABundle: []byte("ca-data"),
+					},
+				}},
 			},
-			expectResult: ctrl.Result{RequeueAfter: defaultPeriodSeconds * time.Second},
-			expectValue:  "true",
+			expectStatus: "true",
 		},
 		{
-			name: "not ready",
-			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-				return false, nil
+			name: "not ready when caBundle is empty",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service: &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+					},
+				}},
 			},
-			expectResult: ctrl.Result{RequeueAfter: defaultPeriodSeconds * time.Second},
-			expectValue:  "false",
+			expectStatus: "false",
 		},
 		{
-			name: "probe error",
-			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-				return false, fmt.Errorf("some error")
+			name: "not ready when webhook configuration contains no webhooks",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
 			},
-			expectResult: ctrl.Result{RequeueAfter: defaultPeriodSeconds * time.Second},
-			expectValue:  "false",
+			expectStatus: "false",
+			expectReason: "webhook configuration contains no webhooks",
 		},
 		{
 			name: "update error",
-			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-				return true, nil
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+						CABundle: []byte("ca-data"),
+					},
+				}},
 			},
 			interceptors: interceptor.Funcs{
 				Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
 					return errors.New("some error")
 				},
 			},
-			expectResult: ctrl.Result{},
 			expectErr:    errors.New("some error"),
-			expectValue:  "",
+			expectStatus: "",
 		},
 		{
-			name: "honors period annotation",
-			setup: func(webhook *admissionv1.MutatingWebhookConfiguration) {
-				webhook.Annotations = map[string]string{
-					constants.WebhookReadinessProbePeriodSecondsAnnotationKey: "123",
-				}
+			name: "not ready when recent failure event recorded",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+						CABundle: []byte("ca-data"),
+					},
+				}},
 			},
-			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
-				return true, nil
+			setup: func(r *Reconciler) {
+				r.recordFailure("istio-sidecar-injector")
 			},
-			expectResult: ctrl.Result{RequeueAfter: 123 * time.Second},
-			expectValue:  "true",
+			expectRequeue: true,
+			expectStatus:  "false",
+			expectReason:  "webhook call failures reported in cluster events",
+		},
+		{
+			name: "recovers after failure ages out",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+						CABundle: []byte("ca-data"),
+					},
+				}},
+			},
+			setup: func(r *Reconciler) {
+				r.failureHistory.Add("istio-sidecar-injector", time.Now().Add(-10*time.Minute))
+			},
+			expectStatus: "true",
+		},
+		{
+			name: "degraded window annotation shortens the default window",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "istio-sidecar-injector",
+					Annotations: map[string]string{constants.WebhookDegradedWindowAnnotationKey: "1s"},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+						CABundle: []byte("ca-data"),
+					},
+				}},
+			},
+			setup: func(r *Reconciler) {
+				// Would still be within DefaultDegradedWindow, but the annotation shortens the window to 1s.
+				r.failureHistory.Add("istio-sidecar-injector", time.Now().Add(-10*time.Second))
+			},
+			expectStatus: "true",
+		},
+		{
+			name: "invalid degraded window annotation falls back to the default",
+			webhook: &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "istio-sidecar-injector",
+					Annotations: map[string]string{constants.WebhookDegradedWindowAnnotationKey: "not-a-duration"},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+						CABundle: []byte("ca-data"),
+					},
+				}},
+			},
+			setup: func(r *Reconciler) {
+				r.recordFailure("istio-sidecar-injector")
+			},
+			expectRequeue: true,
+			expectStatus:  "false",
+			expectReason:  "webhook call failures reported in cluster events",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			webhook := &admissionv1.MutatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "istio-sidecar-injector",
-				},
-			}
-			if tt.setup != nil {
-				tt.setup(webhook)
-			}
-
 			cl := newFakeClientBuilder().
-				WithObjects(webhook).
+				WithObjects(tt.webhook).
 				WithInterceptorFuncs(tt.interceptors).
 				Build()
 			r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
-			r.probe = tt.probeFunc
+			if tt.setup != nil {
+				tt.setup(r)
+			}
 
-			result, err := r.Reconcile(ctx, webhook)
+			result, err := r.Reconcile(ctx, tt.webhook)
 
-			g.Expect(result).To(Equal(tt.expectResult))
+			if tt.expectRequeue {
+				g.Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+			} else {
+				g.Expect(result.RequeueAfter).To(BeZero())
+			}
 			if tt.expectErr != nil {
 				g.Expect(err).To(Equal(tt.expectErr))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}
 
-			g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
-			g.Expect(webhook.Annotations[constants.WebhookReadinessProbeStatusAnnotationKey]).To(Equal(tt.expectValue), "Unexpected annotation value")
+			if tt.expectStatus != "" {
+				g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), tt.webhook)).To(Succeed())
+				g.Expect(tt.webhook.Annotations[constants.WebhookReadinessStatusAnnotationKey]).To(Equal(tt.expectStatus))
+			}
+			if tt.expectReason != "" {
+				g.Expect(tt.webhook.Annotations[constants.WebhookReadinessReasonAnnotationKey]).To(Equal(tt.expectReason))
+			}
 		})
 	}
 }
 
-func TestDoProbe(t *testing.T) {
+func TestReconcileDoesNotUpdateWhenAnnotationsAreCurrent(t *testing.T) {
+	g := NewWithT(t)
+
+	webhook := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "istio-sidecar-injector",
+			Annotations: map[string]string{
+				constants.WebhookReadinessStatusAnnotationKey: "true",
+				constants.WebhookReadinessReasonAnnotationKey: "",
+			},
+		},
+		Webhooks: []admissionv1.MutatingWebhook{{
+			ClientConfig: admissionv1.WebhookClientConfig{
+				Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+				CABundle: []byte("ca-data"),
+			},
+		}},
+	}
+
+	cl := newFakeClientBuilder().WithObjects(webhook).Build()
+	r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
+
+	before := &admissionv1.MutatingWebhookConfiguration{}
+	g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), before)).To(Succeed())
+
+	_, err := r.Reconcile(ctx, webhook)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
+	g.Expect(webhook.ResourceVersion).To(Equal(before.ResourceVersion),
+		"no update expected when the readiness annotations are already current")
+}
+
+func TestReconcileRemovesLegacyReadinessAnnotations(t *testing.T) {
+	g := NewWithT(t)
+
+	webhook := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "istio-sidecar-injector",
+			Annotations: map[string]string{
+				"sailoperator.io/readinessProbe.status":         "false",
+				"sailoperator.io/readinessProbe.reason":         "readiness probe failed",
+				"sailoperator.io/readinessProbe.periodSeconds":  "10",
+				"sailoperator.io/readinessProbe.timeoutSeconds": "5",
+			},
+		},
+		Webhooks: []admissionv1.MutatingWebhook{{
+			ClientConfig: admissionv1.WebhookClientConfig{
+				Service:  &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+				CABundle: []byte("ca-data"),
+			},
+		}},
+	}
+
+	cl := newFakeClientBuilder().WithObjects(webhook).Build()
+	r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
+
+	_, err := r.Reconcile(ctx, webhook)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
+	g.Expect(webhook.Annotations).ToNot(HaveKey("sailoperator.io/readinessProbe.status"))
+	g.Expect(webhook.Annotations).ToNot(HaveKey("sailoperator.io/readinessProbe.reason"))
+	g.Expect(webhook.Annotations).ToNot(HaveKey("sailoperator.io/readinessProbe.periodSeconds"))
+	g.Expect(webhook.Annotations).ToNot(HaveKey("sailoperator.io/readinessProbe.timeoutSeconds"))
+	g.Expect(webhook.Annotations[constants.WebhookReadinessStatusAnnotationKey]).To(Equal("true"))
+}
+
+func TestEvaluateReadiness(t *testing.T) {
 	svc := admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"}
-	host := svc.Name + "." + svc.Namespace + ".svc"
-
-	// Generate a self-signed certificate and key
-	certPEM, keyPEM, err := generateSelfSignedCert(host)
-	if err != nil {
-		panic(err)
-	}
-
-	// Load the certificate and key
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		panic(err)
-	}
-
-	// Create a custom TLS configuration using the certificate and key
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
-	}
 
 	tests := []struct {
 		name           string
-		webhook        *admissionv1.MutatingWebhookConfiguration
-		httpStatus     int
-		serverDelay    time.Duration
-		contextTimout  time.Duration
-		maxDuration    time.Duration
-		expectedResult bool
-		expectedError  string
+		webhookName    string
+		webhooks       []admissionv1.MutatingWebhook
+		setup          func(r *Reconciler)
+		expectedReady  bool
+		expectedReason string
 	}{
 		{
-			name: "No webhooks",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{},
-			},
-			expectedResult: false,
-			expectedError:  "mutatingwebhookconfiguration contains no webhooks",
+			name:           "no webhooks",
+			webhookName:    "test",
+			webhooks:       []admissionv1.MutatingWebhook{},
+			expectedReady:  false,
+			expectedReason: "webhook configuration contains no webhooks",
 		},
 		{
-			name: "No service in client config",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{ClientConfig: admissionv1.WebhookClientConfig{Service: nil}},
-				},
-			},
-			expectedResult: false,
-			expectedError:  "missing webhooks[].clientConfig.service",
+			name:           "no endpoint configured",
+			webhookName:    "test",
+			webhooks:       []admissionv1.MutatingWebhook{{}},
+			expectedReady:  false,
+			expectedReason: "no endpoint configured in webhooks[].clientConfig",
 		},
 		{
-			name: "Missing CA bundle",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: nil,
-						},
-					},
-				},
-			},
-			expectedResult: false,
-			expectedError:  "webhooks[].clientConfig.caBundle hasn't been set; check if the remote istiod can access this cluster",
+			name:           "missing caBundle with service",
+			webhookName:    "test",
+			webhooks:       []admissionv1.MutatingWebhook{{ClientConfig: admissionv1.WebhookClientConfig{Service: &svc}}},
+			expectedReady:  false,
+			expectedReason: "webhooks[].clientConfig.caBundle hasn't been set; check if the remote istiod can access this cluster",
 		},
 		{
-			name: "Invalid CA bundle",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: []byte("invalid"),
-						},
-					},
-				},
-			},
-			expectedResult: false,
-			expectedError:  "failed to append CA bundle to cert pool",
+			name:          "ready with service endpoint",
+			webhookName:   "test",
+			webhooks:      []admissionv1.MutatingWebhook{{ClientConfig: admissionv1.WebhookClientConfig{Service: &svc, CABundle: []byte("ca")}}},
+			expectedReady: true,
 		},
 		{
-			name: "Unsuccessful HTTP response",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: certPEM,
-						},
-					},
-				},
-			},
-			httpStatus:     http.StatusInternalServerError,
-			expectedResult: false,
-			expectedError:  "",
+			name:        "ready with URL endpoint",
+			webhookName: "test",
+			webhooks: []admissionv1.MutatingWebhook{{ClientConfig: admissionv1.WebhookClientConfig{
+				URL:      ptr.Of("https://remote-istiod.example.com/inject"),
+				CABundle: []byte("ca-data"),
+			}}},
+			expectedReady: true,
 		},
 		{
-			name: "Successful HTTP response",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: certPEM,
-						},
-					},
-				},
+			name:        "degraded due to recent failure event",
+			webhookName: "test",
+			webhooks:    []admissionv1.MutatingWebhook{{ClientConfig: admissionv1.WebhookClientConfig{Service: &svc, CABundle: []byte("ca")}}},
+			setup: func(r *Reconciler) {
+				r.recordFailure("test")
 			},
-			httpStatus:     http.StatusOK,
-			expectedResult: true,
-			expectedError:  "",
-		},
-		{
-			name: "Context timeout",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: certPEM,
-						},
-					},
-				},
-			},
-			httpStatus:     http.StatusOK,
-			serverDelay:    10 * time.Second,
-			contextTimout:  1 * time.Second,
-			maxDuration:    1500 * time.Millisecond,
-			expectedResult: false,
-			expectedError:  "context deadline exceeded",
-		},
-		{
-			name: "Default probe timeout",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: certPEM,
-						},
-					},
-				},
-			},
-			httpStatus:     http.StatusOK,
-			serverDelay:    defaultTimeoutSeconds + 10*time.Second,
-			maxDuration:    defaultTimeoutSeconds*time.Second + 500*time.Millisecond,
-			expectedResult: false,
-			expectedError:  "context deadline exceeded",
-		},
-		{
-			name: "Probe timeout annotation",
-			webhook: &admissionv1.MutatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						constants.WebhookReadinessProbeTimeoutSecondsAnnotationKey: "1",
-					},
-				},
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service:  &svc,
-							CABundle: certPEM,
-						},
-					},
-				},
-			},
-			httpStatus:     http.StatusOK,
-			serverDelay:    10 * time.Second,
-			maxDuration:    1500 * time.Millisecond,
-			expectedResult: false,
-			expectedError:  "context deadline exceeded",
+			expectedReady:  false,
+			expectedReason: "webhook call failures reported in cluster events",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if tt.serverDelay > 0 {
-					delay := time.NewTimer(tt.serverDelay)
-					select {
-					case <-delay.C:
-					case <-r.Context().Done():
-						delay.Stop()
-					}
-				}
-
-				if r.URL.Path == "/ready" {
-					w.WriteHeader(tt.httpStatus)
-				} else {
-					http.Error(w, "Not Found", http.StatusNotFound)
-				}
-			}))
-			server.TLS = tlsConfig
-			server.StartTLS()
-			defer server.Close()
-
-			customDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				if addr == host+":443" {
-					return net.Dial(network, server.Listener.Addr().String())
-				}
-				return net.Dial(network, addr)
+			r := NewReconciler(newReconcilerTestConfig(t), nil, scheme.Scheme)
+			if tt.setup != nil {
+				tt.setup(r)
 			}
-			defer func() {
-				customDialContext = nil
+			result := r.evaluateReadiness(tt.webhookName, tt.webhooks, DefaultDegradedWindow)
+			g.Expect(result.ready).To(Equal(tt.expectedReady))
+			g.Expect(result.reason).To(Equal(tt.expectedReason))
+		})
+	}
+}
+
+func TestIsDegraded(t *testing.T) {
+	g := NewWithT(t)
+	r := NewReconciler(newReconcilerTestConfig(t), nil, scheme.Scheme)
+
+	g.Expect(r.isDegraded("test", DefaultDegradedWindow)).To(BeZero(), "no failure recorded")
+
+	// Recent failure: still within the degraded window
+	r.recordFailure("test")
+	g.Expect(r.isDegraded("test", DefaultDegradedWindow)).To(BeNumerically(">", 0), "recent single failure")
+
+	// Failure older than the degraded window has aged out
+	r.failureHistory.Add("test", time.Now().Add(-(DefaultDegradedWindow + time.Minute)))
+	g.Expect(r.isDegraded("test", DefaultDegradedWindow)).To(BeZero(), "failure aged out")
+
+	// Verify the entry was cleaned up
+	_, exists := r.failureHistory.Get("test")
+	g.Expect(exists).To(BeFalse(), "expired entry removed from map")
+
+	// Failure within the degraded window is still degraded
+	r.failureHistory.Add("test", time.Now().Add(-(DefaultDegradedWindow - time.Minute)))
+	g.Expect(r.isDegraded("test", DefaultDegradedWindow)).To(BeNumerically(">", 0), "still within the degraded window")
+}
+
+func TestPruneStaleFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		seed       map[string]time.Duration // name -> age of the entry (how far in the past it was recorded)
+		wantPruned int
+		wantKept   []string
+	}{
+		{
+			name:       "empty map is a no-op",
+			seed:       map[string]time.Duration{},
+			wantPruned: 0,
+			wantKept:   nil,
+		},
+		{
+			name:       "all fresh entries are kept",
+			seed:       map[string]time.Duration{"a": 0, "b": time.Minute},
+			wantPruned: 0,
+			wantKept:   []string{"a", "b"},
+		},
+		{
+			name:       "all stale entries are pruned",
+			seed:       map[string]time.Duration{"a": DefaultDegradedWindow + time.Minute, "b": DefaultDegradedWindow + 2*time.Minute},
+			wantPruned: 2,
+			wantKept:   nil,
+		},
+		{
+			name:       "entries at the window boundary are pruned",
+			seed:       map[string]time.Duration{"a": DefaultDegradedWindow},
+			wantPruned: 1,
+			wantKept:   nil,
+		},
+		{
+			name:       "mixed entries: only those within the window survive",
+			seed:       map[string]time.Duration{"stale": DefaultDegradedWindow + time.Minute, "boundary": DefaultDegradedWindow, "fresh": time.Minute},
+			wantPruned: 2,
+			wantKept:   []string{"fresh"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := NewReconciler(newReconcilerTestConfig(t), nil, scheme.Scheme)
+
+			now := time.Now()
+			for name, age := range tt.seed {
+				r.failureHistory.Add(name, now.Add(-age))
+			}
+
+			g.Expect(r.pruneStaleFailures()).To(Equal(tt.wantPruned))
+
+			g.Expect(r.failureHistory.Len()).To(Equal(len(tt.wantKept)))
+			for _, name := range tt.wantKept {
+				_, ok := r.failureHistory.Get(name)
+				g.Expect(ok).To(BeTrue(), "expected entry to survive: %s", name)
+			}
+		})
+	}
+}
+
+func TestFailureHistoryJanitor(t *testing.T) {
+	tests := []struct {
+		name     string
+		seed     map[string]time.Duration // name -> age of the entry
+		wantKept []string
+	}{
+		{
+			name:     "prunes stale entries and keeps fresh ones",
+			seed:     map[string]time.Duration{"stale": DefaultDegradedWindow + time.Minute, "fresh": 0},
+			wantKept: []string{"fresh"},
+		},
+		{
+			name:     "no-op when all entries are fresh",
+			seed:     map[string]time.Duration{"a": 0, "b": time.Minute},
+			wantKept: []string{"a", "b"},
+		},
+		{
+			name:     "no-op on empty map",
+			seed:     map[string]time.Duration{},
+			wantKept: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := NewReconciler(newReconcilerTestConfig(t), nil, scheme.Scheme)
+
+			now := time.Now()
+			for name, age := range tt.seed {
+				r.failureHistory.Add(name, now.Add(-age))
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_ = r.failureHistoryJanitor(logr.Discard(), 10*time.Millisecond).Start(ctx)
 			}()
 
-			var probeCtx context.Context
-			if tt.contextTimout > 0 {
-				var cancel context.CancelFunc
-				probeCtx, cancel = context.WithTimeout(ctx, tt.contextTimout)
-				defer cancel()
+			g.Eventually(func() bool {
+				if r.failureHistory.Len() != len(tt.wantKept) {
+					return false
+				}
+				for _, name := range tt.wantKept {
+					if _, ok := r.failureHistory.Get(name); !ok {
+						return false
+					}
+				}
+				return true
+			}).Should(BeTrue(), "janitor should leave exactly the entries within the window")
+
+			cancel()
+			<-done
+		})
+	}
+}
+
+func TestExtractWebhookName(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{
+			name: "replicaset controller event with connection refused",
+			message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": ` +
+				`Post "https://istiod.istio-system.svc:443/inject": dial tcp: connect: connection refused`,
+			expected: "sidecar-injector.istio.io",
+		},
+		{
+			name: "replicaset controller event with no endpoints",
+			message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": ` +
+				`Post "https://istiod.istio-system.svc:443/inject": no endpoints available for service "istiod"`,
+			expected: "sidecar-injector.istio.io",
+		},
+		{
+			name: "webhook with no further details",
+			message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io"; ` +
+				`no further details available`,
+			expected: "sidecar-injector.istio.io",
+		},
+		{
+			name:     "no match",
+			message:  "some other event message",
+			expected: "",
+		},
+		{
+			name:     "empty message",
+			message:  "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(ExtractWebhookName(tt.message)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestWebhookFailureEventPredicate(t *testing.T) {
+	pred := webhookFailureEventPredicate()
+	tests := []struct {
+		name     string
+		obj      client.Object
+		expected bool
+	}{
+		{
+			name: "matching event with webhook failure message",
+			obj: &corev1.Event{
+				Type:    corev1.EventTypeWarning,
+				Reason:  "FailedCreate",
+				Message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": connection refused`,
+			},
+			expected: true,
+		},
+		{
+			name: "warning event without webhook failure",
+			obj: &corev1.Event{
+				Type:    corev1.EventTypeWarning,
+				Reason:  "FailedCreate",
+				Message: "Error creating: some other error",
+			},
+			expected: false,
+		},
+		{
+			name: "normal event with webhook text",
+			obj: &corev1.Event{
+				Type:    corev1.EventTypeNormal,
+				Message: `failed calling webhook "sidecar-injector.istio.io"`,
+			},
+			expected: false,
+		},
+		{
+			name:     "not an event",
+			obj:      &admissionv1.MutatingWebhookConfiguration{},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(pred.Create(event.CreateEvent{Object: tt.obj})).To(Equal(tt.expected))
+		})
+	}
+
+	failureEvent := &corev1.Event{
+		Type:    corev1.EventTypeWarning,
+		Reason:  "FailedCreate",
+		Message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": connection refused`,
+	}
+	t.Run("update matches on the new object", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(pred.Update(event.UpdateEvent{ObjectNew: failureEvent})).To(BeTrue())
+		g.Expect(pred.Update(event.UpdateEvent{
+			ObjectNew: &corev1.Event{Type: corev1.EventTypeWarning, Message: "Error creating: some other error"},
+		})).To(BeFalse())
+	})
+	t.Run("delete is ignored", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(pred.Delete(event.DeleteEvent{Object: failureEvent})).To(BeFalse())
+	})
+	t.Run("generic is ignored", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(pred.Generic(event.GenericEvent{Object: failureEvent})).To(BeFalse())
+	})
+}
+
+func testOwnedByRevisionRef(revisionName string) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: v1.GroupVersion.String(),
+		Kind:       v1.IstioRevisionKind,
+		Name:       revisionName,
+		UID:        types.UID(revisionName + "-uid"),
+	}
+}
+
+func testRemoteRevision(name string) *v1.IstioRevision {
+	return &v1.IstioRevision{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.IstioRevisionSpec{
+			Values: &v1.Values{Profile: ptr.Of("remote")},
+		},
+	}
+}
+
+func TestMapFailureEventToWebhook(t *testing.T) {
+	mutatingConfig := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "istio-sidecar-injector",
+			OwnerReferences: []metav1.OwnerReference{testOwnedByRevisionRef("test-revision")},
+		},
+		Webhooks: []admissionv1.MutatingWebhook{{
+			Name: "sidecar-injector.istio.io",
+			ClientConfig: admissionv1.WebhookClientConfig{
+				Service: &admissionv1.ServiceReference{Name: "istiod", Namespace: "istio-system"},
+			},
+		}},
+	}
+	unownedConfig := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "unowned-sidecar-injector"},
+		Webhooks: []admissionv1.MutatingWebhook{{
+			Name: "unowned.istio.io",
+		}},
+	}
+	localConfig := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "local-sidecar-injector",
+			OwnerReferences: []metav1.OwnerReference{testOwnedByRevisionRef("local-revision")},
+		},
+		Webhooks: []admissionv1.MutatingWebhook{{
+			Name: "local.istio.io",
+		}},
+	}
+
+	tests := []struct {
+		name         string
+		obj          client.Object
+		expectedReqs []reconcile.Request
+		expectFailed bool
+	}{
+		{
+			name: "maps event to webhook config and records failure",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt1", Namespace: "default"},
+				Message: `Error creating: Internal error occurred: failed calling webhook "sidecar-injector.istio.io": ` +
+					`Post "https://istiod.istio-system.svc:443/inject": dial tcp: connect: connection refused`,
+			},
+			expectedReqs: []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "istio-sidecar-injector"}}},
+			expectFailed: true,
+		},
+		{
+			name: "ignores webhook in config that is not owned by an IstioRevision",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt2", Namespace: "default"},
+				Message:    `Error creating: Internal error occurred: failed calling webhook "unowned.istio.io": connection refused`,
+			},
+		},
+		{
+			name: "ignores webhook in config owned by a non-remote IstioRevision",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt3", Namespace: "default"},
+				Message:    `Error creating: Internal error occurred: failed calling webhook "local.istio.io": connection refused`,
+			},
+		},
+		{
+			name: "ignores webhook name not found in any config",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt4", Namespace: "default"},
+				Message:    `Error creating: Internal error occurred: failed calling webhook "unknown-webhook.example.com": connection refused`,
+			},
+		},
+		{
+			name: "ignores unrelated message",
+			obj: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt5", Namespace: "default"},
+				Message:    "some unrelated message",
+			},
+		},
+		{
+			name: "ignores non-event",
+			obj:  &admissionv1.MutatingWebhookConfiguration{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cl := newFakeClientBuilder().WithObjects(
+				mutatingConfig, unownedConfig, localConfig,
+				testRemoteRevision("test-revision"),
+				&v1.IstioRevision{ObjectMeta: metav1.ObjectMeta{Name: "local-revision"}},
+			).Build()
+			r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
+
+			reqs := r.mapFailureEventToWebhook(ctx, tt.obj)
+			g.Expect(reqs).To(Equal(tt.expectedReqs))
+
+			if tt.expectFailed {
+				g.Expect(r.isDegraded("istio-sidecar-injector", DefaultDegradedWindow)).To(BeNumerically(">", 0))
 			} else {
-				probeCtx = ctx
+				g.Expect(r.isDegraded("unowned-sidecar-injector", DefaultDegradedWindow)).To(BeZero())
+				g.Expect(r.isDegraded("local-sidecar-injector", DefaultDegradedWindow)).To(BeZero())
 			}
+		})
+	}
+}
 
-			startTime := time.Now()
-			result, err := doProbe(probeCtx, tt.webhook)
-			stopTime := time.Now()
+func TestFindOwnedWebhookConfig(t *testing.T) {
+	owned := testOwnedByRevisionRef("test-revision")
+	configs := []client.Object{
+		&admissionv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "istio-sidecar-injector",
+				OwnerReferences: []metav1.OwnerReference{owned},
+			},
+			Webhooks: []admissionv1.MutatingWebhook{
+				{Name: "sidecar-injector.istio.io"},
+				{Name: "namespace.sidecar-injector.istio.io"},
+			},
+		},
+		&admissionv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "third-party-injector"},
+			Webhooks: []admissionv1.MutatingWebhook{
+				{Name: "third-party.istio.io"},
+			},
+		},
+	}
 
-			if tt.maxDuration > 0 {
-				g.Expect(stopTime.Sub(startTime)).To(BeNumerically("<=", tt.maxDuration))
-			}
-
-			g.Expect(result).To(Equal(tt.expectedResult))
-			if tt.expectedError == "" {
-				g.Expect(err).ToNot(HaveOccurred())
-			} else {
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectedError))
-			}
+	tests := []struct {
+		name        string
+		webhookName string
+		expected    string
+	}{
+		{
+			name:        "finds owned config",
+			webhookName: "sidecar-injector.istio.io",
+			expected:    "istio-sidecar-injector",
+		},
+		{
+			name:        "finds second webhook in owned config",
+			webhookName: "namespace.sidecar-injector.istio.io",
+			expected:    "istio-sidecar-injector",
+		},
+		{
+			name:        "ignores webhook in config that is not owned by an IstioRevision",
+			webhookName: "third-party.istio.io",
+			expected:    "",
+		},
+		{
+			name:        "returns empty for unknown webhook",
+			webhookName: "unknown.webhook.io",
+			expected:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cl := newFakeClientBuilder().WithObjects(configs...).WithObjects(testRemoteRevision("test-revision")).Build()
+			r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
+			g.Expect(r.findOwnedWebhookConfig(ctx, tt.webhookName)).To(Equal(tt.expected))
 		})
 	}
 }
@@ -397,34 +801,28 @@ func TestIsOwnedByRevisionWithRemoteControlPlane(t *testing.T) {
 		},
 		{
 			name: "Owner reference not IstioRevision",
-			ownerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: "someothergroup/v1",
-					Kind:       "SomeKind",
-				},
-			},
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: "someothergroup/v1",
+				Kind:       "SomeKind",
+			}},
 			expected: false,
 		},
 		{
 			name: "IstioRevision not found",
-			ownerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: v1.GroupVersion.String(),
-					Kind:       v1.IstioRevisionKind,
-					Name:       "revision1",
-				},
-			},
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: v1.GroupVersion.String(),
+				Kind:       v1.IstioRevisionKind,
+				Name:       "revision1",
+			}},
 			expected: false,
 		},
 		{
 			name: "IstioRevision fetch error",
-			ownerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: v1.GroupVersion.String(),
-					Kind:       v1.IstioRevisionKind,
-					Name:       "revision1",
-				},
-			},
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: v1.GroupVersion.String(),
+				Kind:       v1.IstioRevisionKind,
+				Name:       "revision1",
+			}},
 			interceptors: interceptor.Funcs{
 				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					return errors.New("some error")
@@ -434,48 +832,37 @@ func TestIsOwnedByRevisionWithRemoteControlPlane(t *testing.T) {
 		},
 		{
 			name: "IstioRevision not using remote profile",
-			ownerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: v1.GroupVersion.String(),
-					Kind:       v1.IstioRevisionKind,
-					Name:       "revision1",
-				},
-			},
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: v1.GroupVersion.String(),
+				Kind:       v1.IstioRevisionKind,
+				Name:       "revision1",
+			}},
 			objects: []client.Object{
 				&v1.IstioRevision{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "revision1",
-					},
-					Spec: v1.IstioRevisionSpec{},
+					ObjectMeta: metav1.ObjectMeta{Name: "revision1"},
+					Spec:       v1.IstioRevisionSpec{},
 				},
 			},
 			expected: false,
 		},
 		{
 			name: "IstioRevision uses remote profile",
-			ownerRefs: []metav1.OwnerReference{
-				{
-					APIVersion: v1.GroupVersion.String(),
-					Kind:       v1.IstioRevisionKind,
-					Name:       "revision1",
-				},
-			},
+			ownerRefs: []metav1.OwnerReference{{
+				APIVersion: v1.GroupVersion.String(),
+				Kind:       v1.IstioRevisionKind,
+				Name:       "revision1",
+			}},
 			objects: []client.Object{
 				&v1.IstioRevision{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "revision1",
-					},
+					ObjectMeta: metav1.ObjectMeta{Name: "revision1"},
 					Spec: v1.IstioRevisionSpec{
-						Values: &v1.Values{
-							Profile: ptr.Of("remote"),
-						},
+						Values: &v1.Values{Profile: ptr.Of("remote")},
 					},
 				},
 			},
 			expected: true,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
@@ -484,134 +871,16 @@ func TestIsOwnedByRevisionWithRemoteControlPlane(t *testing.T) {
 				WithObjects(tt.objects...).
 				WithInterceptorFuncs(tt.interceptors).
 				Build()
-
 			obj := &admissionv1.MutatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: tt.ownerRefs,
-				},
+				ObjectMeta: metav1.ObjectMeta{OwnerReferences: tt.ownerRefs},
 			}
-
-			result := IsOwnedByRevisionWithRemoteControlPlane(cl, obj)
-			g.Expect(result).To(Equal(tt.expected))
-		})
-	}
-}
-
-func TestGetReadinessProbeURL(t *testing.T) {
-	tests := []struct {
-		name      string
-		config    admissionv1.WebhookClientConfig
-		expectURL string
-		expectErr bool
-	}{
-		{
-			name: "URL",
-			config: admissionv1.WebhookClientConfig{
-				URL: ptr.Of("https://some.url"),
-			},
-			expectErr: true,
-		},
-		{
-			name:      "no URL or Service",
-			config:    admissionv1.WebhookClientConfig{},
-			expectErr: true,
-		},
-		{
-			name: "default port",
-			config: admissionv1.WebhookClientConfig{
-				Service: &admissionv1.ServiceReference{
-					Name:      "istiod",
-					Namespace: "istio-system",
-				},
-			},
-			expectURL: "https://istiod.istio-system.svc:443/ready",
-		},
-		{
-			name: "custom port",
-			config: admissionv1.WebhookClientConfig{
-				Service: &admissionv1.ServiceReference{
-					Name:      "istiod",
-					Namespace: "istio-system",
-					Port:      ptr.Of(int32(123)),
-				},
-			},
-			expectURL: "https://istiod.istio-system.svc:123/ready",
-		},
-		{
-			name: "ignores path",
-			config: admissionv1.WebhookClientConfig{
-				Service: &admissionv1.ServiceReference{
-					Name:      "istiod",
-					Namespace: "istio-system",
-					Path:      ptr.Of("/some/path"),
-				},
-			},
-			expectURL: "https://istiod.istio-system.svc:443/ready",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-
-			got, err := getReadinessProbeURL(tt.config)
-
-			g.Expect(got).To(Equal(tt.expectURL))
-			if tt.expectErr {
-				g.Expect(err).To(HaveOccurred())
-			} else {
-				g.Expect(err).ToNot(HaveOccurred())
-			}
+			g.Expect(IsOwnedByRevisionWithRemoteControlPlane(cl, obj)).To(Equal(tt.expected))
 		})
 	}
 }
 
 func newFakeClientBuilder() *fake.ClientBuilder {
-	return fake.NewClientBuilder().
-		WithScheme(scheme.Scheme)
-}
-
-func generateSelfSignedCert(dnsNames ...string) (certPEM []byte, keyPEM []byte, err error) {
-	// Generate a private key
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Create a template for the certificate
-	template := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			Organization: []string{"test"},
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(365 * 24 * time.Hour), // 1 year
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-		DNSNames:              dnsNames,
-	}
-
-	// Generate a self-signed certificate
-	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Encode the certificate and key to PEM format
-	certPEM = pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: certDER,
-	})
-	keyDER, err := x509.MarshalECPrivateKey(privateKey)
-	if err != nil {
-		return nil, nil, err
-	}
-	keyPEM = pem.EncodeToMemory(&pem.Block{
-		Type:  "EC PRIVATE KEY",
-		Bytes: keyDER,
-	})
-
-	return certPEM, keyPEM, nil
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme)
 }
 
 func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	k8s.io/apimachinery v0.36.4
 	k8s.io/cli-runtime v0.36.0
 	k8s.io/client-go v0.36.4
+	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -178,7 +179,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260821135717-be32def86098 // indirect
 	k8s.io/kubectl v0.36.0 // indirect
 	k8s.io/streaming v0.36.4 // indirect
-	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/controller-tools v0.14.0 // indirect

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -64,21 +64,13 @@ const (
 	// ManagedByLabelValue is the ManagedByKey label value the operator sets on all objects it creates
 	ManagedByLabelValue = "sail-operator"
 
-	// WebhookReadinessProbeStatusAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
+	// WebhookReadinessStatusAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
 	// reports whether the remote control plane is ready or not
-	WebhookReadinessProbeStatusAnnotationKey = MetadataNamespace + "/readinessProbe.status"
+	WebhookReadinessStatusAnnotationKey = MetadataNamespace + "/readiness.status"
 
-	// WebhookReadinessProbeStatusReasonAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
+	// WebhookReadinessReasonAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
 	// reports why the remote control plane is not ready
-	WebhookReadinessProbeStatusReasonAnnotationKey = MetadataNamespace + "/readinessProbe.reason"
-
-	// WebhookReadinessProbePeriodSecondsAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
-	// specifies the period for the readiness probe
-	WebhookReadinessProbePeriodSecondsAnnotationKey = MetadataNamespace + "/readinessProbe.periodSeconds"
-
-	// WebhookReadinessProbeTimeoutSecondsAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
-	// specifies the timeout for the readiness probe
-	WebhookReadinessProbeTimeoutSecondsAnnotationKey = MetadataNamespace + "/readinessProbe.timeoutSeconds"
+	WebhookReadinessReasonAnnotationKey = MetadataNamespace + "/readiness.reason"
 
 	// IstioInjectionLabel is the label that is used to configure injection for the 'default' IstioRevision
 	IstioInjectionLabel = "istio-injection"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -64,21 +64,18 @@ const (
 	// ManagedByLabelValue is the ManagedByKey label value the operator sets on all objects it creates
 	ManagedByLabelValue = "sail-operator"
 
-	// WebhookReadinessProbeStatusAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
+	// WebhookReadinessStatusAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
 	// reports whether the remote control plane is ready or not
-	WebhookReadinessProbeStatusAnnotationKey = MetadataNamespace + "/readinessProbe.status"
+	WebhookReadinessStatusAnnotationKey = MetadataNamespace + "/readiness.status"
 
-	// WebhookReadinessProbeStatusReasonAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
+	// WebhookReadinessReasonAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
 	// reports why the remote control plane is not ready
-	WebhookReadinessProbeStatusReasonAnnotationKey = MetadataNamespace + "/readinessProbe.reason"
+	WebhookReadinessReasonAnnotationKey = MetadataNamespace + "/readiness.reason"
 
-	// WebhookReadinessProbePeriodSecondsAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
-	// specifies the period for the readiness probe
-	WebhookReadinessProbePeriodSecondsAnnotationKey = MetadataNamespace + "/readinessProbe.periodSeconds"
-
-	// WebhookReadinessProbeTimeoutSecondsAnnotationKey is an annotation on the istio-sidecar-injection MutatingWebhookConfiguration that
-	// specifies the timeout for the readiness probe
-	WebhookReadinessProbeTimeoutSecondsAnnotationKey = MetadataNamespace + "/readinessProbe.timeoutSeconds"
+	// WebhookDegradedWindowAnnotationKey is an annotation that can be set on a MutatingWebhookConfiguration to
+	// override, for that webhook only, how long it stays not-ready after a call failure. The value must be
+	// parseable by time.ParseDuration. Falls back to the operator-wide default when absent or invalid.
+	WebhookDegradedWindowAnnotationKey = MetadataNamespace + "/webhook-degraded-window"
 
 	// IstioInjectionLabel is the label that is used to configure injection for the 'default' IstioRevision
 	IstioInjectionLabel = "istio-injection"

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -17,6 +17,7 @@ package env
 import (
 	"os"
 	"strconv"
+	"time"
 )
 
 func Get(key, defaultValue string) string {
@@ -43,4 +44,13 @@ func GetInt(key string, defaultValue int) int {
 		return defaultValue
 	}
 	return intValue
+}
+
+func GetDuration(key string, defaultValue time.Duration) time.Duration {
+	value := Get(key, defaultValue.String())
+	durationValue, err := time.ParseDuration(value)
+	if err != nil {
+		return defaultValue
+	}
+	return durationValue
 }

--- a/tests/e2e/operator/webhook_event_test.go
+++ b/tests/e2e/operator/webhook_event_test.go
@@ -1,0 +1,162 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"time"
+
+	"github.com/istio-ecosystem/sail-operator/controllers/webhook"
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Webhook failure event detection", Label("operator", "webhook-event"), Ordered, func() {
+	SetDefaultEventuallyTimeout(120 * time.Second)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	const (
+		testNS            = "webhook-event-test"
+		webhookName       = "test-webhook.sail-operator.io"
+		webhookCfgName    = "test-webhook-cfg"
+		triggerDeployment = "test-trigger"
+	)
+
+	BeforeAll(func(ctx SpecContext) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNS}}
+		Expect(cl.Create(ctx, ns)).To(Succeed())
+		Log("Created test namespace", testNS)
+
+		DeferCleanup(func(ctx SpecContext) {
+			// Delete webhook config first to avoid blocking namespace deletion
+			whCfg := &admissionv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: webhookCfgName}}
+			_ = cl.Delete(ctx, whCfg)
+
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNS}}
+			_ = cl.Delete(ctx, ns)
+		})
+	})
+
+	It("generates a real webhook failure event that matches our extraction code", func(ctx SpecContext) {
+		sideEffects := admissionv1.SideEffectClassNone
+		failPolicy := admissionv1.Fail
+
+		whCfg := &admissionv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: webhookCfgName},
+			Webhooks: []admissionv1.MutatingWebhook{{
+				Name:                    webhookName,
+				AdmissionReviewVersions: []string{"v1"},
+				SideEffects:             &sideEffects,
+				FailurePolicy:           &failPolicy,
+				ClientConfig: admissionv1.WebhookClientConfig{
+					Service: &admissionv1.ServiceReference{
+						Name:      "nonexistent-service",
+						Namespace: testNS,
+						Path:      strPtr("/inject"),
+					},
+				},
+				Rules: []admissionv1.RuleWithOperations{{
+					Operations: []admissionv1.OperationType{admissionv1.Create},
+					Rule: admissionv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+					},
+				}},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"webhook-event-test": "true"},
+				},
+			}},
+		}
+
+		Expect(cl.Create(ctx, whCfg)).To(Succeed())
+		Success("Created MutatingWebhookConfiguration pointing to non-existent service")
+
+		// Label the namespace to match the webhook's namespaceSelector
+		ns := &corev1.Namespace{}
+		Expect(cl.Get(ctx, client.ObjectKey{Name: testNS}, ns)).To(Succeed())
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		ns.Labels["webhook-event-test"] = "true"
+		Expect(cl.Update(ctx, ns)).To(Succeed())
+
+		// Create a Deployment to trigger the webhook failure
+		replicas := int32(1)
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      triggerDeployment,
+				Namespace: testNS,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "test-trigger"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "test-trigger"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:    "busybox",
+							Image:   "busybox:latest",
+							Command: []string{"sleep", "3600"},
+						}},
+					},
+				},
+			},
+		}
+
+		Expect(cl.Create(ctx, deploy)).To(Succeed())
+		Success("Created Deployment to trigger webhook failure events")
+
+		// Wait for a Warning event containing "failed calling webhook" to appear.
+		// The ReplicaSet controller generates this when pod creation fails due to an unreachable webhook.
+		var matchedEvent *corev1.Event
+		Eventually(func(g Gomega) {
+			events := &corev1.EventList{}
+			g.Expect(cl.List(ctx, events, client.InNamespace(testNS))).To(Succeed())
+
+			for i := range events.Items {
+				evt := &events.Items[i]
+				if evt.Type == corev1.EventTypeWarning && webhook.ExtractWebhookName(evt.Message) != "" {
+					matchedEvent = evt
+					return
+				}
+			}
+			g.Expect(matchedEvent).NotTo(BeNil(), "no webhook failure event found yet")
+		}).Should(Succeed())
+
+		Log("Found webhook failure event:", matchedEvent.Message)
+
+		// Verify our extraction code correctly parses the real event
+		extractedName := webhook.ExtractWebhookName(matchedEvent.Message)
+		Expect(extractedName).To(Equal(webhookName),
+			"ExtractWebhookName should extract the webhook name from the real Kubernetes event")
+		Success("Extraction code correctly matched real Kubernetes webhook failure event")
+	})
+})
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/tests/e2e/operator/webhook_event_test.go
+++ b/tests/e2e/operator/webhook_event_test.go
@@ -1,0 +1,349 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"strings"
+	"time"
+
+	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/controllers/webhook"
+	"github.com/istio-ecosystem/sail-operator/pkg/constants"
+	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
+	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Webhook failure event detection", Label("operator", "webhook-event"), Ordered, func() {
+	SetDefaultEventuallyTimeout(120 * time.Second)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	const (
+		testNS            = "webhook-event-test"
+		webhookName       = "test-webhook.sail-operator.io"
+		webhookCfgName    = "test-webhook-cfg"
+		triggerDeployment = "test-trigger"
+	)
+
+	BeforeAll(func(ctx SpecContext) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNS}}
+		Expect(cl.Create(ctx, ns)).To(Succeed())
+		Log("Created test namespace", testNS)
+
+		DeferCleanup(func(ctx SpecContext) {
+			// Delete webhook config first to avoid blocking namespace deletion
+			whCfg := &admissionv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: webhookCfgName}}
+			_ = cl.Delete(ctx, whCfg)
+
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNS}}
+			_ = cl.Delete(ctx, ns)
+		})
+	})
+
+	It("generates a real webhook failure event that matches our extraction code", func(ctx SpecContext) {
+		sideEffects := admissionv1.SideEffectClassNone
+		failPolicy := admissionv1.Fail
+
+		whCfg := &admissionv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: webhookCfgName},
+			Webhooks: []admissionv1.MutatingWebhook{{
+				Name:                    webhookName,
+				AdmissionReviewVersions: []string{"v1"},
+				SideEffects:             &sideEffects,
+				FailurePolicy:           &failPolicy,
+				ClientConfig: admissionv1.WebhookClientConfig{
+					Service: &admissionv1.ServiceReference{
+						Name:      "nonexistent-service",
+						Namespace: testNS,
+						Path:      ptr.To("/inject"),
+					},
+				},
+				Rules: []admissionv1.RuleWithOperations{{
+					Operations: []admissionv1.OperationType{admissionv1.Create},
+					Rule: admissionv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+					},
+				}},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"webhook-event-test": "true"},
+				},
+			}},
+		}
+
+		Expect(cl.Create(ctx, whCfg)).To(Succeed())
+		Success("Created MutatingWebhookConfiguration pointing to non-existent service")
+
+		// Label the namespace to match the webhook's namespaceSelector
+		ns := &corev1.Namespace{}
+		Expect(cl.Get(ctx, client.ObjectKey{Name: testNS}, ns)).To(Succeed())
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		ns.Labels["webhook-event-test"] = "true"
+		Expect(cl.Update(ctx, ns)).To(Succeed())
+
+		// Create a Deployment to trigger the webhook failure
+		replicas := int32(1)
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      triggerDeployment,
+				Namespace: testNS,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "test-trigger"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "test-trigger"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:    "busybox",
+							Image:   "busybox:latest",
+							Command: []string{"sleep", "3600"},
+						}},
+					},
+				},
+			},
+		}
+
+		Expect(cl.Create(ctx, deploy)).To(Succeed())
+		Success("Created Deployment to trigger webhook failure events")
+
+		// Wait for a Warning event containing "failed calling webhook" to appear.
+		// The ReplicaSet controller generates this when pod creation fails due to an unreachable webhook.
+		var matchedEvent *corev1.Event
+		Eventually(func(g Gomega) {
+			events := &corev1.EventList{}
+			g.Expect(cl.List(ctx, events, client.InNamespace(testNS))).To(Succeed())
+
+			for i := range events.Items {
+				evt := &events.Items[i]
+				if evt.Type == corev1.EventTypeWarning && webhook.ExtractWebhookName(evt.Message) != "" {
+					matchedEvent = evt
+					return
+				}
+			}
+			g.Expect(matchedEvent).NotTo(BeNil(), "no webhook failure event found yet")
+		}).Should(Succeed())
+
+		Log("Found webhook failure event:", matchedEvent.Message)
+
+		// Verify our extraction code correctly parses the real event
+		extractedName := webhook.ExtractWebhookName(matchedEvent.Message)
+		Expect(extractedName).To(Equal(webhookName),
+			"ExtractWebhookName should extract the webhook name from the real Kubernetes event")
+		Success("Extraction code correctly matched real Kubernetes webhook failure event")
+	})
+})
+
+var _ = Describe("Remote istiod webhook (DNS-based URL) failure detection", Label("operator", "webhook-remote-url"), Ordered, func() {
+	SetDefaultEventuallyTimeout(120 * time.Second)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	const (
+		testNS  = "webhook-remote-url-test"
+		revName = "remote-url-test-rev"
+		// Must equal injectionWebhookKey(rev), or the revision's Ready check won't find this config.
+		webhookCfgName    = "istio-sidecar-injector-" + testNS
+		webhookName       = "sidecar-injector.istio.io"
+		triggerDeployment = "test-trigger-url"
+	)
+	// Points at a service that does not exist, so every webhook call fails.
+	webhookURL := "https://istiod-remote." + testNS + ".svc:15017/mutate-istio.io"
+
+	BeforeAll(func(ctx SpecContext) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNS, Labels: map[string]string{testNS: "true"}}}
+		Expect(cl.Create(ctx, ns)).To(Succeed())
+		Log("Created test namespace", testNS)
+
+		istio := &v1.Istio{
+			ObjectMeta: metav1.ObjectMeta{Name: revName},
+			Spec: v1.IstioSpec{
+				Version:   istioversion.Default,
+				Namespace: testNS,
+				Profile:   "remote",
+				Values: &v1.Values{
+					Global: &v1.GlobalConfig{
+						// So the istio chart does not create a conflicting MutatingWebhookConfiguration.
+						OperatorManageWebhooks: ptr.To(true),
+					},
+				},
+			},
+		}
+		Expect(cl.Create(ctx, istio)).To(Succeed())
+		Log("Created remote-profile Istio", revName)
+
+		// The Istio's InPlace update strategy names the IstioRevision it creates after the Istio itself.
+		rev := &v1.IstioRevision{}
+		Eventually(func(g Gomega) {
+			g.Expect(cl.Get(ctx, client.ObjectKey{Name: revName}, rev)).To(Succeed())
+		}).Should(Succeed())
+		Log("IstioRevision created for remote-profile Istio", revName)
+
+		sideEffects := admissionv1.SideEffectClassNone
+		failPolicy := admissionv1.Fail
+		whCfg := &admissionv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: webhookCfgName,
+				// Shortens the degraded window for this webhook only, so the recovery step is fast.
+				Annotations: map[string]string{constants.WebhookDegradedWindowAnnotationKey: "10s"},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         v1.GroupVersion.String(),
+					Kind:               v1.IstioRevisionKind,
+					Name:               revName,
+					UID:                rev.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				}},
+			},
+			Webhooks: []admissionv1.MutatingWebhook{{
+				Name:                    webhookName,
+				AdmissionReviewVersions: []string{"v1"},
+				SideEffects:             &sideEffects,
+				FailurePolicy:           &failPolicy,
+				ClientConfig: admissionv1.WebhookClientConfig{
+					URL:      ptr.To(webhookURL),
+					CABundle: []byte("test-ca-bundle"),
+				},
+				Rules: []admissionv1.RuleWithOperations{{
+					Operations: []admissionv1.OperationType{admissionv1.Create},
+					Rule: admissionv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+					},
+				}},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{testNS: "true"},
+				},
+			}},
+		}
+		Expect(cl.Create(ctx, whCfg)).To(Succeed())
+		Success("Created MutatingWebhookConfiguration with a DNS-based URL, owned by the remote IstioRevision")
+
+		DeferCleanup(func(ctx SpecContext) {
+			whCfg := &admissionv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: webhookCfgName}}
+			_ = cl.Delete(ctx, whCfg)
+			istio := &v1.Istio{ObjectMeta: metav1.ObjectMeta{Name: revName}}
+			_ = cl.Delete(ctx, istio)
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNS}}
+			_ = cl.Delete(ctx, ns)
+		})
+	})
+
+	It("marks the webhook ready when a DNS-based URL and caBundle are configured", func(ctx SpecContext) {
+		Eventually(func(g Gomega) {
+			whCfg := &admissionv1.MutatingWebhookConfiguration{}
+			g.Expect(cl.Get(ctx, client.ObjectKey{Name: webhookCfgName}, whCfg)).To(Succeed())
+			g.Expect(whCfg.Annotations[constants.WebhookReadinessStatusAnnotationKey]).To(Equal("true"),
+				"webhook with a DNS-based URL and caBundle should be ready")
+		}).Should(Succeed())
+		Success("Webhook with DNS-based URL marked ready")
+	})
+
+	It("detects a webhook call failure from a cluster event and marks it not ready", func(ctx SpecContext) {
+		var ns corev1.Namespace
+		if err := cl.Get(ctx, client.ObjectKey{Name: testNS}, &ns); err != nil {
+			Log("Namespace", testNS, "could not be re-fetched at the start of this spec:", err)
+			events := &corev1.EventList{}
+			_ = cl.List(ctx, events)
+			for i := range events.Items {
+				e := &events.Items[i]
+				if e.InvolvedObject.Name == testNS || strings.Contains(e.Message, testNS) {
+					Log("Related event:", e.LastTimestamp, e.Reason, e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Message)
+				}
+			}
+			common.LogDebugInfo(common.Operator, k)
+		}
+
+		replicas := int32(1)
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      triggerDeployment,
+				Namespace: testNS,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": triggerDeployment},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": triggerDeployment},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:    "busybox",
+							Image:   "busybox:latest",
+							Command: []string{"sleep", "3600"},
+						}},
+					},
+				},
+			},
+		}
+		Expect(cl.Create(ctx, deploy)).To(Succeed())
+		Success("Created Deployment to trigger webhook call failures")
+
+		Eventually(func(g Gomega) {
+			whCfg := &admissionv1.MutatingWebhookConfiguration{}
+			g.Expect(cl.Get(ctx, client.ObjectKey{Name: webhookCfgName}, whCfg)).To(Succeed())
+			g.Expect(whCfg.Annotations[constants.WebhookReadinessStatusAnnotationKey]).To(Equal("false"),
+				"webhook should be marked not ready after a call failure")
+			g.Expect(whCfg.Annotations[constants.WebhookReadinessReasonAnnotationKey]).To(
+				Equal("webhook call failures reported in cluster events"))
+		}).Should(Succeed())
+		Success("Webhook marked not ready after a call failure detected from a cluster event")
+
+		Eventually(func(g Gomega) {
+			rev := &v1.IstioRevision{}
+			g.Expect(cl.Get(ctx, client.ObjectKey{Name: revName}, rev)).To(Succeed())
+			cond := rev.Status.GetCondition(v1.IstioRevisionConditionReady)
+			g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(cond.Reason).To(Equal(v1.IstioRevisionReasonRemoteIstiodNotReady))
+		}).Should(Succeed())
+		Success("Remote IstioRevision reports Ready=False (RemoteIstiodNotReady)")
+	})
+
+	It("recovers to ready after the degraded window expires", func(ctx SpecContext) {
+		// Delete the Deployment first: while it is stuck, each re-attempted pod creation
+		// re-records the failure (via the event count-increment update), resetting the window.
+		deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: triggerDeployment, Namespace: testNS}}
+		Expect(cl.Delete(ctx, deploy)).To(Succeed())
+		Success("Deleted the trigger Deployment to stop new failure events")
+
+		Eventually(func(g Gomega) {
+			whCfg := &admissionv1.MutatingWebhookConfiguration{}
+			g.Expect(cl.Get(ctx, client.ObjectKey{Name: webhookCfgName}, whCfg)).To(Succeed())
+			g.Expect(whCfg.Annotations[constants.WebhookReadinessStatusAnnotationKey]).To(Equal("true"),
+				"webhook should recover to ready after the degraded window expires")
+		}).WithTimeout(60 * time.Second).Should(Succeed())
+		Success("Webhook recovered to ready after the degraded window expired")
+	})
+})


### PR DESCRIPTION
Instead of manually probing the webhook endpoints to determine readiness and health, we should rely on the API server as it is already doing that for us. This rewrite now uses the events emitted by the API server to detect failing webhook endpoints.