### PR TITLE
Revert "Add new sail-operator chart release - 1.30.4 (#2298)"

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,16 +2,6 @@ apiVersion: v1
 entries:
   sail-operator:
   - apiVersion: v2
-    appVersion: 1.30.4
-    created: "2026-09-02T07:05:54.209727112Z"
-    description: A Helm chart for Kubernetes
-    digest: ab47738dce461f959914515e17c029c08ca49d3c631afd4ab7da7966e249f292
-    name: sail-operator
-    type: application
-    urls:
-    - https://github.com/istio-ecosystem/sail-operator/releases/download/1.30.4/sail-operator-1.30.4.tgz
-    version: 1.30.4
-  - apiVersion: v2
     appVersion: 1.30.3
     created: "2026-07-22T06:06:19.897149593Z"
     description: A Helm chart for Kubernetes
@@ -231,4 +221,4 @@ entries:
     urls:
     - https://github.com/istio-ecosystem/sail-operator/releases/download/0.1.0/sail-operator-0.1.0.tgz
     version: 0.1.0
-generated: "2026-09-02T07:05:54.19780734Z"
+generated: "2026-07-22T06:06:19.887559807Z"


### PR DESCRIPTION
This reverts commit 5f5132cc90ccd14723a97f1df863b43a97c39d57.

Since we need to do release again due to missing PREVIOUS_VERSION in OLM part 