### PR TITLE
Add CSV path to versions-triggered-build workflow

### DIFF
--- a/.github/workflows/versions-triggered-build.yaml
+++ b/.github/workflows/versions-triggered-build.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'pkg/istioversion/versions.yaml'
+      - 'bundle/manifests/sailoperator.clusterserviceversion.yaml'
 
 run-name: versions-triggered-build
 

--- a/bundle/manifests/sailoperator.clusterserviceversion.yaml
+++ b/bundle/manifests/sailoperator.clusterserviceversion.yaml
@@ -45,7 +45,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/sail-dev/sail-operator:1.31-latest
-    createdAt: "2026-08-03T07:45:05Z"
+    createdAt: "2026-08-05T07:45:05Z"
     description: The Sail Operator manages the lifecycle of your Istio control plane. It provides custom resources for you to deploy and manage your control plane components.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"


### PR DESCRIPTION
Add the CSV path to the versions-triggered-build workflow to ensure the image is rebuilt when the containerImage reference changes.

So, the images are rebuilt with a new tag right after the PR, like https://github.com/istio-ecosystem/sail-operator/pull/2209 (after release branch cutting)

Changed CSV timestamp to see if workflow will be triggered after merge 