### PR TITLE
[release-1.30] test: skip TLS profile e2e tests when APIServer is not writable

### DIFF
--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -45,6 +45,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -245,6 +246,21 @@ spec:
 			Expect(infraErr).NotTo(HaveOccurred(), "Failed to get Infrastructure resource")
 			if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
 				Skip("Skipping TLS profile tests on hosted cluster: APIServer resource is read-only on hosted clusters")
+			}
+
+			// The TLS profile tests must update the cluster-scoped APIServer resource. Rather than
+			// enumerate cluster flavors, probe writability directly: perform a no-op server-side
+			// dry-run update and skip if admission rejects it. This covers managed clusters (e.g.
+			// ROSA/OSD, whose Red Hat SRE webhooks forbid the write) and any other case where the
+			// resource is not manageable, without persisting any change.
+			Step("Checking whether the APIServer resource is writable")
+			apiServerProbe := &configv1.APIServer{}
+			Expect(cl.Get(ctx, apiServerKey, apiServerProbe)).To(Succeed(), "Failed to get APIServer")
+			if probeErr := cl.Update(ctx, apiServerProbe, client.DryRunAll); probeErr != nil {
+				if apierrors.IsForbidden(probeErr) {
+					Skip("Skipping TLS profile tests: the APIServer resource is not writable on this cluster: " + probeErr.Error())
+				}
+				Expect(probeErr).NotTo(HaveOccurred(), "Unexpected error while probing APIServer writability")
 			}
 
 			Step("Determining OpenShift version")

--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -237,6 +237,16 @@ spec:
 				Skip("Skipping OpenShift-specific tests on non-OpenShift cluster")
 			}
 
+			// On hosted clusters, the APIServer resource is read-only and TLS settings cannot be changed,
+			// so skip all TLS profile tests. If the test run in a regular cluster, the APIServer resource is writable and the tests can run as normal.
+			Step("Checking if this is a Hosted Cluster")
+			infra := &configv1.Infrastructure{}
+			infraErr := cl.Get(ctx, client.ObjectKey{Name: "cluster"}, infra)
+			Expect(infraErr).NotTo(HaveOccurred(), "Failed to get Infrastructure resource")
+			if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+				Skip("Skipping TLS profile tests on hosted cluster: APIServer resource is read-only on hosted clusters")
+			}
+
 			Step("Determining OpenShift version")
 			cv := &configv1.ClusterVersion{}
 			err := cl.Get(ctx, client.ObjectKey{Name: "version"}, cv)


### PR DESCRIPTION
PR for release-1.30

#### What type of PR is this?

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

Backport of #2313 to `release-1.30`.

The TLS profile tests update the cluster-scoped APIServer resource, which managed clusters (e.g. ROSA/OSD) reject via Red Hat SRE admission webhooks with a Forbidden error. Instead of enumerating cluster types, the tls-profile BeforeAll now probes writability directly with a no-op server-side dry-run update and skips on Forbidden, persisting nothing. This generalises the existing hosted-cluster guard and covers any cluster where the resource is not manageable, while self-managed OpenShift continues to run the tests.

Note: `release-1.30` did not yet have the hosted-cluster guard that #2313 builds on, so this backport also cherry-picks #1873 ("tests: Skip TLS profile change test when is executed on Hosted clusters") first, so the two skip checks land together and the test file matches `main` / `release-1.31`.

#### Which issue(s) this PR fixes:

Fixes #

Related Issue/PR #2313, #1873

#### Additional information:

Cherry-picked commits (in order):
- `d82d87d0` — tests: Skip TLS profile change test when is executed on Hosted clusters (#1873)
- `5f5bc8fc` — test: skip TLS profile e2e tests when APIServer is not writable (#2313)

Verified: e2e test package compiles (`go test -tags e2e -c ./tests/e2e/operator/`); no conflicts.
