### PR TITLE
Using gcr.io registry directly to workaround proxy issue

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "istio build-tools",
-  "image": "registry.istio.io/testing/build-tools:release-1.30-d868c62ea286fa9370c5202c29c25e755eaa71d6",
+  "image": "gcr.io/istio-testing/build-tools:release-1.30-d868c62ea286fa9370c5202c29c25e755eaa71d6",
   "privileged": true,
   "remoteEnv": {
     "USE_GKE_GCLOUD_AUTH_PLUGIN": "True",

--- a/common/scripts/setup_env.sh
+++ b/common/scripts/setup_env.sh
@@ -74,8 +74,8 @@ else
 fi
 
 # Build image to use
-TOOLS_REGISTRY_PROVIDER=${TOOLS_REGISTRY_PROVIDER:-registry.istio.io}
-PROJECT_ID=${PROJECT_ID:-testing}
+TOOLS_REGISTRY_PROVIDER=${TOOLS_REGISTRY_PROVIDER:-gcr.io}
+PROJECT_ID=${PROJECT_ID:-istio-testing}
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
   IMAGE_VERSION=release-1.30-d868c62ea286fa9370c5202c29c25e755eaa71d6
 fi


### PR DESCRIPTION
registry.istio.io proxy no longer points to gcr.io. New registry does not contain expected images so the pull from registry.istio.io fails and we need to pull directly from gcr.io

Tmp workaround until upstream CI is fixed

