### PR TITLE
Fix race condition between install library reconciler and Uninstall

### DIFF
--- a/pkg/install/library.go
+++ b/pkg/install/library.go
@@ -33,6 +33,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -156,8 +158,9 @@ type Status struct {
 // Library manages the lifecycle of an istiod installation without
 // requiring the full Sail Operator to be deployed.
 type Library struct {
-	mu       sync.Mutex
-	statusMu sync.RWMutex
+	mu          sync.Mutex
+	lifecycleMu sync.Mutex
+	statusMu    sync.RWMutex
 
 	kubeConfig             *rest.Config
 	resourceFS             fs.FS
@@ -259,6 +262,8 @@ func (l *Library) Apply(opts Options) error {
 	if err := ValidateOptions(opts); err != nil {
 		return fmt.Errorf("invalid options: %w", err)
 	}
+	l.lifecycleMu.Lock()
+	defer l.lifecycleMu.Unlock()
 	l.mu.Lock()
 	if l.desiredOpts != nil && optionsEqual(*l.desiredOpts, opts) {
 		l.mu.Unlock()
@@ -302,17 +307,23 @@ func (l *Library) Status() Status {
 	return l.currentStatus
 }
 
-// Uninstall removes the istiod Helm release. It nils the desired state
-// first so that any in-flight reconciliation triggered by drift watches
-// will short-circuit. On success, the status is cleared so that Status()
-// reflects the uninstalled state and a subsequent Apply with the same
-// options will trigger a fresh installation.
+// Uninstall removes the istiod Helm release. It holds the lifecycle lock
+// so that Apply and the reconciliation loop cannot run concurrently,
+// preventing a race where an in-flight reconcile reinstalls istiod
+// immediately after the Helm uninstall completes.
+// On success, the status is cleared so that Status() reflects the
+// uninstalled state and a subsequent Apply with the same options will
+// trigger a fresh installation.
 func (l *Library) Uninstall(ctx context.Context, namespace, revision string) error {
+	l.lifecycleMu.Lock()
+	defer l.lifecycleMu.Unlock()
+
 	l.mu.Lock()
 	l.desiredOpts = nil
 	inst := l.newInstaller(namespace)
 	l.mu.Unlock()
 
+	log.Infof("Uninstalling: namespace=%s, revision=%s", namespace, revision)
 	if err := inst.uninstall(ctx, namespace, revision); err != nil {
 		return err
 	}
@@ -320,5 +331,6 @@ func (l *Library) Uninstall(ctx context.Context, namespace, revision string) err
 	l.statusMu.Lock()
 	l.currentStatus = Status{}
 	l.statusMu.Unlock()
+	log.Infof("Uninstall complete: namespace=%s, revision=%s", namespace, revision)
 	return nil
 }

--- a/pkg/install/reconciler.go
+++ b/pkg/install/reconciler.go
@@ -47,12 +47,14 @@ type libraryReconciler struct {
 }
 
 func (r *libraryReconciler) Reconcile(ctx context.Context, _ ctrlreconcile.Request) (ctrlreconcile.Result, error) {
+	r.lib.lifecycleMu.Lock()
 	r.lib.mu.Lock()
 	opts := r.lib.desiredOpts
 	gen := r.lib.generation
 	r.lib.mu.Unlock()
 
 	if opts == nil {
+		r.lib.lifecycleMu.Unlock()
 		return ctrlreconcile.Result{}, nil
 	}
 
@@ -61,9 +63,12 @@ func (r *libraryReconciler) Reconcile(ctx context.Context, _ ctrlreconcile.Reque
 		optsCopy.Values = optsCopy.Values.DeepCopy()
 	}
 
+	log.Info("Reconciling")
 	inst := r.lib.newInstaller(optsCopy.Namespace)
 	status := inst.reconcile(ctx, optsCopy)
 	status.Generation = gen
+	log.Infof("Reconcile complete: installed=%v, error=%v", status.Installed, status.Error)
+	r.lib.lifecycleMu.Unlock()
 
 	r.lib.statusMu.Lock()
 	r.lib.currentStatus = status


### PR DESCRIPTION
## Summary

The install library's `Uninstall()` can race with an in-flight `libraryReconciler.Reconcile()`, causing istiod to be reinstalled immediately after being uninstalled. Restores the `lifecycleMu` serialization that was removed in the 3.4 rewrite, and adds back `Reconciling`/`Reconcile complete`/`Uninstalling`/`Uninstall complete` log messages that were also lost.

## Root Cause

The 3.4 rewrite (https://github.com/istio-ecosystem/sail-operator/pull/1857) replaced the workqueue-based lifecycle (`lifecycle.go`) with a controller-runtime manager (`reconciler.go`). This removed the `lifecycleMu` mutex that previously serialized `Apply` and `Uninstall` with the reconciliation loop.

Without it, the following race occurs:

1. `libraryReconciler.Reconcile()` copies `desiredOpts` and starts a Helm install
2. The consumer calls `Uninstall()`, which nils `desiredOpts` and runs Helm uninstall
3. The in-flight reconciler finishes its Helm install **after** the uninstall, reinstalling istiod

```mermaid
sequenceDiagram
    participant R as libraryReconciler.Reconcile()
    participant U as Uninstall()
    participant H as Helm State

    R->>R: opts = desiredOpts (copied)
    R->>H: inst.reconcile(opts) starts...
    Note over R,H: Helm install in progress

    U->>U: desiredOpts = nil
    U->>H: inst.uninstall()
    H-->>U: istiod deleted
    U->>U: return nil (success)

    H-->>R: inst.reconcile(opts) finishes
    Note over R,H: istiod reinstalled!
```

The consumer sees a successful `Uninstall()` return, but istiod is still running.

The previous implementation in `lifecycle.go` prevented this with `lifecycleMu`, which serialized `Apply`, `Uninstall`, and the processing loop. It also stopped informers and drained the work queue before running the Helm uninstall.

**Previous implementation (release-3.3):**
- [`lifecycleMu` field](https://github.com/openshift-service-mesh/sail-operator/blob/release-3.3/pkg/install/library.go#L198)
- [`Apply` lock](https://github.com/openshift-service-mesh/sail-operator/blob/release-3.3/pkg/install/lifecycle.go#L63-L64)
- [`Uninstall` lock + informer drain](https://github.com/openshift-service-mesh/sail-operator/blob/release-3.3/pkg/install/lifecycle.go#L132-L168)
- [Reconcile/Uninstall log messages](https://github.com/openshift-service-mesh/sail-operator/blob/release-3.3/pkg/install/lifecycle.go#L246-L249)

## Fix

Restore `lifecycleMu` on the `Library` struct. Hold it in:
- `Apply()` — while setting `desiredOpts` and sending the trigger
- `Uninstall()` — across the entire Helm uninstall
- `libraryReconciler.Reconcile()` — across the Helm reconcile

This ensures `Uninstall` cannot run while a reconcile is in progress, and vice versa.

## Reproduction

Rapidly creating and deleting a GatewayClass while the library's reconciler is mid-install consistently reproduces the race. In OpenShift CI, the failure manifested as a flaky test where istiod pods remained after GatewayClass deletion, with the Helm release secret still present. This caused the 3.4 vendor bump to be reverted: https://github.com/openshift/cluster-ingress-operator/pull/1507

Confirmed via debug logging:
```
libraryReconciler.Reconcile: starting Helm reconcile     ← reconciler grabs opts, starts install
Library.Uninstall: starting Helm uninstall               ← CIO calls Uninstall, nils desiredOpts
libraryReconciler.Reconcile: finished Helm reconcile     ← reconciler finishes AFTER, reinstalls
```