### PR TITLE
[release-1.26] chartmanager: disable OpenAPI validation during install (#1126)

### DIFF
--- a/pkg/helm/chartmanager.go
+++ b/pkg/helm/chartmanager.go
@@ -127,6 +127,7 @@ func (h *ChartManager) UpgradeOrInstallChart(
 		updateAction.PostRenderer = NewHelmPostRenderer(ownerReference, "", true)
 		updateAction.MaxHistory = 1
 		updateAction.SkipCRDs = true
+		updateAction.DisableOpenAPIValidation = true
 
 		rel, err = updateAction.RunWithContext(ctx, releaseName, chart, values)
 		if err != nil {
@@ -140,6 +141,7 @@ func (h *ChartManager) UpgradeOrInstallChart(
 		installAction.Namespace = namespace
 		installAction.ReleaseName = releaseName
 		installAction.SkipCRDs = true
+		installAction.DisableOpenAPIValidation = true
 
 		rel, err = installAction.RunWithContext(ctx, chart, values)
 		if err != nil {


### PR DESCRIPTION
## Summary

Cherry-pick of #1126 to release-1.26.

Disabling OpenAPI validation during Helm install/upgrade reduces memory allocations during integration tests from 58GB to 18GB. There's no need to constantly perform OpenAPI validations — we're working with pre-vetted charts, and the API server will validate again anyway.

No conflicts during cherry-pick. Already present in release-1.27 as #1185.