### PR TITLE
use new blob.istio.io base URL for charts

### DIFF
--- a/hack/download-charts.sh
+++ b/hack/download-charts.sh
@@ -49,7 +49,7 @@ function downloadRequired() {
       if [ ! -f "${etag_file}" ]; then
         return 0
       fi
-      current=$(curl -I "$url" 2>/dev/null | awk -F': ' '/^etag:/ {print $2}' | tr -d "\"")
+      current=$(curl -IL "$url" 2>/dev/null | awk -F': ' '/^etag:/ {print $2}' | tr -d "\"")
       if [ "$current" != "$(cat "${etag_file}")" ]; then
         return 0
       fi
@@ -199,16 +199,16 @@ function replaceDockerHubWithRegistryIstio() {
   find "${CHARTS_DIR}" -name values.yaml -exec sed -i 's/hub: docker.io\/istio/hub: registry.istio.io\/release/g' {} \;
 }
 
-# The alpha/beta releases from istio-release.storage.googleapis.com may specify
-# registry.istio.io/testing in their charts, but the images are actually published
+# The alpha/beta releases from istio-release.storage.googleapis.com (or blob.istio.io/istio-release)
+# may specify registry.istio.io/testing in their charts, but the images are actually published
 # to registry.istio.io/release. This function replaces /testing/ with /release/ only for
-# official releases from istio-release.storage.googleapis.com.
+# official releases from istio-release.storage.googleapis.com or blob.istio.io/istio-release.
 # Dev builds from istio-build/dev/ should keep /testing/ as their images are published there.
 function replaceChartsNSForAlphaRelease() {
   local is_official_release=false
   if [ "${#CHART_URLS[@]}" -gt 0 ]; then
     for url in "${CHART_URLS[@]}"; do
-      if [[ "$url" == *"istio-release.storage.googleapis.com"* ]]; then
+      if [[ "$url" == *"istio-release.storage.googleapis.com"* || "$url" == *"blob.istio.io/istio-release"* ]]; then
         is_official_release=true
         break
       fi

--- a/hack/update-istio.sh
+++ b/hack/update-istio.sh
@@ -32,7 +32,7 @@ function add_stable_version() {
     istiod_remote_line=""
     if [[ ${1} == 1.23.* ]]
     then
-      istiod_remote_line="\"https://istio-release.storage.googleapis.com/charts/istiod-remote-${1}.tgz\","
+      istiod_remote_line="\"https://blob.istio.io/istio-release/charts/istiod-remote-${1}.tgz\","
     fi
     template=$(cat <<-END
 {
@@ -41,12 +41,12 @@ function add_stable_version() {
   "repo": "https://github.com/istio/istio",
   "commit": "${1}",
   "charts": [
-    "https://istio-release.storage.googleapis.com/charts/base-${1}.tgz",
-    "https://istio-release.storage.googleapis.com/charts/istiod-${1}.tgz",
+    "https://blob.istio.io/istio-release/charts/base-${1}.tgz",
+    "https://blob.istio.io/istio-release/charts/istiod-${1}.tgz",
     ${istiod_remote_line}
-    "https://istio-release.storage.googleapis.com/charts/gateway-${1}.tgz",
-    "https://istio-release.storage.googleapis.com/charts/cni-${1}.tgz",
-    "https://istio-release.storage.googleapis.com/charts/ztunnel-${1}.tgz"
+    "https://blob.istio.io/istio-release/charts/gateway-${1}.tgz",
+    "https://blob.istio.io/istio-release/charts/cni-${1}.tgz",
+    "https://blob.istio.io/istio-release/charts/ztunnel-${1}.tgz"
     ]
 }
 END
@@ -154,10 +154,10 @@ function update_prerelease() {
     fi
 
     echo Updating "${VERSION_CURRENT}" to commit "${COMMIT}"
-    echo "Verifying the artifacts are available on GCS, this might take a while - you can abort the wait with CTRL+C"
+    echo "Verifying the artifacts are available, this might take a while - you can abort the wait with CTRL+C"
 
-    URL="https://storage.googleapis.com/istio-build/dev/${COMMIT}"
-    until curl --output /dev/null --silent --head --fail "${URL}"; do
+    URL="https://blob.istio.io/istio-build/dev/${COMMIT}"
+    until curl --output /dev/null --silent --head --fail --location "${URL}"; do
         echo -n '.'
         sleep ${SLEEP_TIME}
     done
@@ -173,11 +173,11 @@ function update_prerelease() {
         (.versions[] | select(.name == "'"${VERSION_CURRENT}"'") | .version) = "'"${full_version}"'" |
         (.versions[] | select(.name == "'"${VERSION_CURRENT}"'") | .commit) = "'"${COMMIT}"'" |
         (.versions[] | select(.name == "'"${VERSION_CURRENT}"'") | .charts) = [
-            "https://storage.googleapis.com/istio-build/dev/'"${full_version}"'/helm/base-'"${full_version}"'.tgz",
-            "https://storage.googleapis.com/istio-build/dev/'"${full_version}"'/helm/cni-'"${full_version}"'.tgz",
-            "https://storage.googleapis.com/istio-build/dev/'"${full_version}"'/helm/gateway-'"${full_version}"'.tgz",
-            "https://storage.googleapis.com/istio-build/dev/'"${full_version}"'/helm/istiod-'"${full_version}"'.tgz",
-            "https://storage.googleapis.com/istio-build/dev/'"${full_version}"'/helm/ztunnel-'"${full_version}"'.tgz"
+            "https://blob.istio.io/istio-build/dev/'"${full_version}"'/helm/base-'"${full_version}"'.tgz",
+            "https://blob.istio.io/istio-build/dev/'"${full_version}"'/helm/cni-'"${full_version}"'.tgz",
+            "https://blob.istio.io/istio-build/dev/'"${full_version}"'/helm/gateway-'"${full_version}"'.tgz",
+            "https://blob.istio.io/istio-build/dev/'"${full_version}"'/helm/istiod-'"${full_version}"'.tgz",
+            "https://blob.istio.io/istio-build/dev/'"${full_version}"'/helm/ztunnel-'"${full_version}"'.tgz"
         ] |
         (.versions[] | select(.name == "'"${VERSION_CURRENT}"'") | .name) = "'"v${VERSION}"'"' "${VERSIONS_YAML_PATH}"
     update_alias "master" "v${VERSION}"


### PR DESCRIPTION
Upstream has moved the charts base URL to blob.istio.io/istio-release/charts.
