### PR TITLE
test: avoid flaky result when cni is not ready and we create test pods

### DIFF
--- a/tests/e2e/util/common/checks.go
+++ b/tests/e2e/util/common/checks.go
@@ -92,7 +92,8 @@ func AwaitCniDaemonSet(ctx context.Context, k kubectl.Kubectl, cl client.Client)
 		if err := cl.Get(ctx, key, daemonset); err != nil {
 			return false
 		}
-		return daemonset.Status.NumberAvailable == daemonset.Status.CurrentNumberScheduled
+		return daemonset.Status.DesiredNumberScheduled > 0 &&
+			daemonset.Status.NumberAvailable == daemonset.Status.DesiredNumberScheduled
 	}).Should(BeTrue(), fmt.Sprintf("DaemonSet '%s' is not Available in the '%s' namespace on %s cluster", key.Name, key.Namespace, k.ClusterName))
 	Success(fmt.Sprintf("DaemonSet '%s' is deployed and running in the '%s' namespace on %s cluster", key.Name, key.Namespace, k.ClusterName))
 }


### PR DESCRIPTION
If we don't wait properly for CNi to be ready, we can deploy test pods and end without running pods.  With the current validation we can have a moment where NumberAvailable is equal to 0 and CurrentNumberScheduled also

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
