### PR TITLE
[release-1.28] fix: filter webhook watches to avoid reconcile loops

### DIFF
--- a/controllers/istiorevisiontag/istiorevisiontag_controller.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller.go
@@ -281,8 +281,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// cluster-scoped resources
 		Watches(&v1.Istio{}, operatorResourcesHandler).
 		Watches(&v1.IstioRevision{}, operatorResourcesHandler).
-		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler).
-		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler).
+		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler,
+			builder.WithPredicates(webhookConfigPredicate())).
+		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler,
+			builder.WithPredicates(webhookConfigPredicate())).
 		Complete(reconciler.NewStandardReconcilerWithFinalizer[*v1.IstioRevisionTag](r.Client, r.Reconcile, r.Finalize, constants.FinalizerName))
 }
 
@@ -470,6 +472,42 @@ func (r *Reconciler) mapOperatorResourceToReconcileRequest(ctx context.Context, 
 		}
 	}
 	return requests
+}
+
+func webhookConfigPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+
+			// Istiod updates the caBundle and failurePolicy fields in its webhook configs.
+			// We must ignore changes to these fields to prevent an endless update loop.
+			// We must use deep copies to avoid mutating the shared informer cache.
+			oldCopy := e.ObjectOld.DeepCopyObject().(client.Object)
+			newCopy := e.ObjectNew.DeepCopyObject().(client.Object)
+			clearIgnoredFields(oldCopy)
+			clearIgnoredFields(newCopy)
+			return !reflect.DeepEqual(newCopy, oldCopy)
+		},
+	}
+}
+
+func clearIgnoredFields(obj client.Object) {
+	obj.SetResourceVersion("")
+	obj.SetGeneration(0)
+	obj.SetManagedFields(nil)
+	switch webhookConfig := obj.(type) {
+	case *admissionv1.ValidatingWebhookConfiguration:
+		for i := range len(webhookConfig.Webhooks) {
+			webhookConfig.Webhooks[i].FailurePolicy = nil
+			webhookConfig.Webhooks[i].ClientConfig.CABundle = nil
+		}
+	case *admissionv1.MutatingWebhookConfiguration:
+		for i := range len(webhookConfig.Webhooks) {
+			webhookConfig.Webhooks[i].ClientConfig.CABundle = nil
+		}
+	}
 }
 
 // ignoreStatusChange returns a predicate that ignores watch events where only the resource status changes; if

--- a/tests/integration/api/istiorevisiontag_test.go
+++ b/tests/integration/api/istiorevisiontag_test.go
@@ -165,6 +165,48 @@ var _ = Describe("IstioRevisionTag resource", Label("istiorevisiontag"), Ordered
 						Expect(webhook.Webhooks[0].ClientConfig.Service.Namespace).To(Equal(istio.Spec.Namespace),
 							"VWC should point to the correct namespace for the referenced revision")
 					})
+
+					It("skips reconcile when only caBundle and failurePolicy are updated on ValidatingWebhookConfiguration", func() {
+						time.Sleep(5 * time.Second)
+
+						webhook := &admissionv1.ValidatingWebhookConfiguration{}
+						webhookKey := client.ObjectKey{Name: "istiod-default-validator"}
+						Expect(k8sClient.Get(ctx, webhookKey, webhook)).To(Succeed())
+
+						expectNoReconciliation(istioRevisionTagController, func() {
+							By("updating caBundle and failurePolicy on ValidatingWebhookConfiguration")
+							for i := range webhook.Webhooks {
+								webhook.Webhooks[i].ClientConfig.CABundle = []byte("new-ca-bundle-data")
+								webhook.Webhooks[i].FailurePolicy = ptr.Of(admissionv1.Fail)
+							}
+							Expect(k8sClient.Update(ctx, webhook)).To(Succeed())
+						})
+					})
+
+					It("skips reconcile when only caBundle is updated on MutatingWebhookConfiguration", func() {
+						time.Sleep(5 * time.Second)
+
+						webhookList := &admissionv1.MutatingWebhookConfigurationList{}
+						Expect(k8sClient.List(ctx, webhookList)).To(Succeed())
+						var webhook *admissionv1.MutatingWebhookConfiguration
+						for i := range webhookList.Items {
+							for _, ref := range webhookList.Items[i].OwnerReferences {
+								if ref.Kind == v1.IstioRevisionTagKind {
+									webhook = &webhookList.Items[i]
+									break
+								}
+							}
+						}
+						Expect(webhook).ToNot(BeNil(), "expected to find a MutatingWebhookConfiguration owned by the IstioRevisionTag")
+
+						expectNoReconciliation(istioRevisionTagController, func() {
+							By("updating caBundle on MutatingWebhookConfiguration")
+							for i := range webhook.Webhooks {
+								webhook.Webhooks[i].ClientConfig.CABundle = []byte("new-ca-bundle-data")
+							}
+							Expect(k8sClient.Update(ctx, webhook)).To(Succeed())
+						})
+					})
 				})
 				When("workload ns is labeled with istio-injection label", func() {
 					BeforeAll(func() {

--- a/tests/integration/api/utils.go
+++ b/tests/integration/api/utils.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	istioRevisionController = "istiorevision"
-	istioCNIController      = "istiocni"
+	istioRevisionController    = "istiorevision"
+	istioRevisionTagController = "istiorevisiontag"
+	istioCNIController         = "istiocni"
 )
 
 func getReconcileCount(g Gomega, controllerName string) float64 {


### PR DESCRIPTION
This is an adaptation of https://github.com/istio-ecosystem/sail-operator/pull/2187 for the release-1.28 branch.