### PR TITLE
test: move crc to postubmit

### DIFF
--- a/.github/workflows/crc-e2e-sail.yaml
+++ b/.github/workflows/crc-e2e-sail.yaml
@@ -1,12 +1,14 @@
 name: crc-e2e-sail
 
-# CRC OpenShift Local smoke — early OCP-shaped signal on ubuntu-latest.
-# Keep this workflow OUT of branch-protection required status checks so PRs can still merge while the suite
-# stabilizes. Requires secrets: CRC_PULL_SECRET, QUAY_PWDNAME, QUAY_PWD.
+# CRC OpenShift Local smoke — postsubmit signal run against merged code.
+# Triggered on push to main/release-* (i.e. after every merged PR) so secrets are always
+# available and only maintainer-approved code is exercised.
+# Keep this workflow OUT of branch-protection required status checks.
+# Requires secrets: CRC_PULL_SECRET, QUAY_USER, QUAY_PWD.
 
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     branches:
       - main
       - release-*
@@ -23,7 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.base_ref || github.ref }}
           persist-credentials: false
           sparse-checkout: |
             common/scripts/setup_env.sh


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
We need to move the CRC job as postubmit to avoid giving the PR's the possibility to expose secrets, moving as postubmit put a barrier where only mantainer approved code is going to be executed avoiding secrets exposure

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
