### PR TITLE
Enable native nftables by default on OpenShift

### DIFF
--- a/docs/common/istio-nftables.adoc
+++ b/docs/common/istio-nftables.adoc
@@ -33,11 +33,14 @@ Many major Linux distributions are actively moving towards adopting native nftab
 === Installation
 
 The support for native nftables in Istio sidecar mode was implemented in the upstream istio https://istio.io/latest/news/releases/1.27.x/announcing-1.27[release-1.27].
-It is disabled by default. To enable it, you can set a feature flag as `+values.global.nativeNftables=true+`.
+On Kubernetes platforms other than OpenShift, it is disabled by default. To enable it, set `+values.global.nativeNftables=true+`.
+
+On OpenShift, the Sail Operator automatically sets `+global.nativeNftables=true+` for both `+Istio+` and `+IstioCNI+` resources.
+If you explicitly set `+spec.values.global.nativeNftables=false+`, that value is honored and overrides the OpenShift default.
 
 ==== Install in Sidecar Mode
 
-When installing `Istio` and `IstioCNI` resources with the Sail Operator, you can enable nftables by setting `spec.values.global.nativeNftables=true` in the resource. This option configures Istio to use the nftables backend for traffic redirection instead of iptables.
+When installing `Istio` and `IstioCNI` resources with the Sail Operator on non-OpenShift platforms, you can enable nftables by setting `spec.values.global.nativeNftables=true` in the resource. This option configures Istio to use the nftables backend for traffic redirection instead of iptables. On OpenShift, this setting is applied automatically unless you override it.
 
 . Create the `+istio-system+` and `+istio-cni+` namespaces.
 
@@ -89,7 +92,9 @@ EOF
 ==== Install in Ambient Mode
 
 The support for native nftables in Istio ambient mode was implemented in the upstream istio https://istio.io/latest/news/releases/1.28.x/announcing-1.28[release-1.28].
-To enable native nftables in ambient mode, you can set the same feature flag with ambient profile. For example,
+To enable native nftables in ambient mode on non-OpenShift platforms, set the same feature flag with the ambient profile.
+On OpenShift, the operator enables native nftables automatically for `+Istio+` and `+IstioCNI+` even when you select the ambient profile.
+For example,
 
 . Create the `+istio-system+`, `+istio-cni+` and `+ztunnel+` namespaces.
 

--- a/pkg/istiovalues/profiles.go
+++ b/pkg/istiovalues/profiles.go
@@ -46,6 +46,12 @@ func ApplyProfilesAndPlatform(
 			return nil, fmt.Errorf("failed to set global.platform: %w", err)
 		}
 	}
+	// On OpenShift, default to native nftables unless the user explicitly sets the flag.
+	if platform == config.PlatformOpenShift {
+		if err = values.SetIfAbsent("global.nativeNftables", true); err != nil {
+			return nil, fmt.Errorf("failed to set global.nativeNftables: %w", err)
+		}
+	}
 	return values, nil
 }
 

--- a/pkg/istiovalues/profiles_test.go
+++ b/pkg/istiovalues/profiles_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/helm"
 	. "github.com/onsi/gomega"
 )
@@ -251,6 +252,111 @@ func TestResolve(t *testing.T) {
 		t.Run("default:"+tc.dflt+",user:"+tc.user, func(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(resolve(tc.dflt, tc.user)).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestApplyProfilesAndPlatformNativeNftables(t *testing.T) {
+	const version = "my-version"
+	resourceDir := t.TempDir()
+	profilesDir := path.Join(resourceDir, version, "profiles")
+	Must(t, os.MkdirAll(profilesDir, 0o755))
+
+	Must(t, os.WriteFile(path.Join(profilesDir, "default.yaml"), []byte(`
+apiVersion: sailoperator.io/v1
+kind: IstioProfile
+spec:
+  values: {}
+`), 0o644))
+	Must(t, os.WriteFile(path.Join(profilesDir, "openshift.yaml"), []byte(`
+apiVersion: sailoperator.io/v1
+kind: IstioProfile
+spec:
+  values:
+    global:
+      platform: openshift
+`), 0o644))
+	Must(t, os.WriteFile(path.Join(profilesDir, "ambient.yaml"), []byte(`
+apiVersion: sailoperator.io/v1
+kind: IstioProfile
+spec:
+  values:
+    profile: ambient
+`), 0o644))
+
+	resourceFS := os.DirFS(resourceDir)
+	tests := []struct {
+		name                 string
+		platform             config.Platform
+		defaultProfile       string
+		userProfile          string
+		userValues           helm.Values
+		expectNativeNftables any
+		expectFound          bool
+	}{
+		{
+			name:                 "openshift unset defaults to true",
+			platform:             config.PlatformOpenShift,
+			defaultProfile:       "openshift",
+			userValues:           helm.Values{},
+			expectNativeNftables: true,
+			expectFound:          true,
+		},
+		{
+			name:           "openshift explicit false is honored",
+			platform:       config.PlatformOpenShift,
+			defaultProfile: "openshift",
+			userValues: helm.Values{
+				"global": map[string]any{
+					"nativeNftables": false,
+				},
+			},
+			expectNativeNftables: false,
+			expectFound:          true,
+		},
+		{
+			name:           "openshift explicit true is honored",
+			platform:       config.PlatformOpenShift,
+			defaultProfile: "openshift",
+			userValues: helm.Values{
+				"global": map[string]any{
+					"nativeNftables": true,
+				},
+			},
+			expectNativeNftables: true,
+			expectFound:          true,
+		},
+		{
+			name:           "kubernetes unset does not set nativeNftables",
+			platform:       config.PlatformKubernetes,
+			defaultProfile: "default",
+			userValues:     helm.Values{},
+			expectFound:    false,
+		},
+		{
+			name:                 "openshift with ambient profile still defaults to true",
+			platform:             config.PlatformOpenShift,
+			defaultProfile:       "openshift",
+			userProfile:          "ambient",
+			userValues:           helm.Values{},
+			expectNativeNftables: true,
+			expectFound:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			values, err := ApplyProfilesAndPlatform(
+				resourceFS, version, tt.platform, tt.defaultProfile, tt.userProfile, tt.userValues)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			got, found, err := values.GetBool("global.nativeNftables")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(found).To(Equal(tt.expectFound))
+			if tt.expectFound {
+				g.Expect(got).To(Equal(tt.expectNativeNftables))
+			}
 		})
 	}
 }

--- a/pkg/revision/values_test.go
+++ b/pkg/revision/values_test.go
@@ -81,6 +81,7 @@ spec:
 		},
 		Global: &v1.GlobalConfig{
 			Platform:       ptr.Of("openshift"),
+			NativeNftables: ptr.Of(true),
 			IstioNamespace: ptr.Of(namespace), // this value is always added/overridden based on IstioRevision.spec.namespace
 		},
 		Revision:        ptr.Of(revisionName),
@@ -124,6 +125,7 @@ spec:`)), 0o644))
 		},
 		Global: &v1.GlobalConfig{
 			Platform:       ptr.Of("openshift"),
+			NativeNftables: ptr.Of(true),
 			IstioNamespace: ptr.Of(namespace), // this value is always added/overridden based on IstioRevision.spec.namespace
 		},
 		Revision:        ptr.Of(revisionName),


### PR DESCRIPTION
On OpenShift, Sail Operator now sets global.nativeNftables=true
for Istio and IstioCNI unless the user explicitly overrides it. Other
platforms keep the existing chart default (disabled).

This avoids requiring every OpenShift install to opt in manually,
while still honoring spec.values.global.nativeNftables=false when set.

**Alternatives Considered:**
1. Update Istio's profile-platform-openshift.yaml

One option is to enable `global.nativeNftables=true` in Istio's OpenShift platform profile so that Helm and istioctl use the same default. My main concern with this approach is that it would affect every OpenShift installation, including older clusters where the host might not have a usable nft binary. Keeping this default in Sail limits the change to operator-managed installations, while still leaving the door open for an upstream change in the future if we decide to go in that direction.

2. Midstream-only change in openshift-service-mesh/sail-operator

Another option is to make this a midstream-only change so that only the productized builds enable nftables by default. The downside is that community Sail users on OpenShift would still need to opt in manually, creating an unnecessary difference in behavior between upstream and midstream. Setting the default in the community Sail operator keeps the experience consistent for OpenShift users and avoids maintaining a downstream-only change.
