### PR TITLE
[release-1.30] test: fix TLSAdherence restart check to detect in-place container res…

### DIFF
--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -546,14 +546,29 @@ func ensureTLSAdherence(ctx context.Context, cl client.Client, policy configv1.T
 		return
 	}
 
-	// Wait for the operator to restart after the TLSAdherence change.
-	oldUIDs := make(map[string]struct{})
+	totalRestarts := func(pod corev1.Pod) int32 {
+		var n int32
+		for _, cs := range pod.Status.ContainerStatuses {
+			n += cs.RestartCount
+		}
+		return n
+	}
+	podReady := func(pod corev1.Pod) bool {
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady {
+				return cond.Status == corev1.ConditionTrue
+			}
+		}
+		return false
+	}
+
+	oldRestarts := make(map[string]int32)
 	podList := &corev1.PodList{}
 	Expect(cl.List(ctx, podList, client.InNamespace(namespace),
 		client.MatchingLabels{"control-plane": deploymentName})).To(Succeed(),
 		"Failed to list operator pods before TLSAdherence change")
 	for _, pod := range podList.Items {
-		oldUIDs[string(pod.UID)] = struct{}{}
+		oldRestarts[string(pod.UID)] = totalRestarts(pod)
 	}
 
 	Step(fmt.Sprintf("Updating APIServer TLSAdherence to %s", policy))
@@ -566,25 +581,17 @@ func ensureTLSAdherence(ctx context.Context, cl client.Client, policy configv1.T
 		g.Expect(cl.List(ctx, pods, client.InNamespace(namespace),
 			client.MatchingLabels{"control-plane": deploymentName})).To(Succeed())
 
-		found := false
+		restarted := false
 		for _, pod := range pods.Items {
-			if _, wasOld := oldUIDs[string(pod.UID)]; wasOld {
+			if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning || !podReady(pod) {
 				continue
 			}
-			if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
-				continue
-			}
-			for _, cond := range pod.Status.Conditions {
-				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-					found = true
-					break
-				}
-			}
-			if found {
+			if prev, seen := oldRestarts[string(pod.UID)]; !seen || totalRestarts(pod) > prev {
+				restarted = true
 				break
 			}
 		}
-		g.Expect(found).To(BeTrue(), "No new ready operator pod found after TLSAdherence change to %s", policy)
+		g.Expect(restarted).To(BeTrue(), "Operator did not restart (in place or via a new pod) after TLSAdherence change to %s", policy)
 	}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
 		"Operator should restart and be ready after TLSAdherence change")
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #2271 to `release-1.30`.

Fixes the operator restart check in the `ensureTLSAdherence` e2e helper (`tests/e2e/operator/operator_install_test.go`), which was added on this branch by the cherry-pick of #2216.

**The bug.** After updating `APIServer.Spec.TLSAdherence`, the helper waited up to 5 minutes for a **brand-new operator pod** — a pod whose UID was *not* in the set captured before the change — to become `Running` and `Ready`. But the operator does **not** roll out a new pod on a TLSAdherence change. It reloads its configuration by shutting down its manager (`cmd/main.go`: `OnAdherencePolicyChange -> shutdown()`), which makes the process exit and the kubelet **restart the container in place** (`restartPolicy: Always`). The pod is not recreated, so its **UID never changes** — only the container's `RestartCount` increments. The new-UID wait can therefore never be satisfied and runs the full 5-minute timeout.

**Why it wasn't caught.** This code path is only exercised on **standalone** clusters. On hosted/HyperShift clusters the whole TLS profile group is skipped because the `APIServer` resource is read-only. Wherever OCP e2e runs on hosted clusters the spec is skipped and the bug stays latent; wherever the suite runs against a standalone cluster it fails deterministically (100%).

**The fix.** Keep the exact same intent introduced by #2216 — *"wait until the operator has restarted AND is Ready before proceeding"* — but detect the restart correctly. Instead of requiring a new pod UID, we now record each operator pod's `RestartCount` as a baseline and treat the operator as restarted when a `Running` + `Ready` pod's `RestartCount` has increased. A brand-new pod (an unseen UID) is still accepted as a valid restart, so the check remains correct if the reload mechanism ever changes to a full pod rollout.

This is a strict superset of the previous condition: everything the old check would have accepted (a new ready pod) is still accepted, plus the in-place container restart that actually occurs. Timeout, polling interval and the readiness requirement are unchanged.

**Cherry-pick notes:** applies cleanly with no conflicts; no adaptations required for `release-1.30`.

#### Which issue(s) this PR fixes:

Related Issue/PR #2216, #2271

#### Additional information:

This change was validated downstream against a **standalone** OCP cluster (the only environment that actually runs this spec) in this test PR: https://github.com/openshift-service-mesh/sail-operator/pull/1101

Job history for that e2e job (permanently red before the fix, green with it): https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-service-mesh-sail-operator-release-3.4-ocp-4.22-e2e-ocp
