### PR TITLE
Fix nondeterministic finalizer ordering

### DIFF
--- a/changelog/fix-finalizer-nondeterministic-order.yaml
+++ b/changelog/fix-finalizer-nondeterministic-order.yaml
@@ -1,8 +1,0 @@
-category: fixed
-title: Fix nondeterministic finalizer ordering
-description: |
-  `AddFinalizer` and `RemoveFinalizer` used `UnsortedList()` when writing
-  finalizers back to the object, which could reorder existing finalizers
-  randomly whenever one was added or removed. They now use `SortedList()`
-  for deterministic ordering.
-issueLink: https://github.com/istio-ecosystem/sail-operator/issues/2090

--- a/changelog/fix-finalizer-nondeterministic-order.yaml
+++ b/changelog/fix-finalizer-nondeterministic-order.yaml
@@ -1,0 +1,8 @@
+category: fixed
+title: Fix nondeterministic finalizer ordering
+description: |
+  `AddFinalizer` and `RemoveFinalizer` used `UnsortedList()` when writing
+  finalizers back to the object, which could reorder existing finalizers
+  randomly whenever one was added or removed. They now use `SortedList()`
+  for deterministic ordering.
+issueLink: https://github.com/istio-ecosystem/sail-operator/issues/2090

--- a/pkg/kube/finalizers.go
+++ b/pkg/kube/finalizers.go
@@ -39,7 +39,7 @@ func RemoveFinalizer(ctx context.Context, cl client.Client, obj client.Object, f
 
 	finalizers := sets.New(obj.GetFinalizers()...)
 	finalizers.Delete(finalizer)
-	obj.SetFinalizers(finalizers.UnsortedList())
+	obj.SetFinalizers(sets.SortedList(finalizers))
 
 	err := cl.Update(ctx, obj)
 	if errors.IsNotFound(err) {
@@ -61,7 +61,7 @@ func AddFinalizer(ctx context.Context, cl client.Client, obj client.Object, fina
 
 	finalizers := sets.New(obj.GetFinalizers()...)
 	finalizers.Insert(finalizer)
-	obj.SetFinalizers(finalizers.UnsortedList())
+	obj.SetFinalizers(sets.SortedList(finalizers))
 
 	err := cl.Update(ctx, obj)
 	if errors.IsNotFound(err) {

--- a/pkg/kube/finalizers_test.go
+++ b/pkg/kube/finalizers_test.go
@@ -136,6 +136,14 @@ func TestRemoveFinalizer(t *testing.T) {
 			checkFinalizers:    true,
 			expectedFinalizers: nil,
 		},
+		{
+			name:               "finalizers written in sorted order",
+			initialFinalizers:  []string{constants.FinalizerName, "z.example.com/finalizer", "a.example.com/finalizer"},
+			expectResult:       ctrl.Result{},
+			expectError:        false,
+			checkFinalizers:    true,
+			expectedFinalizers: []string{"a.example.com/finalizer", "z.example.com/finalizer"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -165,7 +173,7 @@ func TestRemoveFinalizer(t *testing.T) {
 
 			if tc.checkFinalizers {
 				g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
-				g.Expect(obj.GetFinalizers()).To(ConsistOf(tc.expectedFinalizers))
+				g.Expect(obj.GetFinalizers()).To(Equal(tc.expectedFinalizers))
 			}
 		})
 	}
@@ -237,6 +245,14 @@ func TestAddFinalizer(t *testing.T) {
 			checkFinalizers:    true,
 			expectedFinalizers: []string{constants.FinalizerName},
 		},
+		{
+			name:               "finalizers written in sorted order",
+			initialFinalizers:  []string{"z.example.com/finalizer", "a.example.com/finalizer"},
+			expectResult:       ctrl.Result{},
+			expectError:        false,
+			checkFinalizers:    true,
+			expectedFinalizers: []string{"a.example.com/finalizer", constants.FinalizerName, "z.example.com/finalizer"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -266,7 +282,7 @@ func TestAddFinalizer(t *testing.T) {
 
 			if tc.checkFinalizers {
 				g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
-				g.Expect(obj.GetFinalizers()).To(ConsistOf(tc.expectedFinalizers))
+				g.Expect(obj.GetFinalizers()).To(Equal(tc.expectedFinalizers))
 			}
 		})
 	}


### PR DESCRIPTION
In Go, map iteration order is unspecified and isn’t guaranteed to be the same from one iteration to the next, which makes using `UnsortedList()` nondeterministic. While describing the issue as happening on “every reconcile” is a bit of an exaggeration, the underlying bug is real. Using `SortedList()` is harmless regardless of how often it actually occurs. When `AddFinalizer` or `RemoveFinalizer` runs on an object that already has other finalizers, the write can otherwise randomly reorder all of them instead of simply appending or removing the relevant entry.

Fixes: https://github.com/istio-ecosystem/sail-operator/issues/2090
