### PR TITLE
Remove errors.Unwrap to prevent silently swallowing reconcile errors

### DIFF
--- a/controllers/istiorevisiontag/istiorevisiontag_controller.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller.go
@@ -87,8 +87,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, tag *v1.IstioRevisionTag) (c
 	log.Info("Reconciliation done. Updating status.")
 	statusErr := r.updateStatus(ctx, tag, rev, reconcileErr)
 
-	reconcileErr = errors.Unwrap(reconcileErr)
-
 	return ctrl.Result{}, errors.Join(reconcileErr, statusErr)
 }
 


### PR DESCRIPTION
errors.Unwrap(err) checks whether err implements an Unwrap() error method. For errors created with errors.New or errors that don't wrap another error, it returns nil. If statusErr is also nil, the reconciler can incorrectly report success, causing the reconcile error to be silently swallowed and prevents a retry.

Fixes: https://github.com/istio-ecosystem/sail-operator/issues/2079
