### PR TITLE
test: fix OLM e2e on OCP 4.23 — PodSecurity and registry check

### DIFF
--- a/tests/e2e/ambient/ambient_suite_test.go
+++ b/tests/e2e/ambient/ambient_suite_test.go
@@ -38,7 +38,7 @@ var (
 	istioCniNamespace     = common.IstioCniNamespace
 	ztunnelNamespace      = common.ZtunnelNamespace
 	istioCniName          = env.Get("ISTIOCNI_NAME", "default")
-	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io|^registry\\.istio\\.io")
+	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io|^registry\\.istio\\.io|^registry\\.redhat\\.io")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 	keepOnFailure         = env.GetBool("KEEP_ON_FAILURE", false)
 	fipsCluster           = env.GetBool("FIPS_CLUSTER", false)

--- a/tests/e2e/common-operator-integ-suite.sh
+++ b/tests/e2e/common-operator-integ-suite.sh
@@ -379,6 +379,14 @@ if [ "${SKIP_BUILD}" == "false" ]; then
     fi
 
     ${COMMAND} create ns "${NAMESPACE}" || true
+    # OLM registry pods (registry-grpc, registry-grpc-init) don't satisfy the
+    # restricted:latest PodSecurity policy that OCP 4.23 enforces by default on new namespaces.
+    if [ "${OCP}" == "true" ]; then
+      ${COMMAND} label namespace "${NAMESPACE}" \
+        pod-security.kubernetes.io/enforce=privileged \
+        pod-security.kubernetes.io/warn=privileged \
+        pod-security.kubernetes.io/audit=privileged --overwrite || true
+    fi
     ${OPERATOR_SDK} run bundle "${BUNDLE_IMG}" -n "${NAMESPACE}" --skip-tls --timeout 5m || exit 1
 
     await_operator

--- a/tests/e2e/controlplane/control_plane_suite_test.go
+++ b/tests/e2e/controlplane/control_plane_suite_test.go
@@ -37,7 +37,7 @@ var (
 	istioName             = env.Get("ISTIO_NAME", "default")
 	istioCniNamespace     = common.IstioCniNamespace
 	istioCniName          = env.Get("ISTIOCNI_NAME", "default")
-	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io|^registry\\.istio\\.io")
+	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io|^registry\\.istio\\.io|^registry\\.redhat\\.io")
 	sampleNamespace       = env.Get("SAMPLE_NAMESPACE", "sample")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 	keepOnFailure         = env.GetBool("KEEP_ON_FAILURE", false)

--- a/tests/e2e/dualstack/dualstack_suite_test.go
+++ b/tests/e2e/dualstack/dualstack_suite_test.go
@@ -35,7 +35,7 @@ var (
 	istioName             = env.Get("ISTIO_NAME", "default")
 	istioCniNamespace     = common.IstioCniNamespace
 	istioCniName          = env.Get("ISTIOCNI_NAME", "default")
-	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io|^registry\\.istio\\.io")
+	expectedRegistry      = env.Get("EXPECTED_REGISTRY", "^docker\\.io|^gcr\\.io|^registry\\.istio\\.io|^registry\\.redhat\\.io")
 	multicluster          = env.GetBool("MULTICLUSTER", false)
 	keepOnFailure         = env.GetBool("KEEP_ON_FAILURE", false)
 	ipFamily              = env.Get("IP_FAMILY", "ipv4")


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
We can't deploy currently using OLM on OCP 4.23 because of the PodSecurity, so this PR add a change to be able to deploy the operator using OLM on those cluster versions

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
