### PR TITLE
test: handle concurrent secret deletion during Helm chart uninstall to fix Test Library flaky test

### DIFF
--- a/pkg/helm/chartmanager.go
+++ b/pkg/helm/chartmanager.go
@@ -29,6 +29,7 @@ import (
 	releasecommon "helm.sh/helm/v4/pkg/release/common"
 	releasev1 "helm.sh/helm/v4/pkg/release/v1"
 	"helm.sh/helm/v4/pkg/storage/driver"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
@@ -211,7 +212,17 @@ func (h *ChartManager) UninstallChart(ctx context.Context, releaseName, namespac
 
 	uninstallAction := action.NewUninstall(cfg)
 	uninstallAction.WaitStrategy = kube.HookOnlyStrategy
-	return uninstallAction.Run(releaseName)
+	resp, err := uninstallAction.Run(releaseName)
+	if err != nil {
+		var statusErr *apierrors.StatusError
+		if errors.As(err, &statusErr) && apierrors.IsNotFound(statusErr) {
+			// The release secret was deleted concurrently (e.g. namespace teardown racing
+			// with Helm's purge step). The release is gone regardless; treat as success.
+			return resp, nil
+		}
+		return nil, err
+	}
+	return resp, nil
 }
 
 func getRelease(cfg *action.Configuration, releaseName string) (release.Releaser, error) {

--- a/tests/e2e/library/library_reconcile_test.go
+++ b/tests/e2e/library/library_reconcile_test.go
@@ -18,7 +18,6 @@ package library
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -33,7 +32,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
-	"helm.sh/helm/v4/pkg/storage/driver"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -85,14 +83,7 @@ var _ = Describe("Library Reconciliation", Label("library", "reconciliation"), O
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				// lib.Uninstall may race with Helm's internal purge step: after finding
-				// the release, the secret can be deleted concurrently before Helm purges
-				// it, producing a spurious ErrReleaseNotFound. EnsureNamespaceWithCleanup
-				// deletes the namespace afterward regardless, so no state is left behind.
-				// Any other error is unexpected and must be reported.
-				if err := lib.Uninstall(ctx, namespace, revision); err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
-					Expect(err).NotTo(HaveOccurred(), "unexpected error uninstalling Helm chart")
-				}
+				Expect(lib.Uninstall(ctx, namespace, revision)).To(Succeed())
 				lib.Stop()
 				Success("Cleaned up TLS test")
 			})
@@ -197,14 +188,7 @@ var _ = Describe("Library Reconciliation", Label("library", "reconciliation"), O
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				// lib.Uninstall may race with Helm's internal purge step: after finding
-				// the release, the secret can be deleted concurrently before Helm purges
-				// it, producing a spurious ErrReleaseNotFound. EnsureNamespaceWithCleanup
-				// deletes the namespace afterward regardless, so no state is left behind.
-				// Any other error is unexpected and must be reported.
-				if err := lib.Uninstall(ctx, namespace, revision); err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
-					Expect(err).NotTo(HaveOccurred(), "unexpected error uninstalling Helm chart")
-				}
+				Expect(lib.Uninstall(ctx, namespace, revision)).To(Succeed())
 				lib.Stop()
 				Success("Cleaned up reconcile loop test")
 			})


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
The library e2e test was flaking with:
```
  unexpected error uninstalling Helm chart
  secrets "sh.helm.release.v1.tlstest-istiod.v1" not found
```

This is a race condition: EnsureNamespaceWithCleanup deletes the test namespace concurrently with lib.Uninstall. Helm's uninstall action finds the release, but by the time it tries to purge the release secret, the secret has already been swept by the namespace deletion, returning a Kubernetes 404.

The fix:
* After `uninstallAction.Run`, use `errors.As` to detect a Kubernetes NotFound status error. If the only failure was the release secret being concurrently deleted, treat the uninstall as successful; the release is gone regardless.
* Remove the now unnecessary workaround in the two DeferCleanup blocks (TLS and loop tests) and simplify them to `Expect(lib.Uninstall(...)).To(Succeed())`. Remove unused errors and driver imports


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
