### PR TITLE
Use "IgnoreStatusChanges" for NetworkPolicy in CNI and ZTunnel watches

### DIFF
--- a/pkg/watches/cni.go
+++ b/pkg/watches/cni.go
@@ -27,7 +27,7 @@ var CNIWatches = []WatchedResource{
 	{Object: &corev1.ConfigMap{}},
 	{Object: &corev1.ResourceQuota{}},
 	{Object: &corev1.ServiceAccount{}, ShouldReconcile: IgnoreAllUpdates()},
-	{Object: &networkingv1.NetworkPolicy{}, ShouldReconcile: IgnoreAllUpdates()},
+	{Object: &networkingv1.NetworkPolicy{}, ShouldReconcile: IgnoreStatusChanges()},
 	{Object: &rbacv1.ClusterRole{}},
 	{Object: &rbacv1.ClusterRoleBinding{}},
 	// +lint-watches:ignore: NetworkAttachmentDefinition (TODO: register NetAttachDef watch when the CRD is installed)

--- a/pkg/watches/ztunnel.go
+++ b/pkg/watches/ztunnel.go
@@ -26,7 +26,7 @@ var ZTunnelWatches = []WatchedResource{
 	{Object: &appsv1.DaemonSet{}},
 	{Object: &corev1.ResourceQuota{}},
 	{Object: &corev1.ServiceAccount{}, ShouldReconcile: IgnoreAllUpdates()},
-	{Object: &networkingv1.NetworkPolicy{}, ShouldReconcile: IgnoreAllUpdates()},
+	{Object: &networkingv1.NetworkPolicy{}, ShouldReconcile: IgnoreStatusChanges()},
 	{Object: &rbacv1.ClusterRole{}},
 	{Object: &rbacv1.ClusterRoleBinding{}},
 }


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
CNI and ZTunnel controllers watched NetworkPolicy with IgnoreAllUpdates, meaning spec drift was never detected or corrected. The IstioRevision controller already used the less aggressive IgnoreStatusChanges for the same resource type. Since NetworkPolicy has no status subresource, there is not risk of reconsilation churn from status updates.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #2111 

Related Issue/PR #

#### Additional information:
