### PR TITLE
On OpenShift pass 1.3 ciphersuites through proxy metadata

### DIFF
--- a/changelog/tls-1.3-ciphersuites.yaml
+++ b/changelog/tls-1.3-ciphersuites.yaml
@@ -1,0 +1,6 @@
+category: changed
+title: Pass TLS 1.3 cipher suites to Envoy via proxy metadata
+description: |
+  Allows passing TLS 1.3 cipher suites to envoy on OpenShift by passing
+  the env var `OPENSSL_TLS1_3_CIPHERSUITES` through proxy metadata. Syncs
+  this with the APIServer TLS settings.

--- a/pkg/istiovalues/tls.go
+++ b/pkg/istiovalues/tls.go
@@ -77,13 +77,32 @@ func ApplyTLSConfig(tlsConfig *config.TLSConfig, istioVersion string, values *v1
 
 	// Configure the Ecdhcurves if they are available on Openshift configuration. Normalize before
 	// copying the names, given Openshift allows a different naming from NIST
-	if tlsConfig.OpenShift != nil && len(tlsConfig.OpenShift.TLSProfileSpec.Groups) > 0 {
-		ecdhCurves := copyECDHCurvesToConfig(tlsConfig.OpenShift.TLSProfileSpec.Groups)
-		if len(values.MeshConfig.TlsDefaults.EcdhCurves) == 0 {
-			values.MeshConfig.TlsDefaults.EcdhCurves = ecdhCurves
+	if tlsConfig.OpenShift != nil {
+		if len(tlsConfig.OpenShift.TLSProfileSpec.Groups) > 0 {
+			ecdhCurves := copyECDHCurvesToConfig(tlsConfig.OpenShift.TLSProfileSpec.Groups)
+			if len(values.MeshConfig.TlsDefaults.EcdhCurves) == 0 {
+				values.MeshConfig.TlsDefaults.EcdhCurves = ecdhCurves
+			}
+			// TODO: MeshMTLS does not support setting ecdhCurves and this will break Gateway provisioning.
+			// we should take care of ecdhCurves for mesh as a second step
 		}
-		// TODO: MeshMTLS does not support setting ecdhCurves and this will break Gateway provisioning.
-		// we should take care of ecdhCurves for mesh as a second step
+
+		// Envoy does not support setting TLS ciphers for TLS 1.3 BUT the openssl
+		// backend does allow you to customize these. On openshift the envoy image has a custom openssl
+		// config file baked in that will populate the tls1.3 cipher suites through an env var.
+		// Also important to note is that all non-FIPS approved ciphers will be silently dropped by
+		// openssl, even if they are specified in the openssl config. So we do not need to filter out
+		// FIPS ciphers here. We can pass them to the conf and openssl will drop them automatically on
+		// a FIPS enabled cluster.
+		if values.MeshConfig.DefaultConfig == nil {
+			values.MeshConfig.DefaultConfig = &v1.MeshConfigProxyConfig{}
+		}
+		if values.MeshConfig.DefaultConfig.ProxyMetadata == nil {
+			values.MeshConfig.DefaultConfig.ProxyMetadata = map[string]string{}
+		}
+		if _, ok := values.MeshConfig.DefaultConfig.ProxyMetadata["OPENSSL_TLS1_3_CIPHERSUITES"]; !ok {
+			values.MeshConfig.DefaultConfig.ProxyMetadata["OPENSSL_TLS1_3_CIPHERSUITES"] = strings.Join(cipherNames, ":")
+		}
 	}
 
 	if values.Pilot == nil {

--- a/pkg/istiovalues/tls.go
+++ b/pkg/istiovalues/tls.go
@@ -77,13 +77,30 @@ func ApplyTLSConfig(tlsConfig *config.TLSConfig, istioVersion string, values *v1
 
 	// Configure the Ecdhcurves if they are available on Openshift configuration. Normalize before
 	// copying the names, given Openshift allows a different naming from NIST
-	if tlsConfig.OpenShift != nil && len(tlsConfig.OpenShift.TLSProfileSpec.Groups) > 0 {
-		ecdhCurves := copyECDHCurvesToConfig(tlsConfig.OpenShift.TLSProfileSpec.Groups)
-		if len(values.MeshConfig.TlsDefaults.EcdhCurves) == 0 {
-			values.MeshConfig.TlsDefaults.EcdhCurves = ecdhCurves
+	if tlsConfig.OpenShift != nil {
+		if len(tlsConfig.OpenShift.TLSProfileSpec.Groups) > 0 {
+			ecdhCurves := copyECDHCurvesToConfig(tlsConfig.OpenShift.TLSProfileSpec.Groups)
+			if len(values.MeshConfig.TlsDefaults.EcdhCurves) == 0 {
+				values.MeshConfig.TlsDefaults.EcdhCurves = ecdhCurves
+			}
+			// TODO: MeshMTLS does not support setting ecdhCurves and this will break Gateway provisioning.
+			// we should take care of ecdhCurves for mesh as a second step
 		}
-		// TODO: MeshMTLS does not support setting ecdhCurves and this will break Gateway provisioning.
-		// we should take care of ecdhCurves for mesh as a second step
+
+		// Envoy does not support setting TLS ciphers when minProtocolVersion is 1.3 BUT the openssl
+		// backend does allow you to customize these. On openshift the envoy image has a custom openssl
+		// config file baked in that will populate the tls1.3 cipher suites through an env var.
+		if tlsConfig.MinVersion == tls.VersionTLS13 {
+			if values.MeshConfig.DefaultConfig == nil {
+				values.MeshConfig.DefaultConfig = &v1.MeshConfigProxyConfig{}
+			}
+			if values.MeshConfig.DefaultConfig.ProxyMetadata == nil {
+				values.MeshConfig.DefaultConfig.ProxyMetadata = map[string]string{}
+			}
+			if _, ok := values.MeshConfig.DefaultConfig.ProxyMetadata["OPENSSL_TLS1_3_CIPHERSUITES"]; !ok {
+				values.MeshConfig.DefaultConfig.ProxyMetadata["OPENSSL_TLS1_3_CIPHERSUITES"] = strings.Join(cipherNames, ":")
+			}
+		}
 	}
 
 	if values.Pilot == nil {

--- a/pkg/istiovalues/tls_test.go
+++ b/pkg/istiovalues/tls_test.go
@@ -289,11 +289,172 @@ func TestApplyTLSConfig(t *testing.T) {
 						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
 						EcdhCurves:         []string{"X25519MLKEM768", "X25519", "P-256", "P-384"},
 					},
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						},
+					},
 				},
 				Pilot: &v1.PilotConfig{
 					ExtraContainerArgs: []string{
 						"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 						"--tls-min-version=1.3",
+					},
+				},
+			},
+		},
+		{
+			name: "does not override existing OPENSSL_TLS1_3_CIPHERSUITES in proxyMetadata",
+			tlsConfig: &config.TLSConfig{
+				CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+				MinVersion:   tls.VersionTLS13,
+				OpenShift:    &config.OpenShiftTLS{},
+			},
+			istioVersion: "1.30.0",
+			inputValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_AES_256_GCM_SHA384",
+						},
+					},
+				},
+			},
+			wantValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					MeshMTLS: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					TlsDefaults: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_AES_256_GCM_SHA384",
+						},
+					},
+				},
+				Pilot: &v1.PilotConfig{
+					ExtraContainerArgs: []string{
+						"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						"--tls-min-version=1.3",
+					},
+				},
+			},
+		},
+		{
+			name: "preserves existing proxyMetadata keys when adding OPENSSL_TLS1_3_CIPHERSUITES",
+			tlsConfig: &config.TLSConfig{
+				CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+				MinVersion:   tls.VersionTLS13,
+				OpenShift:    &config.OpenShiftTLS{},
+			},
+			istioVersion: "1.30.0",
+			inputValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"ISTIO_DUAL_STACK": "true",
+						},
+					},
+				},
+			},
+			wantValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					MeshMTLS: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					TlsDefaults: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"ISTIO_DUAL_STACK":            "true",
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						},
+					},
+				},
+				Pilot: &v1.PilotConfig{
+					ExtraContainerArgs: []string{
+						"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						"--tls-min-version=1.3",
+					},
+				},
+			},
+		},
+		{
+			name: "preserves existing defaultConfig fields when adding proxyMetadata",
+			tlsConfig: &config.TLSConfig{
+				CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+				MinVersion:   tls.VersionTLS13,
+				OpenShift:    &config.OpenShiftTLS{},
+			},
+			istioVersion: "1.30.0",
+			inputValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						DiscoveryAddress: new("istiod.custom-ns.svc:15012"),
+					},
+				},
+			},
+			wantValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					MeshMTLS: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					TlsDefaults: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						DiscoveryAddress: new("istiod.custom-ns.svc:15012"),
+						ProxyMetadata: map[string]string{
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						},
+					},
+				},
+				Pilot: &v1.PilotConfig{
+					ExtraContainerArgs: []string{
+						"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						"--tls-min-version=1.3",
+					},
+				},
+			},
+		},
+		{
+			name: "sets OPENSSL_TLS1_3_CIPHERSUITES on OpenShift even when MinVersion is not 1.3",
+			tlsConfig: &config.TLSConfig{
+				CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+				MinVersion:   tls.VersionTLS12,
+				OpenShift:    &config.OpenShiftTLS{},
+			},
+			istioVersion: "1.30.0",
+			inputValues:  &v1.Values{},
+			wantValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					MeshMTLS: &v1.MeshConfigTLSConfig{
+						CipherSuites:       []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv12,
+					},
+					TlsDefaults: &v1.MeshConfigTLSConfig{
+						CipherSuites:       []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv12,
+					},
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						},
+					},
+				},
+				Pilot: &v1.PilotConfig{
+					ExtraContainerArgs: []string{
+						"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						"--tls-min-version=1.2",
 					},
 				},
 			},

--- a/pkg/istiovalues/tls_test.go
+++ b/pkg/istiovalues/tls_test.go
@@ -289,6 +289,134 @@ func TestApplyTLSConfig(t *testing.T) {
 						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
 						EcdhCurves:         []string{"X25519MLKEM768", "X25519", "P-256", "P-384"},
 					},
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						},
+					},
+				},
+				Pilot: &v1.PilotConfig{
+					ExtraContainerArgs: []string{
+						"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						"--tls-min-version=1.3",
+					},
+				},
+			},
+		},
+		{
+			name: "does not override existing OPENSSL_TLS1_3_CIPHERSUITES in proxyMetadata",
+			tlsConfig: &config.TLSConfig{
+				CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+				MinVersion:   tls.VersionTLS13,
+				OpenShift:    &config.OpenShiftTLS{},
+			},
+			istioVersion: "1.30.0",
+			inputValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_AES_256_GCM_SHA384",
+						},
+					},
+				},
+			},
+			wantValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					MeshMTLS: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					TlsDefaults: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_AES_256_GCM_SHA384",
+						},
+					},
+				},
+				Pilot: &v1.PilotConfig{
+					ExtraContainerArgs: []string{
+						"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						"--tls-min-version=1.3",
+					},
+				},
+			},
+		},
+		{
+			name: "preserves existing proxyMetadata keys when adding OPENSSL_TLS1_3_CIPHERSUITES",
+			tlsConfig: &config.TLSConfig{
+				CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+				MinVersion:   tls.VersionTLS13,
+				OpenShift:    &config.OpenShiftTLS{},
+			},
+			istioVersion: "1.30.0",
+			inputValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"ISTIO_DUAL_STACK": "true",
+						},
+					},
+				},
+			},
+			wantValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					MeshMTLS: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					TlsDefaults: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						ProxyMetadata: map[string]string{
+							"ISTIO_DUAL_STACK":             "true",
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						},
+					},
+				},
+				Pilot: &v1.PilotConfig{
+					ExtraContainerArgs: []string{
+						"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						"--tls-min-version=1.3",
+					},
+				},
+			},
+		},
+		{
+			name: "preserves existing defaultConfig fields when adding proxyMetadata",
+			tlsConfig: &config.TLSConfig{
+				CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+				MinVersion:   tls.VersionTLS13,
+				OpenShift:    &config.OpenShiftTLS{},
+			},
+			istioVersion: "1.30.0",
+			inputValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						DiscoveryAddress: new("istiod.custom-ns.svc:15012"),
+					},
+				},
+			},
+			wantValues: &v1.Values{
+				MeshConfig: &v1.MeshConfig{
+					MeshMTLS: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					TlsDefaults: &v1.MeshConfigTLSConfig{
+						CipherSuites:       nil,
+						MinProtocolVersion: v1.MeshConfigTLSConfigTLSProtocolTlsv13,
+					},
+					DefaultConfig: &v1.MeshConfigProxyConfig{
+						DiscoveryAddress: new("istiod.custom-ns.svc:15012"),
+						ProxyMetadata: map[string]string{
+							"OPENSSL_TLS1_3_CIPHERSUITES": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						},
+					},
 				},
 				Pilot: &v1.PilotConfig{
 					ExtraContainerArgs: []string{

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -19,7 +19,6 @@ package operator
 import (
 	"context"
 	"crypto/rand"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -41,7 +40,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
-	crtls "github.com/openshift/controller-runtime-common/pkg/tls"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -69,24 +67,7 @@ var sailCRDs = []string{
 	"workloadgroups.networking.istio.io",
 }
 
-// markerCipher is the OpenSSL name for a cipher that is in the Intermediate (default)
-// profile but intentionally omitted from the custom TLS profile used in tests.
-// Its absence distinguishes Custom from Intermediate on both the metrics endpoint
-// and in the IstioRevision values.
-const markerCipher = "ECDHE-RSA-AES128-GCM-SHA256"
-
-// markerCipherName is the Go TLS cipher name for the marker cipher.
-const markerCipherName = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-
-var (
-	apiServerKey = client.ObjectKey{Name: crtls.APIServerName}
-
-	// customTLSProfileCiphers is the default (Intermediate) cipher list with the
-	// marker cipher removed. Its absence distinguishes Custom from Intermediate in tests.
-	customTLSProfileCiphers = slices.DeleteFunc(slices.Clone(crtls.DefaultTLSCiphers), func(c string) bool {
-		return c == markerCipher
-	})
-)
+var apiServerKey = client.ObjectKey{Name: "cluster"}
 
 var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
 	SetDefaultEventuallyTimeout(time.Duration(env.GetInt("DEFAULT_TEST_TIMEOUT", 180)) * time.Second)
@@ -230,10 +211,9 @@ spec:
 	})
 
 	// These tests verify the operator's TLS behavior when the APIServer TLS settings change.
-	// Each test verifies both the metrics endpoint TLS configuration (by connecting with
-	// a specific TLS 1.2 cipher) and the TLS settings synced to the IstioRevision resource.
-	// Test 1 runs on all OpenShift clusters. Tests 2 and 3 require OpenShift >= 4.22
+	// The first test runs on all OpenShift clusters; the second requires OpenShift >= 4.22
 	// because the TLSAdherence field was introduced in 4.22.
+	// NOTE: Running this test may have side effects such as setting feature gates on OpenShift.
 	Describe("TLS profile change", Label("tls-profile"), func() {
 		var ocpMinorVersion int
 		var ocpMajorVersion int
@@ -302,16 +282,7 @@ spec:
 					Success("TLSAdherence feature gate is active")
 
 					Step("Waiting for kube-apiserver to finish rolling out after feature gate change")
-					Eventually(func(g Gomega) {
-						co := &configv1.ClusterOperator{}
-						g.Expect(cl.Get(ctx, client.ObjectKey{Name: "kube-apiserver"}, co)).To(Succeed())
-						for _, cond := range co.Status.Conditions {
-							if cond.Type == configv1.OperatorProgressing {
-								g.Expect(cond.Status).To(Equal(configv1.ConditionFalse), "kube-apiserver should not be Progressing")
-							}
-						}
-					}).WithTimeout(30*time.Minute).WithPolling(30*time.Second).Should(Succeed(),
-						"kube-apiserver should finish rolling out after enabling feature gate")
+					waitForAPIServerStable(ctx, cl)
 					Success("kube-apiserver is stable after feature gate change")
 				}
 			}
@@ -339,6 +310,9 @@ spec:
 					}
 					g.Expect(cl.Update(ctx, apiServer)).To(Succeed(), "Failed to update APIServer TLS settings")
 				}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+
+				Step("Waiting for kube-apiserver to finish rolling out after restoring TLS settings")
+				waitForAPIServerStable(ctx, cl)
 			})
 
 			Step("Creating Istio")
@@ -368,8 +342,6 @@ spec:
 				Skip(fmt.Sprintf("TLSAdherence is already set to %q; cannot reset to NoOpinion. Skipping test.", apiServer.Spec.TLSAdherence))
 			}
 
-			applyCustomTLSProfile(ctx, cl, customTLSProfileCiphers)
-
 			Step("Verifying IstioRevision does not have TLS cipher suites")
 			Consistently(func(g Gomega) {
 				rev := &v1.IstioRevision{}
@@ -378,9 +350,9 @@ spec:
 					"IstioRevision should not have cipher suites when TLSAdherence is NoOpinion")
 			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 
-			Step("Verifying metrics endpoint still accepts the marker cipher")
-			Expect(metricsEndpointAcceptsCipher(k, markerCipher, "1.2")).To(BeTrue(),
-				"Metrics endpoint should accept ECDHE-RSA-AES128-GCM-SHA256 when TLSAdherence is NoOpinion (custom profile not applied)")
+			Step("Verifying metrics endpoint accepts a TLS 1.2 cipher")
+			Expect(metricsEndpointAcceptsCipher(k, "ECDHE-RSA-AES256-GCM-SHA384", "1.2")).To(BeTrue(),
+				"Metrics endpoint should accept TLS 1.2 ciphers when TLSAdherence is NoOpinion")
 			Success("TLS settings were not synced when TLSAdherence is NoOpinion")
 		})
 
@@ -405,7 +377,6 @@ spec:
 				ciphers := getIstioRevisionCipherSuites(rev)
 				g.Expect(ciphers).To(BeEmpty(), "IstioRevision should not have cipher suites")
 
-				// assert that pilot.extraContainerArgs does not contain --tls-cipher-suites
 				var pilotExtraArgs []string
 				if rev.Spec.Values != nil && rev.Spec.Values.Pilot != nil {
 					pilotExtraArgs = rev.Spec.Values.Pilot.ExtraContainerArgs
@@ -415,49 +386,83 @@ spec:
 
 			ensureTLSAdherence(ctx, cl, configv1.TLSAdherencePolicyStrictAllComponents)
 
-			Step("Verifying IstioRevision has TLS cipher suites from the custom profile")
+			Step("Verifying IstioRevision has TLS cipher suites from the Intermediate profile")
 			Eventually(func(g Gomega) {
 				rev := &v1.IstioRevision{}
 				g.Expect(cl.Get(ctx, client.ObjectKey{Name: "default"}, rev)).To(Succeed())
 				ciphers := getIstioRevisionCipherSuites(rev)
 				g.Expect(ciphers).NotTo(BeEmpty(), "IstioRevision should have cipher suites")
-				// This is on the intermediate profile, so it should be present
-				g.Expect(ciphers).To(ContainElement(tls.CipherSuiteName(tls.TLS_AES_256_GCM_SHA384)),
-					"IstioRevision should contain TLS_AES_256_GCM_SHA384 from the intermediate profile")
 
 				g.Expect(rev.Spec.Values.Pilot).NotTo(BeNil())
 				g.Expect(rev.Spec.Values.Pilot.ExtraContainerArgs).To(
 					ContainElement(ContainSubstring("--tls-cipher-suites=")),
-					"IstioRevision should have --tls-cipher-suites in pilot.extraContainerArgs")
+					"IstioRevision should have --tls-cipher-suites in pilot.extraContainerArgs",
+				)
 			}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
 				"IstioRevision is not syncing TLS settings but should be")
 
-			Step("Verifying metrics endpoint accepts the custom cipher")
-			Eventually(func() bool {
-				return metricsEndpointAcceptsCipher(k, "ECDHE-RSA-AES256-GCM-SHA384", "1.2")
-			}).Should(BeTrue(),
-				"Metrics endpoint should accept ECDHE-RSA-AES256-GCM-SHA384 when TLS profile includes it")
-			Success("TLS settings were synced after TLSAdherence change to StrictAllComponents")
+			Step("Applying Modern TLS profile (TLS 1.3 only)")
+			applyModernTLSProfile(ctx, cl)
 
-			Step("Applying custom TLS profile without ECDHE-RSA-AES128-GCM-SHA256")
-			applyCustomTLSProfile(ctx, cl, customTLSProfileCiphers)
-
-			Step("Verifying IstioRevision cipher suites no longer include the marker cipher")
+			Step("Verifying IstioRevision has TLS 1.3 settings from the Modern profile")
 			Eventually(func(g Gomega) {
 				rev := &v1.IstioRevision{}
 				g.Expect(cl.Get(ctx, client.ObjectKey{Name: "default"}, rev)).To(Succeed())
-				ciphers := getIstioRevisionCipherSuites(rev)
-				g.Expect(ciphers).NotTo(BeEmpty(), "IstioRevision should have cipher suites")
-				g.Expect(ciphers).NotTo(ContainElement(markerCipherName),
-					"IstioRevision should not contain ECDHE-RSA-AES128-GCM-SHA256 after custom profile is applied")
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+				g.Expect(rev.Spec.Values).NotTo(BeNil())
+				g.Expect(rev.Spec.Values.MeshConfig).NotTo(BeNil())
 
-			Step("Verifying metrics endpoint rejects the marker cipher")
+				g.Expect(rev.Spec.Values.MeshConfig.TlsDefaults).NotTo(BeNil())
+				g.Expect(rev.Spec.Values.MeshConfig.TlsDefaults.MinProtocolVersion).To(
+					Equal(v1.MeshConfigTLSConfigTLSProtocolTlsv13),
+					"tlsDefaults.minProtocolVersion should be TLSV1_3",
+				)
+				g.Expect(rev.Spec.Values.MeshConfig.TlsDefaults.CipherSuites).To(BeEmpty(),
+					"tlsDefaults.cipherSuites should be empty for TLS 1.3")
+
+				g.Expect(rev.Spec.Values.MeshConfig.MeshMTLS).NotTo(BeNil())
+				g.Expect(rev.Spec.Values.MeshConfig.MeshMTLS.MinProtocolVersion).To(
+					Equal(v1.MeshConfigTLSConfigTLSProtocolTlsv13),
+					"meshMTLS.minProtocolVersion should be TLSV1_3",
+				)
+				g.Expect(rev.Spec.Values.MeshConfig.MeshMTLS.CipherSuites).To(BeEmpty(),
+					"meshMTLS.cipherSuites should be empty for TLS 1.3")
+
+				proxyMeta := getIstioRevisionProxyMetadata(rev)
+				g.Expect(proxyMeta).To(HaveKey("OPENSSL_TLS1_3_CIPHERSUITES"),
+					"proxyMetadata should contain OPENSSL_TLS1_3_CIPHERSUITES for TLS 1.3")
+				tls13Ciphers := proxyMeta["OPENSSL_TLS1_3_CIPHERSUITES"]
+				g.Expect(tls13Ciphers).NotTo(BeEmpty(),
+					"OPENSSL_TLS1_3_CIPHERSUITES should not be empty")
+				for _, cipher := range configv1.TLSProfiles[configv1.TLSProfileModernType].Ciphers {
+					g.Expect(tls13Ciphers).To(ContainSubstring(cipher),
+						fmt.Sprintf("OPENSSL_TLS1_3_CIPHERSUITES should contain %s from the Modern profile", cipher))
+				}
+			}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+				"IstioRevision should have TLS 1.3 settings from the Modern profile")
+
+			Step("Verifying metrics endpoint rejects TLS 1.2 connections")
 			Eventually(func() bool {
-				return metricsEndpointAcceptsCipher(k, markerCipher, "1.2")
+				return metricsEndpointAcceptsCipher(k, "ECDHE-RSA-AES256-GCM-SHA384", "1.2")
 			}).Should(BeFalse(),
-				"Metrics endpoint should reject ECDHE-RSA-AES128-GCM-SHA256 after custom profile is applied")
-			Success("TLS settings were updated after profile change")
+				"Metrics endpoint should reject TLS 1.2 connections when Modern profile is active")
+			Success("TLS settings were synced after switching to Modern profile")
+
+			Step("Deploying a proxy pod to verify synced TLS settings produce a healthy sidecar")
+			const tlsTestNamespace = "tls-test"
+			Expect(k.CreateNamespace(tlsTestNamespace)).To(Succeed(), "Failed to create test namespace")
+			DeferCleanup(func() {
+				_ = k.Delete("namespace", tlsTestNamespace)
+			})
+			Expect(k.Label("namespace", tlsTestNamespace, "istio-injection", "enabled")).To(Succeed(),
+				"Failed to label namespace for sidecar injection")
+			Expect(k.WithNamespace(tlsTestNamespace).ApplyKustomize("sleep")).To(Succeed(),
+				"Failed to deploy sleep workload")
+
+			Eventually(func() error {
+				return common.CheckPodsReady(ctx, cl, tlsTestNamespace)
+			}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+				"Sleep pod with sidecar should be ready after TLS settings are synced")
+			Success("Proxy pod is healthy with synced TLS settings")
 		})
 	})
 
@@ -567,6 +572,21 @@ type tokenRequest struct {
 	} `json:"status"`
 }
 
+func waitForAPIServerStable(ctx context.Context, cl client.Client) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		co := &configv1.ClusterOperator{}
+		g.Expect(cl.Get(ctx, client.ObjectKey{Name: "kube-apiserver"}, co)).To(Succeed())
+		for _, cond := range co.Status.Conditions {
+			if cond.Type == configv1.OperatorProgressing {
+				g.Expect(cond.Status).To(Equal(configv1.ConditionFalse), "kube-apiserver should not be Progressing")
+			}
+		}
+	}).WithTimeout(30*time.Minute).WithPolling(30*time.Second).Should(Succeed(),
+		"kube-apiserver should finish rolling out")
+}
+
 func ensureTLSAdherence(ctx context.Context, cl client.Client, policy configv1.TLSAdherencePolicy) {
 	GinkgoHelper()
 
@@ -602,7 +622,7 @@ func ensureTLSAdherence(ctx context.Context, cl client.Client, policy configv1.T
 		oldRestarts[string(pod.UID)] = totalRestarts(pod)
 	}
 
-	Step(fmt.Sprintf("Updating APIServer TLSAdherence to %s", policy))
+	Step(fmt.Sprintf("Updating APIServer TLSAdherence from: %s to %s", apiServer.Spec.TLSAdherence, policy))
 	apiServer.Spec.TLSAdherence = policy
 	Expect(cl.Update(ctx, apiServer)).To(Succeed(), "Failed to update APIServer TLSAdherence")
 
@@ -627,23 +647,22 @@ func ensureTLSAdherence(ctx context.Context, cl client.Client, policy configv1.T
 		"Operator should restart and be ready after TLSAdherence change")
 }
 
-func applyCustomTLSProfile(ctx context.Context, cl client.Client, ciphers []string) {
+func applyModernTLSProfile(ctx context.Context, cl client.Client) {
 	GinkgoHelper()
-	Step("Applying a Custom TLS profile")
+	Step("Applying Modern TLS profile")
 
 	apiServer := &configv1.APIServer{}
 	Expect(cl.Get(ctx, apiServerKey, apiServer)).To(Succeed(), "Failed to get APIServer")
 	apiServer.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
-		Type: configv1.TLSProfileCustomType,
-		Custom: &configv1.CustomTLSProfile{
-			TLSProfileSpec: configv1.TLSProfileSpec{
-				Ciphers:       ciphers,
-				MinTLSVersion: configv1.VersionTLS12,
-			},
-		},
+		Type:   configv1.TLSProfileModernType,
+		Modern: &configv1.ModernTLSProfile{},
 	}
-	Expect(cl.Update(ctx, apiServer)).To(Succeed(), "Failed to update APIServer with custom TLS profile")
-	Success("Applied Custom TLS profile to APIServer")
+	Expect(cl.Update(ctx, apiServer)).To(Succeed(), "Failed to update APIServer with Modern TLS profile")
+	Success("Applied Modern TLS profile to APIServer")
+
+	Step("Waiting for kube-apiserver to finish rolling out after TLS profile change")
+	waitForAPIServerStable(ctx, cl)
+	Success("kube-apiserver is stable after TLS profile change")
 }
 
 func getIstioRevisionCipherSuites(rev *v1.IstioRevision) []string {
@@ -651,6 +670,13 @@ func getIstioRevisionCipherSuites(rev *v1.IstioRevision) []string {
 		return nil
 	}
 	return rev.Spec.Values.MeshConfig.TlsDefaults.CipherSuites
+}
+
+func getIstioRevisionProxyMetadata(rev *v1.IstioRevision) map[string]string {
+	if rev.Spec.Values == nil || rev.Spec.Values.MeshConfig == nil || rev.Spec.Values.MeshConfig.DefaultConfig == nil {
+		return nil
+	}
+	return rev.Spec.Values.MeshConfig.DefaultConfig.ProxyMetadata
 }
 
 // metricsEndpointAcceptsCipher tests whether the operator's metrics endpoint

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -458,6 +458,57 @@ spec:
 			}).Should(BeFalse(),
 				"Metrics endpoint should reject ECDHE-RSA-AES128-GCM-SHA256 after custom profile is applied")
 			Success("TLS settings were updated after profile change")
+
+			Step("Applying custom TLS profile with MinTLSVersion 1.3")
+			applyCustomTLSProfileWithMinVersion(ctx, cl, customTLSProfileCiphers, configv1.VersionTLS13)
+
+			Step("Verifying IstioRevision has TLS 1.3 settings with proxyMetadata")
+			Eventually(func(g Gomega) {
+				rev := &v1.IstioRevision{}
+				g.Expect(cl.Get(ctx, client.ObjectKey{Name: "default"}, rev)).To(Succeed())
+				g.Expect(rev.Spec.Values).NotTo(BeNil())
+				g.Expect(rev.Spec.Values.MeshConfig).NotTo(BeNil())
+
+				g.Expect(rev.Spec.Values.MeshConfig.TlsDefaults).NotTo(BeNil())
+				g.Expect(rev.Spec.Values.MeshConfig.TlsDefaults.MinProtocolVersion).To(
+					Equal(v1.MeshConfigTLSConfigTLSProtocolTlsv13),
+					"tlsDefaults.minProtocolVersion should be TLSV1_3")
+				g.Expect(rev.Spec.Values.MeshConfig.TlsDefaults.CipherSuites).To(BeEmpty(),
+					"tlsDefaults.cipherSuites should be empty for TLS 1.3")
+
+				g.Expect(rev.Spec.Values.MeshConfig.MeshMTLS).NotTo(BeNil())
+				g.Expect(rev.Spec.Values.MeshConfig.MeshMTLS.MinProtocolVersion).To(
+					Equal(v1.MeshConfigTLSConfigTLSProtocolTlsv13),
+					"meshMTLS.minProtocolVersion should be TLSV1_3")
+				g.Expect(rev.Spec.Values.MeshConfig.MeshMTLS.CipherSuites).To(BeEmpty(),
+					"meshMTLS.cipherSuites should be empty for TLS 1.3")
+
+				proxyMeta := getIstioRevisionProxyMetadata(rev)
+				g.Expect(proxyMeta).To(HaveKey("OPENSSL_TLS1_3_CIPHERSUITES"),
+					"proxyMetadata should contain OPENSSL_TLS1_3_CIPHERSUITES for TLS 1.3")
+				g.Expect(proxyMeta["OPENSSL_TLS1_3_CIPHERSUITES"]).NotTo(BeEmpty(),
+					"OPENSSL_TLS1_3_CIPHERSUITES should not be empty")
+			}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+				"IstioRevision should have TLS 1.3 proxyMetadata settings")
+
+			Step("Switching back to custom TLS profile with MinTLSVersion 1.2")
+			applyCustomTLSProfile(ctx, cl, customTLSProfileCiphers)
+
+			Step("Verifying proxyMetadata no longer has OPENSSL_TLS1_3_CIPHERSUITES")
+			Eventually(func(g Gomega) {
+				rev := &v1.IstioRevision{}
+				g.Expect(cl.Get(ctx, client.ObjectKey{Name: "default"}, rev)).To(Succeed())
+
+				ciphers := getIstioRevisionCipherSuites(rev)
+				g.Expect(ciphers).NotTo(BeEmpty(),
+					"tlsDefaults.cipherSuites should be populated for TLS 1.2 profile")
+
+				proxyMeta := getIstioRevisionProxyMetadata(rev)
+				g.Expect(proxyMeta).NotTo(HaveKey("OPENSSL_TLS1_3_CIPHERSUITES"),
+					"proxyMetadata should not contain OPENSSL_TLS1_3_CIPHERSUITES for TLS 1.2 profile")
+			}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+				"IstioRevision should revert to TLS 1.2 profile settings")
+			Success("OPENSSL_TLS1_3_CIPHERSUITES is correctly set for TLS 1.3 and cleared for TLS 1.2")
 		})
 	})
 
@@ -621,8 +672,12 @@ func ensureTLSAdherence(ctx context.Context, cl client.Client, policy configv1.T
 }
 
 func applyCustomTLSProfile(ctx context.Context, cl client.Client, ciphers []string) {
+	applyCustomTLSProfileWithMinVersion(ctx, cl, ciphers, configv1.VersionTLS12)
+}
+
+func applyCustomTLSProfileWithMinVersion(ctx context.Context, cl client.Client, ciphers []string, minVersion configv1.TLSProtocolVersion) {
 	GinkgoHelper()
-	Step("Applying a Custom TLS profile")
+	Step(fmt.Sprintf("Applying a Custom TLS profile with MinTLSVersion %s", minVersion))
 
 	apiServer := &configv1.APIServer{}
 	Expect(cl.Get(ctx, apiServerKey, apiServer)).To(Succeed(), "Failed to get APIServer")
@@ -631,12 +686,12 @@ func applyCustomTLSProfile(ctx context.Context, cl client.Client, ciphers []stri
 		Custom: &configv1.CustomTLSProfile{
 			TLSProfileSpec: configv1.TLSProfileSpec{
 				Ciphers:       ciphers,
-				MinTLSVersion: configv1.VersionTLS12,
+				MinTLSVersion: minVersion,
 			},
 		},
 	}
 	Expect(cl.Update(ctx, apiServer)).To(Succeed(), "Failed to update APIServer with custom TLS profile")
-	Success("Applied Custom TLS profile to APIServer")
+	Success(fmt.Sprintf("Applied Custom TLS profile with MinTLSVersion %s to APIServer", minVersion))
 }
 
 func getIstioRevisionCipherSuites(rev *v1.IstioRevision) []string {
@@ -644,6 +699,13 @@ func getIstioRevisionCipherSuites(rev *v1.IstioRevision) []string {
 		return nil
 	}
 	return rev.Spec.Values.MeshConfig.TlsDefaults.CipherSuites
+}
+
+func getIstioRevisionProxyMetadata(rev *v1.IstioRevision) map[string]string {
+	if rev.Spec.Values == nil || rev.Spec.Values.MeshConfig == nil || rev.Spec.Values.MeshConfig.DefaultConfig == nil {
+		return nil
+	}
+	return rev.Spec.Values.MeshConfig.DefaultConfig.ProxyMetadata
 }
 
 // metricsEndpointAcceptsCipher tests whether the operator's metrics endpoint


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Envoy does not allow setting cipher suites for TLS 1.3 BUT you can configure them in openssl when that is your crypto backend. The openshift envoy image has been updated to allow configuring these via env var.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
