### PR TITLE
Return API errors from IstioRevision tag conflict check

### DIFF
--- a/controllers/istiorevision/istiorevision_controller.go
+++ b/controllers/istiorevision/istiorevision_controller.go
@@ -182,6 +182,8 @@ func (r *Reconciler) validateNoTagConflict(ctx context.Context, rev *v1.IstioRev
 		if validation.ResourceTakesPrecedence(&tag.ObjectMeta, &rev.ObjectMeta) {
 			return reconciler.NewNameAlreadyExistsError("an IstioRevisionTag exists with this name", nil)
 		}
+	} else if !apierrors.IsNotFound(err) {
+		return err
 	}
 	return nil
 }

--- a/controllers/istiorevision/istiorevision_controller_test.go
+++ b/controllers/istiorevision/istiorevision_controller_test.go
@@ -53,10 +53,11 @@ func TestValidate(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		rev       *v1.IstioRevision
-		objects   []client.Object
-		expectErr string
+		name         string
+		rev          *v1.IstioRevision
+		objects      []client.Object
+		interceptors interceptor.Funcs
+		expectErr    string
 	}{
 		{
 			name: "success",
@@ -195,11 +196,38 @@ func TestValidate(t *testing.T) {
 			objects:   []client.Object{ns},
 			expectErr: `values.revision does not match revision name`,
 		},
+		{
+			name: "tag conflict check fails with transient error",
+			rev: &v1.IstioRevision{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: v1.IstioRevisionSpec{
+					Version:   istioversion.Default,
+					Namespace: "istio-system",
+					Values: &v1.Values{
+						Global: &v1.GlobalConfig{
+							IstioNamespace: ptr.Of("istio-system"),
+						},
+					},
+				},
+			},
+			objects: []client.Object{ns},
+			interceptors: interceptor.Funcs{
+				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*v1.IstioRevisionTag); ok {
+						return fmt.Errorf("simulated error")
+					}
+					return cl.Get(ctx, key, obj, opts...)
+				},
+			},
+			expectErr: "simulated error",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tc.objects...).Build()
+			cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(tc.objects...).WithInterceptorFuncs(tc.interceptors).Build()
 
 			// Create controller reconciler for CRD-specific validations
 			reconciler := &Reconciler{


### PR DESCRIPTION
validateNoTagConflict only reacted when Client.Get returned no error, so a transient API error looked the same as "no tag with this name". That let a conflicting IstioRevision pass validation and install, fighting an identically-named IstioRevisionTag over the same webhook resources. Now we return any non-NotFound error, matching the check that already exists in the IstioRevisionTag controller.

Fixes: https://github.com/istio-ecosystem/sail-operator/issues/2082
