### PR TITLE
[release-1.28] Pin build-tools image

### DIFF
--- a/common/scripts/setup_env.sh
+++ b/common/scripts/setup_env.sh
@@ -74,8 +74,8 @@ else
 fi
 
 # Build image to use
-TOOLS_REGISTRY_PROVIDER=${TOOLS_REGISTRY_PROVIDER:-gcr.io}
-PROJECT_ID=${PROJECT_ID:-istio-testing}
+TOOLS_REGISTRY_PROVIDER=${TOOLS_REGISTRY_PROVIDER:-quay.io}
+PROJECT_ID=${PROJECT_ID:-sail-dev}
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
   IMAGE_VERSION=release-1.28-879cab1fff4bf7578feb9973cac1e413b6e16147
 fi

--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -112,12 +112,13 @@ function getLatestVersionFromDockerHub() {
   curl -sL "https://hub.docker.com/v2/repositories/${1}/tags/?page_size=100" | jq -r '.results[].name' | sort -V | tail -n 1
 }
 
+# NOTE: This is skipped as 1.28 is EOL upstream and we need to use a custom quay.io build-tools image
 # Update common files
-make update-common
+# make update-common
 
 # update build container used in github actions
-NEW_IMAGE_MASTER=$(grep IMAGE_VERSION= < common/scripts/setup_env.sh | cut -d= -f2)
-"$SED_CMD" -i -e "s|\(registry.istio.io/testing/build-tools\):master.*|\1:$NEW_IMAGE_MASTER|" .github/workflows/update-deps.yaml
+# NEW_IMAGE_MASTER=$(grep IMAGE_VERSION= < common/scripts/setup_env.sh | cut -d= -f2)
+# "$SED_CMD" -i -e "s|\(registry.istio.io/testing/build-tools\):master.*|\1:$NEW_IMAGE_MASTER|" .github/workflows/update-deps.yaml
 
 # Update go dependencies
 export GO111MODULE=on


### PR DESCRIPTION
This pins the build-tools image to a copy I created on quay.io, as the original upstream image is no longer on registry.istio.io since changing the backend. It also skips updating common-files to avoid overwriting it but that should not be an issue as the branch is EOL upstream and has not seen commits in 3 months.