### PR TITLE
test: add kubectl utils func for ocp test related

### DIFF
--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -440,28 +440,6 @@ func getKustomizeDir(appName string) string {
 	return filepath.Join(project.RootDir, "tests", "e2e", "samples", appName)
 }
 
-func (k Kubectl) Rollout(action, kind, name string) error {
-	var subcmd string
-
-	switch action {
-	case "restart":
-		subcmd = fmt.Sprintf(" rollout restart %s/%s", kind, name)
-	case "status":
-		subcmd = fmt.Sprintf(" rollout status %s/%s --timeout=300s", kind, name)
-	default:
-		return fmt.Errorf("unsupported rollout action: %s", action)
-	}
-
-	cmd := k.build(subcmd)
-
-	_, err := shell.ExecuteShell(cmd, "")
-	if err != nil {
-		return fmt.Errorf("rollout %s failed: %w", action, err)
-	}
-
-	return nil
-}
-
 // ApplyStringWithForceConflicts applies yaml using server-side apply and forces conflicts
 func (k Kubectl) ApplyStringWithForceConflicts(yamlString string) error {
 	cmd := k.build(" apply --server-side --force-conflicts -f -")

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -6,11 +6,11 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR Condition OF ANY KIND, either express or implied.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
@@ -25,6 +25,7 @@ import (
 
 	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/shell"
+	"github.com/onsi/gomega"
 )
 
 type Kubectl struct {
@@ -279,14 +280,34 @@ func (k Kubectl) GetSecret(secret string) (string, error) {
 	return output, nil
 }
 
-// Exec executes a command in the pod or specific container
+// Exec executes a command in the pod or specific container, retrying on transient WebSocket close
+// 1006 errors that occur on ARM64/Graviton2 when SPIRE ECDSA mTLS handshakes are slow.
 func (k Kubectl) Exec(pod, container, command string) (string, error) {
 	cmd := k.build(fmt.Sprintf(" exec %s %s -- %s", pod, containerFlag(container), command))
-	output, err := k.executeCommand(cmd)
-	if err != nil {
-		return "", err
+
+	var output string
+	var execErr error
+	// Noop fail handler: propagate the error to the caller rather than failing the test on timeout.
+	g := gomega.NewGomega(func(string, ...int) {})
+	g.Eventually(func() error {
+		output, execErr = k.executeCommand(cmd)
+		if isWebSocketCloseError(execErr) {
+			return execErr // keep retrying on transient WebSocket drops
+		}
+		return nil // success or non-retryable error — stop
+	}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+
+	return output, execErr
+}
+
+// isWebSocketCloseError returns true for WebSocket close 1006 (abnormal closure) errors.
+func isWebSocketCloseError(err error) bool {
+	if err == nil {
+		return false
 	}
-	return output, nil
+	msg := err.Error()
+	return strings.Contains(msg, "websocket: close 1006") ||
+		strings.Contains(msg, "abnormal closure")
 }
 
 // GetEvents returns the events of a namespace
@@ -404,7 +425,7 @@ func containerFlag(container string) string {
 // The path is determined with the following priority:
 // 1. App-specific environment variable (e.g., HTTPBIN_KUSTOMIZE_PATH).
 // 2. Custom base path defined in CUSTOM_SAMPLES_PATH.
-// 3. Default path within the project in this case will be: `tests/e2e/samples/httpbin“.
+// 3. Default path within the project in this case will be: `tests/e2e/samples/httpbin`.
 func getKustomizeDir(appName string) string {
 	// If app specific environment variable is set, use it.
 	if customPath := os.Getenv(strings.ToUpper(strings.ReplaceAll(appName, "-", "_") + "_KUSTOMIZE_PATH")); customPath != "" {
@@ -417,4 +438,36 @@ func getKustomizeDir(appName string) string {
 	}
 
 	return filepath.Join(project.RootDir, "tests", "e2e", "samples", appName)
+}
+
+func (k Kubectl) Rollout(action, kind, name string) error {
+	var subcmd string
+
+	switch action {
+	case "restart":
+		subcmd = fmt.Sprintf(" rollout restart %s/%s", kind, name)
+	case "status":
+		subcmd = fmt.Sprintf(" rollout status %s/%s --timeout=300s", kind, name)
+	default:
+		return fmt.Errorf("unsupported rollout action: %s", action)
+	}
+
+	cmd := k.build(subcmd)
+
+	_, err := shell.ExecuteShell(cmd, "")
+	if err != nil {
+		return fmt.Errorf("rollout %s failed: %w", action, err)
+	}
+
+	return nil
+}
+
+// ApplyStringWithForceConflicts applies yaml using server-side apply and forces conflicts
+func (k Kubectl) ApplyStringWithForceConflicts(yamlString string) error {
+	cmd := k.build(" apply --server-side --force-conflicts -f -")
+	_, err := shell.ExecuteCommandWithInput(cmd, yamlString)
+	if err != nil {
+		return fmt.Errorf("error applying yaml with force conflicts: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
This changes are needed to be able to run the test against OCP clusters

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
This PR adds to this repo changes that are done in the midstream repository to be able to execute test on the OCP cluster. There are basically functions added 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
