### PR TITLE
test(e2e): replace remaining istioctl proxy-status calls with kubectlexec

### DIFF
--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -193,7 +193,7 @@ metadata:
 					It("has sidecars with the correct istio version", func(ctx SpecContext) {
 						Eventually(func(g Gomega) {
 							for _, pod := range samplePods.Items {
-								sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
+								sidecarVersion, err := common.GetProxyVersionFromPod(pod.Name, sampleNamespace)
 								g.Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
 								g.Expect(sidecarVersion).To(Equal(version.Version), "Sidecar Istio version does not match the expected version")
 							}

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -298,7 +298,7 @@ spec:
 						}
 
 						for _, pod := range samplePods.Items {
-							sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
+							sidecarVersion, err := common.GetProxyVersionFromPod(pod.Name, sampleNamespace)
 							if err != nil || !sidecarVersion.Equal(newVersion.Version) {
 								return false
 							}


### PR DESCRIPTION

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Two callers still used common.GetProxyVersion (which calls istioctl proxy-status over XDS) to verify sidecar versions. During control plane upgrades on OCP, when two istiod pods run simultaneously, XDS connections drop with a TLS handshake EOF, causing spurious test failures.

Replaced both with common.GetProxyVersionFromPod, which reads the version directly from the istio-proxy container via kubectl exec pilot-agent version — no XDS connectivity required.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #https://github.com/istio-ecosystem/sail-operator/issues/2243

Related Issue/PR #

#### Additional information:
