### PR TITLE
test: skip TLS profile e2e tests when APIServer is not writable

### DIFF
--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -43,6 +43,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -231,6 +232,21 @@ spec:
 			Expect(infraErr).NotTo(HaveOccurred(), "Failed to get Infrastructure resource")
 			if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
 				Skip("Skipping TLS profile tests on hosted cluster: APIServer resource is read-only on hosted clusters")
+			}
+
+			// The TLS profile tests must update the cluster-scoped APIServer resource. Rather than
+			// enumerate cluster flavors, probe writability directly: perform a no-op server-side
+			// dry-run update and skip if admission rejects it. This covers managed clusters (e.g.
+			// ROSA/OSD, whose Red Hat SRE webhooks forbid the write) and any other case where the
+			// resource is not manageable, without persisting any change.
+			Step("Checking whether the APIServer resource is writable")
+			apiServerProbe := &configv1.APIServer{}
+			Expect(cl.Get(ctx, apiServerKey, apiServerProbe)).To(Succeed(), "Failed to get APIServer")
+			if probeErr := cl.Update(ctx, apiServerProbe, client.DryRunAll); probeErr != nil {
+				if apierrors.IsForbidden(probeErr) {
+					Skip("Skipping TLS profile tests: the APIServer resource is not writable on this cluster: " + probeErr.Error())
+				}
+				Expect(probeErr).NotTo(HaveOccurred(), "Unexpected error while probing APIServer writability")
 			}
 
 			Step("Determining OpenShift version")


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

The TLS profile tests update the cluster-scoped `APIServer` resource, which managed clusters (e.g. ROSA/OSD) reject via Red Hat SRE admission webhooks with a `Forbidden` error. Instead of enumerating cluster types, the `tls-profile` `BeforeAll` now probes writability directly with a no-op server-side dry-run update and skips on `Forbidden`, persisting nothing. This generalises the existing hosted-cluster guard and covers any cluster where the resource is not manageable, while self-managed OpenShift continues to run the tests.

#### Which issue(s) this PR fixes:

Fixes #

Related Issue/PR #

#### Additional information:

Verified on a live ROSA cluster: a no-op server-side dry-run `PUT` of the `APIServer` resource returns `admission webhook "regular-user-validation.managed.openshift.io" denied the request` (HTTP 403), so the probe hits the `Skip` branch. On self-managed OpenShift the same dry-run succeeds and the tests run as before. Only `Forbidden` triggers the skip — any other error still fails the test.