### PR TITLE
fix: Derive revision names from the resolved version

### DIFF
--- a/changelog/fix-revisionbased-version-alias-name.yaml
+++ b/changelog/fix-revisionbased-version-alias-name.yaml
@@ -1,0 +1,10 @@
+category: fixed
+title: Derive RevisionBased revision names from the resolved version, not a version alias
+description: |
+  When `spec.version` was set to a version alias (e.g. `v1.30-latest`), the
+  `RevisionBased` update strategy named the `IstioRevision` after the raw
+  alias instead of the resolved version. If the alias later started
+  pointing at a different patch release, the operator kept updating the
+  same revision in place instead of performing a canary upgrade to a new
+  revision.
+issueLink: https://github.com/istio-ecosystem/sail-operator/issues/2080

--- a/controllers/istio/istio_controller.go
+++ b/controllers/istio/istio_controller.go
@@ -187,7 +187,17 @@ func getActiveRevisionName(istio *v1.Istio) string {
 	case v1.UpdateStrategyTypeInPlace:
 		return istio.Name
 	case v1.UpdateStrategyTypeRevisionBased:
-		return istio.Name + "-" + strings.ReplaceAll(istio.Spec.Version, ".", "-")
+		// Use the resolved version (e.g. "v1.30.3") rather than the raw spec.Version so that
+		// moving a version alias (e.g. "v1.30-latest") to a new patch produces a new revision
+		// name. Otherwise the existing revision would be updated in place, defeating the
+		// canary upgrade behavior that RevisionBased is meant to provide. If the version can't
+		// be resolved (e.g. it's invalid), fall back to the raw value; reconcileActiveRevision
+		// will already have failed reconciliation in that case.
+		version := istio.Spec.Version
+		if resolved, err := istioversion.Resolve(version); err == nil {
+			version = resolved
+		}
+		return istio.Name + "-" + strings.ReplaceAll(version, ".", "-")
 	}
 }
 

--- a/controllers/istio/istio_controller_test.go
+++ b/controllers/istio/istio_controller_test.go
@@ -843,6 +843,26 @@ func TestGetActiveRevisionName(t *testing.T) {
 		},
 	}
 
+	// Regression test for https://github.com/istio-ecosystem/sail-operator/issues/2080: the
+	// revision name must be derived from the resolved version, not the raw alias, so that a
+	// change in what the alias points to results in a new revision name.
+	for name, info := range istioversion.Map {
+		if name != istioversion.New && info.Name == istioversion.New {
+			tests = append(tests, struct {
+				name                 string
+				version              string
+				updateStrategyType   *v1.UpdateStrategyType
+				expectedRevisionName string
+			}{
+				name:                 "RevisionBased with version alias",
+				version:              name,
+				updateStrategyType:   ptr.Of(v1.UpdateStrategyTypeRevisionBased),
+				expectedRevisionName: "test-istio-" + strings.ReplaceAll(istioversion.New, ".", "-"),
+			})
+			break
+		}
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			istio := &v1.Istio{

--- a/tests/integration/api/istio_test.go
+++ b/tests/integration/api/istio_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
+	"github.com/istio-ecosystem/sail-operator/pkg/revision"
 	. "github.com/istio-ecosystem/sail-operator/pkg/test/util/ginkgo"
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	. "github.com/onsi/ginkgo/v2"
@@ -715,6 +716,118 @@ var _ = Describe("Istio resource", Ordered, func() {
 			Consistently(k8sClient.Get).WithArguments(ctx, validatorWebhookKey, &admissionv1.ValidatingWebhookConfiguration{}).Should(ReturnNotFoundError())
 		})
 	})
+
+	Describe("RevisionBased strategy with a version alias", func() {
+		// Regression test for https://github.com/istio-ecosystem/sail-operator/issues/2080:
+		// revision names used to be derived from the raw (unresolved) spec.Version. This meant
+		// that a version alias (e.g. "v1.30-latest") always produced the same revision name even
+		// after the alias started pointing at a different patch release, so what should have been
+		// a RevisionBased canary upgrade instead silently mutated the existing revision in place.
+		var (
+			aliasVersion    string
+			resolvedVersion string
+		)
+
+		BeforeAll(func() {
+			resolvedVersion = istioversion.New
+			aliasVersion = findAliasFor(resolvedVersion)
+			if aliasVersion == "" {
+				Skip("no version alias points to the latest version; skipping alias regression test")
+			}
+		})
+
+		It("names the IstioRevision after the resolved version, not the alias", func() {
+			istio = &v1.Istio{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: istioName,
+				},
+				Spec: v1.IstioSpec{
+					Version:   aliasVersion,
+					Namespace: istioNamespace,
+					UpdateStrategy: &v1.IstioUpdateStrategy{
+						Type: v1.UpdateStrategyTypeRevisionBased,
+						InactiveRevisionDeletionGracePeriodSeconds: ptr.Of(int64(gracePeriod.Seconds())),
+					},
+				},
+			}
+			createIstioWithCleanup(ctx, istio)
+
+			revKey := getRevisionKey(istio, resolvedVersion)
+			rev := &v1.IstioRevision{}
+			Eventually(k8sClient.Get).WithArguments(ctx, revKey, rev).Should(Succeed())
+			Expect(rev.Spec.Version).To(Equal(resolvedVersion))
+
+			aliasRevKey := getRevisionKey(istio, aliasVersion)
+			Consistently(k8sClient.Get).WithArguments(ctx, aliasRevKey, &v1.IstioRevision{}).Should(ReturnNotFoundError())
+		})
+
+		// Simulates upgrading the operator across this fix: an existing revision was named after
+		// the alias by a pre-fix operator build; the newly-reconciled Istio must not keep updating
+		// that revision in place. Instead it should create a new, correctly-named revision and
+		// prune the old one once its grace period expires.
+		When("an old-style revision (named after the alias) already exists from before the fix", func() {
+			var oldRevisionKey client.ObjectKey
+
+			BeforeAll(func() {
+				istio = &v1.Istio{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: istioName,
+					},
+					Spec: v1.IstioSpec{
+						Version:   aliasVersion,
+						Namespace: istioNamespace,
+						UpdateStrategy: &v1.IstioUpdateStrategy{
+							Type: v1.UpdateStrategyTypeRevisionBased,
+							InactiveRevisionDeletionGracePeriodSeconds: ptr.Of(int64(gracePeriod.Seconds())),
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, istio)).To(Succeed())
+
+				// Recreate what a pre-fix operator would have created: a revision named after
+				// the raw alias instead of the resolved version.
+				oldRevisionKey = getRevisionKey(istio, aliasVersion)
+				values, err := revision.ComputeValues(
+					istio.Spec.Values, istio.Spec.Namespace, resolvedVersion,
+					istioReconciler.Config.Platform, istioReconciler.Config.DefaultProfile, istio.Spec.Profile,
+					istioReconciler.Config.ResourceFS, oldRevisionKey.Name, istioReconciler.Config.TLSConfig)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(revision.CreateOrUpdate(ctx, k8sClient,
+					oldRevisionKey.Name, resolvedVersion, istio.Spec.Namespace, values,
+					metav1.OwnerReference{
+						APIVersion:         v1.GroupVersion.String(),
+						Kind:               v1.IstioKind,
+						Name:               istio.Name,
+						UID:                istio.UID,
+						Controller:         ptr.Of(true),
+						BlockOwnerDeletion: ptr.Of(true),
+					})).To(Succeed())
+			})
+
+			AfterAll(func() {
+				deleteAllIstiosAndRevisions(ctx)
+			})
+
+			It("creates a new, correctly-named IstioRevision instead of reusing the old one", func() {
+				revKey := getRevisionKey(istio, resolvedVersion)
+				rev := &v1.IstioRevision{}
+				Eventually(k8sClient.Get).WithArguments(ctx, revKey, rev).Should(Succeed())
+				Expect(rev.Spec.Version).To(Equal(resolvedVersion))
+			})
+
+			It("doesn't immediately delete the old alias-named revision", func() {
+				marginOfError := 2 * time.Second
+				Consistently(k8sClient.Get, gracePeriod-marginOfError).WithArguments(ctx, oldRevisionKey, &v1.IstioRevision{}).Should(Succeed())
+			})
+
+			When("grace period expires", func() {
+				It("prunes the old alias-named revision", func() {
+					marginOfError := 30 * time.Second
+					Eventually(k8sClient.Get, gracePeriod+marginOfError).WithArguments(ctx, oldRevisionKey, &v1.IstioRevision{}).Should(ReturnNotFoundError())
+				})
+			})
+		})
+	})
 })
 
 func deleteAllIstiosAndRevisions(ctx context.Context) {
@@ -758,6 +871,17 @@ func getRevisionName(istio *v1.Istio, version string) string {
 		return istio.Name
 	}
 	return istio.Name + "-" + strings.ReplaceAll(version, ".", "-")
+}
+
+// findAliasFor returns a version alias name (e.g. "v1.30-latest") that currently resolves to
+// target, or "" if none exists.
+func findAliasFor(target string) string {
+	for name, info := range istioversion.Map {
+		if name != target && info.Name == target {
+			return name
+		}
+	}
+	return ""
 }
 
 func getObject(ctx context.Context, cl client.Client, key client.ObjectKey, obj client.Object) (client.Object, error) {


### PR DESCRIPTION
Previously, when `spec.version` was set to an alias we would include that literal alias name in the resulting revision name in RevisionBased deployments. That meant that when the latest patch version changed, we performed an in-place upgrade rather than a RevisionBased upgrade. This commit fixes the behavior by resolving the underlying version name and using it for the revision name.