### PR TITLE
test: fix TLSAdherence restart check to detect in-place container res…

### DIFF
--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -577,14 +577,29 @@ func ensureTLSAdherence(ctx context.Context, cl client.Client, policy configv1.T
 		return
 	}
 
-	// Wait for the operator to restart after the TLSAdherence change.
-	oldUIDs := make(map[string]struct{})
+	totalRestarts := func(pod corev1.Pod) int32 {
+		var n int32
+		for _, cs := range pod.Status.ContainerStatuses {
+			n += cs.RestartCount
+		}
+		return n
+	}
+	podReady := func(pod corev1.Pod) bool {
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady {
+				return cond.Status == corev1.ConditionTrue
+			}
+		}
+		return false
+	}
+
+	oldRestarts := make(map[string]int32)
 	podList := &corev1.PodList{}
 	Expect(cl.List(ctx, podList, client.InNamespace(namespace),
 		client.MatchingLabels{"control-plane": deploymentName})).To(Succeed(),
 		"Failed to list operator pods before TLSAdherence change")
 	for _, pod := range podList.Items {
-		oldUIDs[string(pod.UID)] = struct{}{}
+		oldRestarts[string(pod.UID)] = totalRestarts(pod)
 	}
 
 	Step(fmt.Sprintf("Updating APIServer TLSAdherence to %s", policy))
@@ -597,25 +612,17 @@ func ensureTLSAdherence(ctx context.Context, cl client.Client, policy configv1.T
 		g.Expect(cl.List(ctx, pods, client.InNamespace(namespace),
 			client.MatchingLabels{"control-plane": deploymentName})).To(Succeed())
 
-		found := false
+		restarted := false
 		for _, pod := range pods.Items {
-			if _, wasOld := oldUIDs[string(pod.UID)]; wasOld {
+			if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning || !podReady(pod) {
 				continue
 			}
-			if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
-				continue
-			}
-			for _, cond := range pod.Status.Conditions {
-				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-					found = true
-					break
-				}
-			}
-			if found {
+			if prev, seen := oldRestarts[string(pod.UID)]; !seen || totalRestarts(pod) > prev {
+				restarted = true
 				break
 			}
 		}
-		g.Expect(found).To(BeTrue(), "No new ready operator pod found after TLSAdherence change to %s", policy)
+		g.Expect(restarted).To(BeTrue(), "Operator did not restart (in place or via a new pod) after TLSAdherence change to %s", policy)
 	}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
 		"Operator should restart and be ready after TLSAdherence change")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [x] Test
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

#### What this PR does / why we need it:

Fixes the operator restart check in the `ensureTLSAdherence` e2e helper (`tests/e2e/operator/operator_install_test.go`), which was added in #2216.

**The bug.** After updating `APIServer.Spec.TLSAdherence`, the helper waited up to 5 minutes for a **brand-new operator pod** — a pod whose UID was *not* in the set captured before the change — to become `Running` and `Ready`:

```go
oldUIDs := <UIDs of control-plane=<deploymentName> pods before the change>
...
// waits for a pod whose UID ∉ oldUIDs to be Running + Ready
g.Expect(found).To(BeTrue(), "No new ready operator pod found after ...")
```

But the operator does **not** roll out a new pod on a TLSAdherence change. It reloads its configuration by shutting down its manager (`cmd/main.go`: `OnAdherencePolicyChange -> shutdown()`), which makes the process exit and the kubelet **restart the container in place** (`restartPolicy: Always`). The pod is not recreated, so its **UID never changes** — only the container's `RestartCount` increments. The new-UID wait can therefore never be satisfied and runs the full 5-minute timeout.

**Why it wasn't caught.** This code path is only exercised on **standalone** clusters. On hosted/HyperShift clusters the whole TLS profile group is skipped because the `APIServer` resource is read-only (`operator_install_test.go`: *"Skipping TLS profile tests on hosted cluster"*). Wherever OCP e2e runs on hosted clusters the spec is skipped and the bug stays latent; wherever the suite runs against a standalone cluster it fails deterministically (100%).

**The fix.** Keep the exact same intent introduced by #2216 — *"wait until the operator has restarted AND is Ready before proceeding"* — but detect the restart correctly. Instead of requiring a new pod UID, we now record each operator pod's `RestartCount` as a baseline and treat the operator as restarted when a `Running` + `Ready` pod's `RestartCount` has increased. A brand-new pod (an unseen UID) is still accepted as a valid restart, so the check remains correct if the reload mechanism ever changes to a full pod rollout.

This is a strict superset of the previous condition: everything the old check would have accepted (a new ready pod) is still accepted, plus the in-place container restart that actually occurs. Timeout, polling interval and the readiness requirement are unchanged.

**Validation.** Verified on the one CI job that actually runs this spec on a standalone cluster: with this change the Operator Installation suite goes from `6 Passed | 1 Failed` (300s timeout on the TLSAdherence spec) to `7/7 specs SUCCESS`, with no `"No new ready operator pod"` / `"did not restart"` timeout and no regressions in the other suites.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #2216

#### Additional information:

This change was validated downstream against a **standalone** OCP cluster (the only environment that actually runs this spec) in this test PR: https://github.com/openshift-service-mesh/sail-operator/pull/1101

Job history for that e2e job (permanently red before the fix, green with it): https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-service-mesh-sail-operator-release-3.4-ocp-4.22-e2e-ocp

The same fix is needed on the release branches that carry the `ensureTLSAdherence` restart block (cherry-picked from #2216): **`release-1.30`**. From there it flows to the midstream branches via the automated upstream-merge bot.
