### PR TITLE
fix: bot PRs don't need changelog entries

### DIFF
--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'skip-changelog') &&
-      github.actor != 'openshiftservicemeshbot' &&
+      github.actor != 'openshift-service-mesh-bot' &&
       github.actor != 'istio-testing'
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
We were matching against the wrong username. Shame on Claude for hallucinating it. And shame on me for not catching it in review.