### PR TITLE
Fix data race in shared Helm REST client getter

### DIFF
--- a/pkg/helm/restclientgetter.go
+++ b/pkg/helm/restclientgetter.go
@@ -15,6 +15,8 @@
 package helm
 
 import (
+	"sync"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
@@ -26,15 +28,31 @@ import (
 
 // restClientGetter is required by helm to instantiate ActionConfig
 type restClientGetter struct {
-	config          *rest.Config
-	discoveryClient discovery.CachedDiscoveryInterface
-	restMapper      meta.RESTMapper
+	config             *rest.Config
+	getDiscoveryClient func() (discovery.CachedDiscoveryInterface, error)
+	getRESTMapper      func() (meta.RESTMapper, error)
 }
 
 func NewRESTClientGetter(config *rest.Config) genericclioptions.RESTClientGetter {
-	return &restClientGetter{
-		config: config,
-	}
+	c := &restClientGetter{config: config}
+	c.getDiscoveryClient = sync.OnceValues(func() (discovery.CachedDiscoveryInterface, error) {
+		cfg := rest.CopyConfig(config)
+		cfg.Burst = 0
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return memory.NewMemCacheClient(discoveryClient), nil
+	})
+	c.getRESTMapper = sync.OnceValues(func() (meta.RESTMapper, error) {
+		discoveryClient, err := c.getDiscoveryClient()
+		if err != nil {
+			return nil, err
+		}
+		mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+		return restmapper.NewShortcutExpander(mapper, discoveryClient, nil), nil
+	})
+	return c
 }
 
 func (c *restClientGetter) ToRESTConfig() (*rest.Config, error) {
@@ -42,33 +60,11 @@ func (c *restClientGetter) ToRESTConfig() (*rest.Config, error) {
 }
 
 func (c *restClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
-	if c.discoveryClient == nil {
-		// Copy the config to avoid mutating the original config.
-		// Otherwise calling ToDiscoveryClient can cause a race condition.
-		cfg := rest.CopyConfig(c.config)
-		// use the default (high) burst for discovery
-		cfg.Burst = 0
-
-		discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
-		if err != nil {
-			return nil, err
-		}
-		c.discoveryClient = memory.NewMemCacheClient(discoveryClient)
-	}
-	return c.discoveryClient, nil
+	return c.getDiscoveryClient()
 }
 
 func (c *restClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
-	if c.restMapper == nil {
-		discoveryClient, err := c.ToDiscoveryClient()
-		if err != nil {
-			return nil, err
-		}
-
-		mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
-		c.restMapper = restmapper.NewShortcutExpander(mapper, discoveryClient, nil)
-	}
-	return c.restMapper, nil
+	return c.getRESTMapper()
 }
 
 func (c *restClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
The restClientGetter lazily initialized discoveryClient and restMapper using bare nil checks with no synchronization. Since a single instance is shared across four controllers via ChartManager, concurrent reconciliations could race on these fields. Replace the manual lazy init with sync.OnceValues to ensure thread-safe, single-execution initialization.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #2104 

Related Issue/PR #

#### Additional information:
