### PR TITLE
fix: apply WebhookFilter to webhook watches

### DIFF
--- a/controllers/istiorevisiontag/istiorevisiontag_controller.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/reconciler"
 	"github.com/istio-ecosystem/sail-operator/pkg/revision"
 	"github.com/istio-ecosystem/sail-operator/pkg/validation"
+	"github.com/istio-ecosystem/sail-operator/pkg/watches"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -254,8 +255,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// cluster-scoped resources
 		Watches(&v1.Istio{}, operatorResourcesHandler).
 		Watches(&v1.IstioRevision{}, operatorResourcesHandler).
-		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler).
-		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler).
+		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler,
+			builder.WithPredicates(watches.AsPredicate(watches.WebhookFilter()))).
+		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler,
+			builder.WithPredicates(watches.AsPredicate(watches.WebhookFilter()))).
 		Complete(reconciler.NewStandardReconcilerWithFinalizer[*v1.IstioRevisionTag](r.Client, r.Reconcile, r.Finalize, constants.FinalizerName))
 }
 

--- a/tests/integration/api/istiorevisiontag_test.go
+++ b/tests/integration/api/istiorevisiontag_test.go
@@ -165,6 +165,48 @@ var _ = Describe("IstioRevisionTag resource", Label("istiorevisiontag"), Ordered
 						Expect(webhook.Webhooks[0].ClientConfig.Service.Namespace).To(Equal(istio.Spec.Namespace),
 							"VWC should point to the correct namespace for the referenced revision")
 					})
+
+					It("skips reconcile when only caBundle and failurePolicy are updated on ValidatingWebhookConfiguration", func() {
+						time.Sleep(5 * time.Second)
+
+						webhook := &admissionv1.ValidatingWebhookConfiguration{}
+						webhookKey := client.ObjectKey{Name: "istiod-default-validator"}
+						Expect(k8sClient.Get(ctx, webhookKey, webhook)).To(Succeed())
+
+						expectNoReconciliation(istioRevisionTagController, func() {
+							By("updating caBundle and failurePolicy on ValidatingWebhookConfiguration")
+							for i := range webhook.Webhooks {
+								webhook.Webhooks[i].ClientConfig.CABundle = []byte("new-ca-bundle-data")
+								webhook.Webhooks[i].FailurePolicy = ptr.Of(admissionv1.Fail)
+							}
+							Expect(k8sClient.Update(ctx, webhook)).To(Succeed())
+						})
+					})
+
+					It("skips reconcile when only caBundle is updated on MutatingWebhookConfiguration", func() {
+						time.Sleep(5 * time.Second)
+
+						webhookList := &admissionv1.MutatingWebhookConfigurationList{}
+						Expect(k8sClient.List(ctx, webhookList)).To(Succeed())
+						var webhook *admissionv1.MutatingWebhookConfiguration
+						for i := range webhookList.Items {
+							for _, ref := range webhookList.Items[i].OwnerReferences {
+								if ref.Kind == v1.IstioRevisionTagKind {
+									webhook = &webhookList.Items[i]
+									break
+								}
+							}
+						}
+						Expect(webhook).ToNot(BeNil(), "expected to find a MutatingWebhookConfiguration owned by the IstioRevisionTag")
+
+						expectNoReconciliation(istioRevisionTagController, func() {
+							By("updating caBundle on MutatingWebhookConfiguration")
+							for i := range webhook.Webhooks {
+								webhook.Webhooks[i].ClientConfig.CABundle = []byte("new-ca-bundle-data")
+							}
+							Expect(k8sClient.Update(ctx, webhook)).To(Succeed())
+						})
+					})
 				})
 				When("workload ns is labeled with istio-injection label", func() {
 					BeforeAll(func() {

--- a/tests/integration/api/utils.go
+++ b/tests/integration/api/utils.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	istioRevisionController = "istiorevision"
-	istioCNIController      = "istiocni"
+	istioRevisionController    = "istiorevision"
+	istioRevisionTagController = "istiorevisiontag"
+	istioCNIController         = "istiocni"
 )
 
 func getReconcileCount(g Gomega, controllerName string) float64 {


### PR DESCRIPTION
This avoids unnecessary reconciliations by ignoring changes to fields we know istiod sets after installation.