### PR TITLE
[release-1.26] test: fix flaky step on TestAmbient (#2222)

### DIFF
--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -244,7 +244,13 @@ spec:
 					})
 
 					It("has the ztunnel proxy sockets configured in the pod network namespace", func(ctx SpecContext) {
-						checkZtunnelPort(sleepPod.Items[0].Name, common.SleepNamespace)
+						// Ztunnel configures the HBONE port (15008) in the pod network namespace
+						// asynchronously after the pod becomes Ready. Retry to avoid flakes on
+						// slow clusters (e.g. OCP ARM) where the socket may not be visible yet.
+						Eventually(func(g Gomega) {
+							checkZtunnelPort(g, sleepPod.Items[0].Name, common.SleepNamespace)
+						}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+							"ztunnel should configure port 15008 in the pod network namespace")
 					})
 
 					It("can access the httpbin service from the sleep pod", func(ctx SpecContext) {
@@ -341,9 +347,9 @@ func checkPodConnectivity(podName, srcNamespace, destNamespace string) {
 	Expect(response).To(ContainSubstring("200"), fmt.Sprintf("Unexpected response from %s pod", podName))
 }
 
-func checkZtunnelPort(podName, srcNamespace string) {
-	response, err := k.WithNamespace(srcNamespace).Exec(podName, srcNamespace, "netstat -tlpn")
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error validating the proxy sockets in the %q pod", podName))
+func checkZtunnelPort(g Gomega, podName, srcNamespace string) {
+	response, err := k.WithNamespace(srcNamespace).Exec(podName, "sleep", "netstat -tlpn")
+	g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error validating the proxy sockets in the %q pod", podName))
 	// Verify that the HBONE mTLS tunnel port (15008) is listed in the output.
-	Expect(response).To(ContainSubstring("15008"), fmt.Sprintf("Unexpected response from %s pod", podName))
+	g.Expect(response).To(ContainSubstring("15008"), fmt.Sprintf("Unexpected response from %s pod", podName))
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #2222 to release-1.26.

Fixes flaky `TestAmbient` on OCP/slow clusters:
- Wraps `checkZtunnelPort` in `Eventually` so HBONE port (15008) can be verified with retries — the socket is configured asynchronously after pod readiness.
- Fixes a bug where `srcNamespace` (the namespace string) was incorrectly used as the container name in `kubectl exec`; now uses `"sleep"` as the container name.

**Conflict adaptations for release-1.26:**
- `common.SleepContainerName` (not yet in this branch) replaced with literal `"sleep"`
- `checkPodConnectivity` kept (still called by another test in this file; `common.ValidateHTTPConnectivity` does not exist on this branch)