### PR TITLE
[release-1.29] test: improve steps to avoid flaky failures on CI (#2216, #2222)

### DIFF
--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -233,7 +233,13 @@ spec:
 					})
 
 					It("has the ztunnel proxy sockets configured in the pod network namespace", func(ctx SpecContext) {
-						checkZtunnelPort(sleepPod.Items[0].Name, common.SleepNamespace)
+						// Ztunnel configures the HBONE port (15008) in the pod network namespace
+						// asynchronously after the pod becomes Ready. Retry to avoid flakes on
+						// slow clusters (e.g. OCP ARM) where the socket may not be visible yet.
+						Eventually(func(g Gomega) {
+							checkZtunnelPort(g, sleepPod.Items[0].Name, common.SleepNamespace)
+						}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+							"ztunnel should configure port 15008 in the pod network namespace")
 					})
 
 					It("can access the httpbin service from the sleep pod", func(ctx SpecContext) {
@@ -315,9 +321,9 @@ func getEnvVars(container corev1.Container) []corev1.EnvVar {
 	return container.Env
 }
 
-func checkZtunnelPort(podName, srcNamespace string) {
-	response, err := k.WithNamespace(srcNamespace).Exec(podName, srcNamespace, "netstat -tlpn")
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error validating the proxy sockets in the %q pod", podName))
+func checkZtunnelPort(g Gomega, podName, srcNamespace string) {
+	response, err := k.WithNamespace(srcNamespace).Exec(podName, common.SleepContainerName, "netstat -tlpn")
+	g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error validating the proxy sockets in the %q pod", podName))
 	// Verify that the HBONE mTLS tunnel port (15008) is listed in the output.
-	Expect(response).To(ContainSubstring("15008"), fmt.Sprintf("Unexpected response from %s pod", podName))
+	g.Expect(response).To(ContainSubstring("15008"), fmt.Sprintf("Unexpected response from %s pod", podName))
 }

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -190,11 +190,13 @@ metadata:
 					})
 
 					It("has sidecars with the correct istio version", func(ctx SpecContext) {
-						for _, pod := range samplePods.Items {
-							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
-							Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
-							Expect(sidecarVersion).To(Equal(version.Version), "Sidecar Istio version does not match the expected version")
-						}
+						Eventually(func(g Gomega) {
+							for _, pod := range samplePods.Items {
+								sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
+								g.Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
+								g.Expect(sidecarVersion).To(Equal(version.Version), "Sidecar Istio version does not match the expected version")
+							}
+						}).Should(Succeed(), "Error verifying sidecar version")
 						Success("Istio sidecar version matches the expected Istio version")
 					})
 				})

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -126,9 +126,12 @@ spec:
 					Success("sample pods are ready")
 
 					for _, pod := range samplePods.Items {
-						sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
-						Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
-						Expect(sidecarVersion).To(Equal(istioversion.Map[istioversion.Base].Version), "Sidecar Istio version does not match the expected version")
+						podName := pod.Name
+						Eventually(func(g Gomega) {
+							sidecarVersion, err := common.GetProxyVersionFromPod(podName, sampleNamespace)
+							g.Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
+							g.Expect(sidecarVersion).To(Equal(istioversion.Map[istioversion.Base].Version), "Sidecar Istio version does not match the expected version")
+						}).Should(Succeed(), "Error verifying sidecar version for pod "+podName)
 					}
 					Success("Istio sidecar version matches the expected base Istio version")
 				})
@@ -196,8 +199,12 @@ spec:
 					Expect(samplePods.Items).ToNot(BeEmpty(), "No pods found in sample namespace")
 
 					for _, pod := range samplePods.Items {
+						podName := pod.Name
 						Eventually(func(g Gomega) {
-							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
+							// Use GetProxyVersionFromPod to avoid XDS authentication issues
+							// that can occur during control plane upgrades when two istiod pods
+							// are running simultaneously on OCP.
+							sidecarVersion, err := common.GetProxyVersionFromPod(podName, sampleNamespace)
 							g.Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
 							g.Expect(sidecarVersion).To(Equal(istioversion.Map[istioversion.Base].Version))
 						}).Should(Succeed(), "Sidecar Istio version does not match the expected version")

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -51,8 +51,9 @@ const (
 )
 
 const (
-	SleepNamespace   = "sleep"
-	HttpbinNamespace = "httpbin"
+	SleepNamespace     = "sleep"
+	HttpbinNamespace   = "httpbin"
+	SleepContainerName = "sleep"
 )
 
 var (

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -476,3 +476,21 @@ func HaveContainersThat(matcher types.GomegaMatcher) types.GomegaMatcher {
 func ImageFromRegistry(regexp string) types.GomegaMatcher {
 	return HaveField("Image", MatchRegexp(regexp))
 }
+
+// GetProxyVersionFromPod extracts the Istio proxy version directly from the pod's
+// istio-proxy container by executing pilot-agent version. This approach does not
+// require XDS connectivity to istiod, making it more reliable during control plane
+// upgrades when istiod may be temporarily inaccessible.
+func GetProxyVersionFromPod(podName, namespace string) (*semver.Version, error) {
+	k := kubectl.New().WithNamespace(namespace)
+	output, err := k.Exec(podName, "istio-proxy", "pilot-agent version")
+	if err != nil {
+		return nil, fmt.Errorf("error getting proxy version from pod %s: %w", podName, err)
+	}
+
+	matches := istiodVersionRegex.FindStringSubmatch(output)
+	if len(matches) > 1 && matches[1] != "" {
+		return semver.NewVersion(matches[1])
+	}
+	return nil, fmt.Errorf("error getting proxy version from pod %s: version not found in output: %s", podName, output)
+}


### PR DESCRIPTION
## Summary
Cherry-pick of #2216 and #2222 to release-1.29.

### #2216 — improve steps to avoid flaky failures on CI

- Adds \`GetProxyVersionFromPod()\` to \`e2e_utils.go\`: uses \`kubectl exec\` to run \`pilot-agent version\` directly in the \`istio-proxy\` container, bypassing XDS connectivity (which can fail during upgrades when two istiod pods run simultaneously on OCP).
- Uses \`GetProxyVersionFromPod()\` in \`control_plane_update_test.go\` for the "proxy version on sample pods still is base version" test to avoid XDS auth issues during upgrades.
- Wraps the sidecar version check in \`control_plane_test.go\` and \`control_plane_update_test.go\` with \`Eventually\` for resilience against transient failures.

**Conflict resolutions:**
- \`control_plane_test.go\`: Applied \`Eventually\` wrapper using the local \`getProxyVersion\` function (release-1.29 uses a file-local function instead of the common package).
- \`control_plane_update_test.go\`: Adapted \`baseVersion.Version\` → \`istioversion.Map[istioversion.Base].Version\` to match release branch variable naming.
- \`e2e_utils.go\`: Added only \`GetProxyVersionFromPod\` (the actual change from #2216); dropped unrelated functions that were added to main in separate earlier PRs.
- \`operator_install_test.go\`: Kept release-1.29 HEAD (OCP-specific \`ensureTLSAdherence\` functions don't exist in this branch).
- \`migration_procedure_test.go\`: Removed (was already deleted from release-1.29).

### #2222 — fix flaky step on TestAmbient

- Wraps \`checkZtunnelPort\` call in \`Eventually\` to handle HBONE port (15008) not yet visible in the pod network namespace on slow clusters (e.g. OCP ARM).
- Updates \`checkZtunnelPort\` signature to accept a \`Gomega\` argument for use inside \`Eventually\`.
- Adds \`SleepContainerName\` constant to \`e2e_utils.go\` (already in main, missing from release-1.29).

**Conflict resolution:**
- \`ambient_test.go\`: Release-1.29 used \`srcNamespace\` as the container name (a bug); took the cherry-pick side which correctly uses \`common.SleepContainerName\`.

Fixes #2218
Fixes #2229