### PR TITLE
Reconcile OwnerRef on IstioRevision object during update

### DIFF
--- a/changelog/reconcile-ownerref-on-istiorevision-during-update.yaml
+++ b/changelog/reconcile-ownerref-on-istiorevision-during-update.yaml
@@ -1,0 +1,9 @@
+category: fixed
+title: Reconcile OwnerRef on IstioRevision object during update
+description: |
+  When revision.CreateOrUpdate reconciles during update, the OwnerReference
+  is not being updated, which could lead to a state, where the orphaned
+  revision is never pruned or reflected in "status.revisions".
+
+  Add OwnerReference during reconcile update.
+issueLink: https://github.com/istio-ecosystem/sail-operator/issues/2083

--- a/pkg/revision/reconcile.go
+++ b/pkg/revision/reconcile.go
@@ -38,33 +38,39 @@ func CreateOrUpdate(
 		return fmt.Errorf("failed to get active IstioRevision: %w", err)
 	}
 
+	rev.Spec.Version = version
+	rev.Spec.Namespace = namespace
+	rev.Spec.Values = values
+	setOwnerReference(&rev, ownerRef)
+
 	if found {
 		// update
-		rev.Spec.Version = version
-		rev.Spec.Values = values
 		log.Info("Updating IstioRevision")
 		if err = cl.Update(ctx, &rev); err != nil {
 			return fmt.Errorf("failed to update IstioRevision %q: %w", rev.Name, err)
 		}
 	} else {
 		// create new
-		rev = v1.IstioRevision{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            revName,
-				OwnerReferences: []metav1.OwnerReference{ownerRef},
-			},
-			Spec: v1.IstioRevisionSpec{
-				Version:   version,
-				Namespace: namespace,
-				Values:    values,
-			},
-		}
+		rev.Name = revName
 		log.Info("Creating IstioRevision")
 		if err = cl.Create(ctx, &rev); err != nil {
 			return fmt.Errorf("failed to create IstioRevision %q: %w", rev.Name, err)
 		}
 	}
 	return nil
+}
+
+// setOwnerReference ensures the expected ownerReference is present on the revision.
+// It replaces any existing ownerRef with the same Kind+Name (e.g. after the owner
+// was re-created with a new UID), or appends if none matches.
+func setOwnerReference(rev *v1.IstioRevision, ownerRef metav1.OwnerReference) {
+	for i, ref := range rev.OwnerReferences {
+		if ref.Kind == ownerRef.Kind && ref.Name == ownerRef.Name {
+			rev.OwnerReferences[i] = ownerRef
+			return
+		}
+	}
+	rev.OwnerReferences = append(rev.OwnerReferences, ownerRef)
 }
 
 func getRevision(ctx context.Context, cl client.Client, name string) (rev v1.IstioRevision, found bool, err error) {

--- a/pkg/revision/reconcile_test.go
+++ b/pkg/revision/reconcile_test.go
@@ -37,6 +37,7 @@ func TestReconcileActiveRevision(t *testing.T) {
 		name                 string
 		istioValues          v1.Values
 		revValues            *v1.Values
+		existingOwnerRef     *metav1.OwnerReference
 		expectOwnerReference bool
 	}{
 		{
@@ -66,7 +67,29 @@ func TestReconcileActiveRevision(t *testing.T) {
 					Image: ptr.Of("old-image"),
 				},
 			},
-			expectOwnerReference: false,
+			expectOwnerReference: true,
+		},
+		{
+			name: "heals stale ownerReference on update",
+			istioValues: v1.Values{
+				Pilot: &v1.PilotConfig{
+					Hub: ptr.Of("quay.io/hub"),
+				},
+			},
+			revValues: &v1.Values{
+				Pilot: &v1.PilotConfig{
+					Image: ptr.Of("old-image"),
+				},
+			},
+			existingOwnerRef: &metav1.OwnerReference{
+				APIVersion:         v1.GroupVersion.String(),
+				Kind:               v1.IstioKind,
+				Name:               "my-istio",
+				UID:                "stale-UID",
+				Controller:         ptr.Of(true),
+				BlockOwnerDeletion: ptr.Of(true),
+			},
+			expectOwnerReference: true,
 		},
 	}
 
@@ -75,17 +98,19 @@ func TestReconcileActiveRevision(t *testing.T) {
 			var initObjs []client.Object
 
 			if tc.revValues != nil {
-				initObjs = append(initObjs,
-					&v1.IstioRevision{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "my-revision",
-						},
-						Spec: v1.IstioRevisionSpec{
-							Version: version,
-							Values:  tc.revValues,
-						},
+				rev := &v1.IstioRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-revision",
 					},
-				)
+					Spec: v1.IstioRevisionSpec{
+						Version: version,
+						Values:  tc.revValues,
+					},
+				}
+				if tc.existingOwnerRef != nil {
+					rev.OwnerReferences = []metav1.OwnerReference{*tc.existingOwnerRef}
+				}
+				initObjs = append(initObjs, rev)
 			}
 
 			cl := newFakeClientBuilder().WithObjects(initObjs...).Build()


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
When revision.CreateOrUpdate reconciles during update, the OwnerReference is not being updated, which could lead to a state, where the orphaned revision is never pruned or reflected in "status.revisions".

Add OwnerReference during reconcile update.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #2083 

Related Issue/PR #

#### Additional information:
