### PR TITLE
Avoid needless webhook config updates

### DIFF
--- a/changelog/fix-webhook-probe-redundant-updates.yaml
+++ b/changelog/fix-webhook-probe-redundant-updates.yaml
@@ -1,0 +1,11 @@
+category: fixed
+title: Avoid redundant webhook config updates and reject invalid probe annotations
+description: |
+  The webhook readiness controller called `Update` on the
+  MutatingWebhookConfiguration on every reconcile, even when the readiness
+  status and reason were unchanged, causing needless API requests and
+  audit-log entries for each remote control plane. It now updates only when a
+  value actually changes. Zero, negative, or non-numeric probe period/timeout
+  annotations are also rejected in favor of the defaults, preventing a
+  requeue hot loop and a disabled probe timeout.
+issueLink: https://github.com/istio-ecosystem/sail-operator/issues/2084

--- a/controllers/webhook/webhook_controller.go
+++ b/controllers/webhook/webhook_controller.go
@@ -88,17 +88,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, webhook *admissionv1.Mutatin
 		reason = err.Error()
 	}
 
-	if webhook.Annotations == nil {
-		webhook.Annotations = make(map[string]string)
-	}
-	webhook.Annotations[constants.WebhookReadinessProbeStatusAnnotationKey] = strconv.FormatBool(isReady)
-	webhook.Annotations[constants.WebhookReadinessProbeStatusReasonAnnotationKey] = reason
+	status := strconv.FormatBool(isReady)
+	if webhook.Annotations[constants.WebhookReadinessProbeStatusAnnotationKey] != status ||
+		webhook.Annotations[constants.WebhookReadinessProbeStatusReasonAnnotationKey] != reason {
+		if webhook.Annotations == nil {
+			webhook.Annotations = make(map[string]string)
+		}
+		webhook.Annotations[constants.WebhookReadinessProbeStatusAnnotationKey] = status
+		webhook.Annotations[constants.WebhookReadinessProbeStatusReasonAnnotationKey] = reason
 
-	err = r.Client.Update(ctx, webhook)
-	if err != nil {
-		return ctrl.Result{}, err
+		if err := r.Client.Update(ctx, webhook); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
-	return ctrl.Result{RequeueAfter: getPeriod(webhook)}, nil
+	return ctrl.Result{RequeueAfter: getPeriod(ctx, webhook)}, nil
 }
 
 func doProbe(ctx context.Context, webhook *admissionv1.MutatingWebhookConfiguration) (bool, error) {
@@ -120,7 +123,7 @@ func doProbe(ctx context.Context, webhook *admissionv1.MutatingWebhookConfigurat
 	}
 
 	httpClient := http.Client{
-		Timeout: getTimeout(webhook),
+		Timeout: getTimeout(ctx, webhook),
 		Transport: &http.Transport{
 			DialContext: customDialContext,
 			TLSClientConfig: &tls.Config{
@@ -235,22 +238,26 @@ func IsOwnedByRevisionWithRemoteControlPlane(cl client.Client, obj client.Object
 	return false
 }
 
-func getPeriod(webhook *admissionv1.MutatingWebhookConfiguration) time.Duration {
-	if period, ok := webhook.Annotations[constants.WebhookReadinessProbePeriodSecondsAnnotationKey]; ok {
-		if p, err := strconv.Atoi(period); err == nil {
-			return time.Duration(p) * time.Second
-		}
-	}
-	return defaultPeriodSeconds * time.Second
+func getPeriod(ctx context.Context, webhook *admissionv1.MutatingWebhookConfiguration) time.Duration {
+	return getSecondsAnnotation(ctx, webhook, constants.WebhookReadinessProbePeriodSecondsAnnotationKey, defaultPeriodSeconds)
 }
 
-func getTimeout(webhook *admissionv1.MutatingWebhookConfiguration) time.Duration {
-	if period, ok := webhook.Annotations[constants.WebhookReadinessProbeTimeoutSecondsAnnotationKey]; ok {
-		if p, err := strconv.Atoi(period); err == nil {
-			return time.Duration(p) * time.Second
+func getTimeout(ctx context.Context, webhook *admissionv1.MutatingWebhookConfiguration) time.Duration {
+	return getSecondsAnnotation(ctx, webhook, constants.WebhookReadinessProbeTimeoutSecondsAnnotationKey, defaultTimeoutSeconds)
+}
+
+// getSecondsAnnotation returns the duration parsed from the given annotation, falling back to the
+// default when the annotation is missing, unparseable, or not a positive value. A non-positive or
+// unparseable value is logged at debug verbosity to aid troubleshooting misconfigured annotations.
+func getSecondsAnnotation(ctx context.Context, webhook *admissionv1.MutatingWebhookConfiguration, key string, defaultSeconds int) time.Duration {
+	if value, ok := webhook.Annotations[key]; ok {
+		if seconds, err := strconv.Atoi(value); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
 		}
+		logf.FromContext(ctx).V(3).Info("Ignoring invalid probe annotation, using default",
+			"annotation", key, "value", value, "default", defaultSeconds)
 	}
-	return defaultTimeoutSeconds * time.Second
+	return time.Duration(defaultSeconds) * time.Second
 }
 
 func wrapEventHandler(logger logr.Logger, handler handler.EventHandler) handler.EventHandler {

--- a/controllers/webhook/webhook_controller_test.go
+++ b/controllers/webhook/webhook_controller_test.go
@@ -112,6 +112,38 @@ func TestReconcile(t *testing.T) {
 			expectResult: ctrl.Result{RequeueAfter: 123 * time.Second},
 			expectValue:  "true",
 		},
+		{
+			name: "skips update when annotations unchanged",
+			setup: func(webhook *admissionv1.MutatingWebhookConfiguration) {
+				webhook.Annotations = map[string]string{
+					constants.WebhookReadinessProbeStatusAnnotationKey:       "true",
+					constants.WebhookReadinessProbeStatusReasonAnnotationKey: "",
+				}
+			},
+			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
+				return true, nil
+			},
+			interceptors: interceptor.Funcs{
+				Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					return errors.New("Update should not be called when annotations are unchanged")
+				},
+			},
+			expectResult: ctrl.Result{RequeueAfter: defaultPeriodSeconds * time.Second},
+			expectValue:  "true",
+		},
+		{
+			name: "invalid period annotation falls back to default",
+			setup: func(webhook *admissionv1.MutatingWebhookConfiguration) {
+				webhook.Annotations = map[string]string{
+					constants.WebhookReadinessProbePeriodSecondsAnnotationKey: "-5",
+				}
+			},
+			probeFunc: func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error) {
+				return true, nil
+			},
+			expectResult: ctrl.Result{RequeueAfter: defaultPeriodSeconds * time.Second},
+			expectValue:  "true",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -144,6 +176,70 @@ func TestReconcile(t *testing.T) {
 
 			g.Expect(cl.Get(ctx, kube.Key("istio-sidecar-injector"), webhook)).To(Succeed())
 			g.Expect(webhook.Annotations[constants.WebhookReadinessProbeStatusAnnotationKey]).To(Equal(tt.expectValue), "Unexpected annotation value")
+		})
+	}
+}
+
+func TestGetPeriodAndTimeout(t *testing.T) {
+	tests := []struct {
+		name           string
+		annotations    map[string]string
+		expectedPeriod time.Duration
+		expectTimeout  time.Duration
+	}{
+		{
+			name:           "no annotations returns defaults",
+			annotations:    nil,
+			expectedPeriod: defaultPeriodSeconds * time.Second,
+			expectTimeout:  defaultTimeoutSeconds * time.Second,
+		},
+		{
+			name: "valid values are honored",
+			annotations: map[string]string{
+				constants.WebhookReadinessProbePeriodSecondsAnnotationKey:  "10",
+				constants.WebhookReadinessProbeTimeoutSecondsAnnotationKey: "20",
+			},
+			expectedPeriod: 10 * time.Second,
+			expectTimeout:  20 * time.Second,
+		},
+		{
+			name: "zero values fall back to defaults",
+			annotations: map[string]string{
+				constants.WebhookReadinessProbePeriodSecondsAnnotationKey:  "0",
+				constants.WebhookReadinessProbeTimeoutSecondsAnnotationKey: "0",
+			},
+			expectedPeriod: defaultPeriodSeconds * time.Second,
+			expectTimeout:  defaultTimeoutSeconds * time.Second,
+		},
+		{
+			name: "negative values fall back to defaults",
+			annotations: map[string]string{
+				constants.WebhookReadinessProbePeriodSecondsAnnotationKey:  "-3",
+				constants.WebhookReadinessProbeTimeoutSecondsAnnotationKey: "-7",
+			},
+			expectedPeriod: defaultPeriodSeconds * time.Second,
+			expectTimeout:  defaultTimeoutSeconds * time.Second,
+		},
+		{
+			name: "non-numeric values fall back to defaults",
+			annotations: map[string]string{
+				constants.WebhookReadinessProbePeriodSecondsAnnotationKey:  "abc",
+				constants.WebhookReadinessProbeTimeoutSecondsAnnotationKey: "xyz",
+			},
+			expectedPeriod: defaultPeriodSeconds * time.Second,
+			expectTimeout:  defaultTimeoutSeconds * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			webhook := &admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			g.Expect(getPeriod(ctx, webhook)).To(Equal(tt.expectedPeriod))
+			g.Expect(getTimeout(ctx, webhook)).To(Equal(tt.expectTimeout))
 		})
 	}
 }


### PR DESCRIPTION
The webhook controller called Update on the MutatingWebhookConfiguration on every reconcile (every 3s by default), even when the readiness status and reason hadn't changed. The API server dedups no-op updates so this usually dosent hit etcd, but it still meant a needless API request, admission processing every few seconds for each remote control plane. Now we only call Update when a value actually changes.

Also, the period and timeout annotations were parsed without checking the result, so a zero or negative value slipped through. A negative period made the controller requeue immediately in a tight loop, and a zero timeout turned off the HTTP timeout completely. We now fall back to the defaults for any value that isn't a positive number, and log it at debug level so a misconfigured annotation is easier to spot.

Fixes: https://github.com/istio-ecosystem/sail-operator/issues/2084
