### PR TITLE
[release-1.30] Make bundle-publish idempotent by reusing existing PRs…

### DIFF
--- a/hack/operatorhub/publish-bundle.sh
+++ b/hack/operatorhub/publish-bundle.sh
@@ -148,10 +148,12 @@ skipInDryRun git commit -s -m"${TITLE}"
 skipInDryRun git push -f fork "${BRANCH}"
 
 PAYLOAD="${TMP_DIR}/PAYLOAD"
+PR_BODY="$(cat "${CUR_DIR}"/operatorhub-pr-template.md)"
+HEAD="${FORK}:${BRANCH}"
 
 jq -c -n \
-  --arg msg "$(cat "${CUR_DIR}"/operatorhub-pr-template.md)" \
-  --arg head "${FORK}:${BRANCH}" \
+  --arg msg "${PR_BODY}" \
+  --arg head "${HEAD}" \
   --arg base "${HUB_BASE_BRANCH}" \
   --arg title "${TITLE}" \
    '{head: $head, base: $base, title: $title, body: $msg }' > "${PAYLOAD}"
@@ -161,10 +163,35 @@ if $dryRun; then
   jq . "${PAYLOAD}"
 fi
 
-skipInDryRun curl \
+EXISTING_PR_URL=$(curl \
   --fail-with-body \
-  -X POST \
+  -s \
   -H "Authorization: token ${GITHUB_TOKEN}" \
   -H "Accept: application/vnd.github.v3+json" \
-  https://api.github.com/repos/"${OWNER}/${OPERATOR_HUB}"/pulls \
-   --data-binary "@${PAYLOAD}"
+  "https://api.github.com/repos/${OWNER}/${OPERATOR_HUB}/pulls?head=${HEAD}&state=open" \
+  | jq -r '.[0].url // empty')
+
+if [ -n "${EXISTING_PR_URL}" ]; then
+  echo "PR already exists: ${EXISTING_PR_URL} — updating"
+  UPDATE_PAYLOAD="${TMP_DIR}/UPDATE_PAYLOAD"
+  jq -c -n \
+    --arg title "${TITLE}" \
+    --arg msg "${PR_BODY}" \
+    '{title: $title, body: $msg}' > "${UPDATE_PAYLOAD}"
+  skipInDryRun curl \
+    --fail-with-body \
+    -X PATCH \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "${EXISTING_PR_URL}" \
+    --data-binary "@${UPDATE_PAYLOAD}"
+else
+  echo "Creating new PR"
+  skipInDryRun curl \
+    --fail-with-body \
+    -X POST \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/${OWNER}/${OPERATOR_HUB}/pulls" \
+    --data-binary "@${PAYLOAD}"
+fi


### PR DESCRIPTION
… (#2302)

When re-running the release workflow, the PR creation step would fail with a 422 because a PR from the same branch already exists. Now the script checks for an existing open PR first and updates it via PATCH instead of unconditionally creating a new one.

 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
